### PR TITLE
feat(runtime-tags): persisted client-owned custom tag instances (experimental)

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count format=(v) => v + input.suffix/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count format=(v) => v + input.suffix/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count format=(v) => v + input.suffix/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count format=(v) => v + input.suffix/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/tags/dump/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/tags/dump/index.marko
@@ -1,0 +1,1 @@
+<p>${JSON.stringify(input)}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/template.marko
@@ -1,0 +1,5 @@
+<let/count=0/>
+<main>
+  <dump value=count format=(v) => v + input.suffix/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// A function value's body reads classify too: the child may invoke it at
+// render time, so a skipped render could hide the server read.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <g-badge value=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: the tag's template reads `$global`, which the skipped render could not keep current.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <g-badge value=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: the tag's template reads `$global`, which the skipped render could not keep current.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <g-badge value=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: the tag's template reads `$global`, which the skipped render could not keep current.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <g-badge value=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: the tag's template reads `$global`, which the skipped render could not keep current.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/tags/g-badge/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/tags/g-badge/index.marko
@@ -1,0 +1,1 @@
+<p>${input.value} ${$global.flag}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/template.marko
@@ -1,0 +1,5 @@
+<let/count=0/>
+<main>
+  <g-badge value=count/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// A client-owned candidate whose template chain reads `$global` rejects:
+// the skipped render could hide a global change.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <price-card label=input.label qty=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <price-card label=input.label qty=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <price-card label=input.label qty=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <price-card label=input.label qty=count/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/tags/price-card/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/tags/price-card/index.marko
@@ -1,0 +1,1 @@
+<p>${input.label} x${input.qty}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/template.marko
@@ -1,0 +1,5 @@
+<let/count=0/>
+<main>
+  <price-card label=input.label qty=count/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// A tag mixing a server-fed attr with a client-state-fed attr cannot
+// patch faithfully yet: the child render would be part stale, part live.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,2 @@
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,2 @@
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,2 @@
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/__snapshots__/error-compile-html.txt
@@ -1,0 +1,2 @@
+Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/tags/dump/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/tags/dump/index.marko
@@ -1,0 +1,1 @@
+<p>${JSON.stringify(input)}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/template.marko
@@ -1,0 +1,8 @@
+static function getStamp() {
+  return Date.now();
+}
+<let/count=0/>
+<main>
+  <dump value=count stamp=getStamp()/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-opaque-attr/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// An untracked call can change server-side (capture polarity), so it
+// counts as server-fed and cannot mix with client state on one tag.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,21 @@
+// tags/dump/index.marko
+const $template$1 = "<p> </p>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $input$1 = ($scope, input) => _text($scope["#text/0"], JSON.stringify(input));
+var dump_default = /*@__PURE__*/ _template("__tests__/tags/dump/index.marko", $template$1, "D l", $setup$1, $input$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<main><h1> </h1>${_w0}<button>+</button></main>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `E l/${_w0}& l`)("D l");
+const $count = /*@__PURE__*/ _let("count/6", ($scope) => $input$1($scope["#childScope/1"], { value: $scope.count }));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $input = ($scope, input) => $input_title($scope, input.title);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// tags/dump/index.marko
+const $input = ($scope, input) => _text($scope.a, JSON.stringify(input));
+
+// template.marko
+const $count = /*@__PURE__*/ _let(6, ($scope) => $input($scope.b, { value: $scope.g }));
+const $setup__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+	$count($scope, $scope.g + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// tags/dump/index.marko
+var dump_default = _template_persisted("__tests__/tags/dump/index.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p>${_patch_text($scope0_id, "#text/0", JSON.stringify(input))}${_escape(JSON.stringify(input))}${_el_resume($scope0_id, "#text/0")}</p>`);
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/dump/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "#childScope/1", $childScope);
+		dump_default({ value: count });
+	}
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/2")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		count,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.js
@@ -1,0 +1,27 @@
+// tags/dump/index.marko
+var dump_default = _template_persisted("b", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p>${_patch_text($scope0_id, "a", JSON.stringify(input))}${_escape(JSON.stringify(input))}${_el_resume($scope0_id, "a")}</p>`);
+	$scope0_reason && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "b", $childScope);
+		dump_default({ value: count });
+	}
+	_html(`<button>+</button>${_el_resume($scope0_id, "c")}</main>`);
+	_script($scope0_id, "a0");
+	$scope0_reason && writeScope($scope0_id, {
+		g: count,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/patches.debug.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  "PatchText:#text/0": "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/patches.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  ta: "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/render.debug.md
@@ -1,0 +1,77 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    {"value":0}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    {"value":1}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text "{\"value\":0}" => "{\"value\":1}"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    {"value":1}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    {"value":2}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text "{\"value\":1}" => "{\"value\":2}"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/render.md
@@ -1,0 +1,77 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    {"value":0}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    {"value":1}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text "{\"value\":0}" => "{\"value\":1}"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    {"value":1}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    {"value":2}
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text "{\"value\":1}" => "{\"value\":2}"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <p>{"value":0}<!--M_*2 #text/0--></p><button>+</button><!--M_*1 #button/2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0,
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <p>{"value":0}<!--M_*2 a--></p><button>+</button><!--M_*1 c-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: 0,
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/sizes.json
@@ -1,0 +1,22 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3169,
+        "brotli": 1579
+      },
+      "files": {
+        "tags/dump/index.marko": 119,
+        "template.marko": 248
+      }
+    }
+  },
+  "html": {
+    "min": 417,
+    "brotli": 279
+  },
+  "patch": {
+    "min": 14,
+    "brotli": 18
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/tags/dump/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/tags/dump/index.marko
@@ -1,0 +1,1 @@
+<p>${JSON.stringify(input)}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/template.marko
@@ -1,0 +1,6 @@
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <dump value=count/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A rest-consumed child (whole-`input` read) classifies through the tag's
+// merged extra: state-only input still client-owns the instance.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [{ title: "Store" }, click, { title: "Store!" }, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count label=input.title/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count label=input.title/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count label=input.title/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko:3:3
+      1 | <let/count=0/>
+      2 | <main>
+    > 3 |   <dump value=count label=input.title/>
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Persisted templates cannot patch this faithfully yet: client state and server values cannot mix across one tag's input.
+      4 |   <button onClick() { count++ }>+</button>
+      5 | </main>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/tags/dump/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/tags/dump/index.marko
@@ -1,0 +1,1 @@
+<p>${JSON.stringify(input)}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/template.marko
@@ -1,0 +1,5 @@
+<let/count=0/>
+<main>
+  <dump value=count label=input.title/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+// Rest-consumed children classify through the tag's merged extra, so
+// state+server mixing rejects on this path too.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,22 @@
+// tags/arg-badge/index.marko
+const $template$1 = "<p>Value <!></p>";
+const $walks$1 = "Db%l";
+const $setup$1 = () => {};
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $input$1 = ($scope, input) => $input_value($scope, input.value);
+var arg_badge_default = /*@__PURE__*/ _template("__tests__/tags/arg-badge/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<main><h1> </h1>${_w0}<button>+</button></main>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `E l/${_w0}& l`)($walks$1);
+const $count = /*@__PURE__*/ _let("count/6", ($scope) => $input$1($scope["#childScope/1"], { value: $scope.count }));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $input = ($scope, input) => $input_title($scope, input.title);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// tags/arg-badge/index.marko
+const $input_value = ($scope, input_value) => _text($scope.a, input_value);
+const $input = ($scope, input) => $input_value($scope, input.value);
+
+// template.marko
+const $count = /*@__PURE__*/ _let(6, ($scope) => $input($scope.b, { value: $scope.g }));
+const $setup__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+	$count($scope, $scope.g + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,27 @@
+// tags/arg-badge/index.marko
+var arg_badge_default = _template_persisted("__tests__/tags/arg-badge/index.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p>Value <!>${_patch_text($scope0_id, "#text/0", input.value)}${_escape(input.value)}${_el_resume($scope0_id, "#text/0")}</p>`);
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/arg-badge/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "#childScope/1", $childScope);
+		arg_badge_default({ value: count });
+	}
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/2")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		count,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.js
@@ -1,0 +1,27 @@
+// tags/arg-badge/index.marko
+var arg_badge_default = _template_persisted("b", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p>Value <!>${_patch_text($scope0_id, "a", input.value)}${_escape(input.value)}${_el_resume($scope0_id, "a")}</p>`);
+	$scope0_reason && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "b", $childScope);
+		arg_badge_default({ value: count });
+	}
+	_html(`<button>+</button>${_el_resume($scope0_id, "c")}</main>`);
+	_script($scope0_id, "a0");
+	$scope0_reason && writeScope($scope0_id, {
+		g: count,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/patches.debug.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  "PatchText:#text/0": "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/patches.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  ta: "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/render.debug.md
@@ -1,0 +1,77 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Value 0
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Value 1
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@6 "0" => "1"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Value 1
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Value 2
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@6 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/render.md
@@ -1,0 +1,77 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Value 0
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <p>
+    Value 1
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@6 "0" => "1"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Value 1
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <p>
+    Value 2
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@6 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <p>Value <!>0<!--M_*2 #text/0--></p><button>+</button><!--M_*1 #button/2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0,
+      "#childScope/1": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <p>Value <!>0<!--M_*2 a--></p><button>+</button><!--M_*1 c-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: 0,
+    b: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/sizes.json
@@ -1,0 +1,22 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3175,
+        "brotli": 1586
+      },
+      "files": {
+        "tags/arg-badge/index.marko": 195,
+        "template.marko": 248
+      }
+    }
+  },
+  "html": {
+    "min": 416,
+    "brotli": 278
+  },
+  "patch": {
+    "min": 14,
+    "brotli": 18
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/tags/arg-badge/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/tags/arg-badge/index.marko
@@ -1,0 +1,1 @@
+<p>Value ${input.value}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/template.marko
@@ -1,0 +1,6 @@
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <arg-badge({ value: count })/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// Client state flowing through a tag ARGUMENT classifies the instance
+// client-owned exactly like an attribute would.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [{ title: "Store" }, click, { title: "Store!" }, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,30 @@
+// tags/counter/index.marko
+const $template$1 = "<section><p>Value <!> (spun <!>)</p><button class=spin>spin</button></section>";
+const $walks$1 = "Eb%c%l l";
+const $spins = /*@__PURE__*/ _let("spins/6", ($scope) => _text($scope["#text/1"], $scope.spins));
+const $setup__script$1 = _script("__tests__/tags/counter/index.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$spins($scope, $scope.spins + 1);
+}));
+function $setup$1($scope) {
+	$spins($scope, 0);
+	$setup__script$1($scope);
+}
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $input$1 = ($scope, input) => $input_value($scope, input.value);
+var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<main><h1> </h1>${_w0}<button class=inc>+</button></main>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `E l/${_w0}& l`)($walks$1);
+const $count = /*@__PURE__*/ _let("count/6", ($scope) => $input_value($scope["#childScope/1"], $scope.count));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$setup$1($scope["#childScope/1"]);
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $input = ($scope, input) => $input_title($scope, input.title);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// tags/counter/index.marko
+const $spins = /*@__PURE__*/ _let(6, ($scope) => _text($scope.b, $scope.g));
+const $setup__script$1 = _script("b0", ($scope) => _on($scope.c, "click", function() {
+	$spins($scope, $scope.g + 1);
+}));
+const $input_value = ($scope, input_value) => _text($scope.a, input_value);
+
+// template.marko
+const $count = /*@__PURE__*/ _let(6, ($scope) => $input_value($scope.b, $scope.g));
+const $setup__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+	$count($scope, $scope.g + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// tags/counter/index.marko
+var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let spins = 0;
+	_html(`<section><p>Value <!>${_patch_text($scope0_id, "#text/0", input.value)}${_escape(input.value)}${_el_resume($scope0_id, "#text/0")} (spun <!>${_escape(spins)}${_el_resume($scope0_id, "#text/1")})</p><button class=spin>spin</button>${_el_resume($scope0_id, "#button/2")}</section>`);
+	_script($scope0_id, "__tests__/tags/counter/index.marko_0");
+	$scope0_reason && writeScope($scope0_id, { spins }, "__tests__/tags/counter/index.marko", 0, { spins: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "#childScope/1", $childScope);
+		counter_default({ value: count });
+	}
+	_html(`<button class=inc>+</button>${_el_resume($scope0_id, "#button/2")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		count,
+		"#childScope/1": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// tags/counter/index.marko
+var counter_default = _template_persisted("b", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let spins = 0;
+	_html(`<section><p>Value <!>${_patch_text($scope0_id, "a", input.value)}${_escape(input.value)}${_el_resume($scope0_id, "a")} (spun <!>${_escape(spins)}${_el_resume($scope0_id, "b")})</p><button class=spin>spin</button>${_el_resume($scope0_id, "c")}</section>`);
+	_script($scope0_id, "b0");
+	$scope0_reason && writeScope($scope0_id, { g: spins });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	const $childScope = _peek_scope_id();
+	if ($scope0_reason) {
+		_patch_child($scope0_id, "b", $childScope);
+		counter_default({ value: count });
+	}
+	_html(`<button class=inc>+</button>${_el_resume($scope0_id, "c")}</main>`);
+	_script($scope0_id, "a0");
+	$scope0_reason && writeScope($scope0_id, {
+		g: count,
+		b: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/patches.debug.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  "PatchText:#text/0": "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/patches.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  ta: "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/render.debug.md
@@ -1,0 +1,175 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 0 (spun 0)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button.inc").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 0)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@6 "0" => "1"
+```
+
+# Update
+```js
+document.querySelector("button.spin").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@14 "0" => "1"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button.inc").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 2 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@6 "1" => "2"
+```
+
+# Update
+```js
+document.querySelector("button.spin").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 2 (spun 2)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@14 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/render.md
@@ -1,0 +1,175 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 0 (spun 0)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button.inc").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 0)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@6 "0" => "1"
+```
+
+# Update
+```js
+document.querySelector("button.spin").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@14 "0" => "1"
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 1 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```js
+document.querySelector("button.inc").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 2 (spun 1)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@6 "1" => "2"
+```
+
+# Update
+```js
+document.querySelector("button.spin").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <p>
+      Value 2 (spun 2)
+    </p>
+    <button
+      class="spin"
+    >
+      spin
+    </button>
+  </section>
+  <button
+    class="inc"
+  >
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > section > p::text@14 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/writes.debug.html
@@ -1,0 +1,19 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <section>
+    <p>Value <!>0<!--M_*2 #text/0--> (spun <!>0<!--M_*2 #text/1-->)</p><button
+      class=spin>spin</button><!--M_*2 #button/2-->
+  </section><button class=inc>+</button><!--M_*1 #button/2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0,
+      "#childScope/1": _(2)
+    }, {
+      spins: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/tags/counter/index.marko_0 2 packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/writes.html
@@ -1,0 +1,17 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <section>
+    <p>Value <!>0<!--M_*2 a--> (spun <!>0<!--M_*2 b-->)</p><button
+      class=spin>spin</button><!--M_*2 c-->
+  </section><button class=inc>+</button><!--M_*1 c-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: 0,
+    b: _(2)
+  }, {
+    g: 0
+  }], "b0 2 a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/sizes.json
@@ -1,0 +1,22 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3221,
+        "brotli": 1580
+      },
+      "files": {
+        "tags/counter/index.marko": 324,
+        "template.marko": 243
+      }
+    }
+  },
+  "html": {
+    "min": 526,
+    "brotli": 316
+  },
+  "patch": {
+    "min": 14,
+    "brotli": 18
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/tags/counter/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/tags/counter/index.marko
@@ -1,0 +1,5 @@
+<let/spins=0/>
+<section>
+  <p>Value ${input.value} (spun ${spins})</p>
+  <button.spin onClick() { spins++ }>spin</button>
+</section>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/template.marko
@@ -1,0 +1,6 @@
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <counter value=count/>
+  <button.inc onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/test.ts
@@ -1,0 +1,15 @@
+import type { TestConfig } from "../../main.test";
+
+const inc = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button.inc")!.click();
+};
+const spin = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button.spin")!.click();
+};
+
+// A child whose attrs are all client-state-fed is client-owned: patches
+// skip its server render entirely and its live DOM/state stay intact.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [{ title: "Store" }, inc, spin, { title: "Store!" }, inc, spin],
+};

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -26,6 +26,7 @@ import {
   type Opt,
   toIter,
 } from "./optional";
+import { kPatchClientOwned } from "./persisted";
 import {
   addRead,
   type Binding,
@@ -61,7 +62,7 @@ import {
   type Section,
   startSection,
 } from "./sections";
-import { getSerializeGuard } from "./serialize-guard";
+import { getSerializeGuard, scopeReasonIdentifier } from "./serialize-guard";
 import {
   addSerializeExpr,
   addSerializeReason,
@@ -216,6 +217,10 @@ export function knownTagTranslateHTML(
     section,
     childScopeBinding,
   );
+  // A client-owned instance renders nothing into a patch: the link and the
+  // child render skip together, and the absent entry keeps the live child.
+  let clientOwnedStatements: t.Statement[] | undefined =
+    isPersisted() && tagExtra[kPatchClientOwned] ? [] : undefined;
 
   if (childScopeSerializeReason) {
     const peekScopeId = generateUidIdentifier(childScopeBinding?.name);
@@ -239,16 +244,19 @@ export function knownTagTranslateHTML(
     );
 
     if (isPersisted()) {
-      statements.push(
-        t.expressionStatement(
-          callRuntime(
-            "_patch_child",
-            getScopeIdIdentifier(section),
-            getScopeAccessorLiteral(childScopeBinding),
-            peekScopeId,
-          ),
+      const patchChildStatement = t.expressionStatement(
+        callRuntime(
+          "_patch_child",
+          getScopeIdIdentifier(section),
+          getScopeAccessorLiteral(childScopeBinding),
+          peekScopeId,
         ),
       );
+      if (tagExtra[kPatchClientOwned]) {
+        clientOwnedStatements = [patchChildStatement];
+      } else {
+        statements.push(patchChildStatement);
+      }
     }
 
     if (tagVar) {
@@ -331,11 +339,16 @@ export function knownTagTranslateHTML(
     }
 
     if (childSerializeReasonExpr) {
-      tag.insertBefore(
-        t.expressionStatement(
-          callRuntime("_set_serialize_reason", childSerializeReasonExpr),
-        ),
+      const setter = t.expressionStatement(
+        callRuntime("_set_serialize_reason", childSerializeReasonExpr),
       );
+      if (clientOwnedStatements) {
+        // Inside the guard: a skipped child never runs `_scope_reason`, so
+        // an ambient reason set outside it would leak to the next consumer.
+        clientOwnedStatements.push(setter);
+      } else {
+        tag.insertBefore(setter);
+      }
     }
   }
 
@@ -353,6 +366,18 @@ export function knownTagTranslateHTML(
 
   if (tagVar) {
     translateVar(tag, callExpression(tagIdentifier, ...getArgs()), "let");
+  } else if (clientOwnedStatements) {
+    // The render-wide persisted reason is the page-vs-patch bit: truthy on
+    // a page render (serialize + render the child), falsy on a patch.
+    let rootSection = section;
+    while (rootSection.parent) rootSection = rootSection.parent;
+    clientOwnedStatements.push(callStatement(tagIdentifier, ...getArgs()));
+    statements.push(
+      t.ifStatement(
+        scopeReasonIdentifier(rootSection),
+        t.blockStatement(clientOwnedStatements),
+      ),
+    );
   } else {
     statements.push(callStatement(tagIdentifier, ...getArgs()));
   }

--- a/packages/runtime-tags/src/translator/util/persisted.ts
+++ b/packages/runtime-tags/src/translator/util/persisted.ts
@@ -8,6 +8,22 @@ import { isDirectClosure, type Section } from "./sections";
 import { getSerializeSourcesForRef } from "./serialize-reasons";
 import { createProgramState } from "./state";
 
+// A custom tag instance whose attrs carry only client state and constants
+// is client-owned: patches skip its render, so nothing inside goes stale.
+export const kPatchClientOwned = Symbol("patch client owned");
+declare module "@marko/compiler/dist/types" {
+  export interface NodeExtra {
+    [kPatchClientOwned]?: true;
+  }
+}
+declare module "@marko/compiler" {
+  export interface MarkoMeta {
+    /** This template (or one it renders) reads `$global`: skipping its
+     * render in a patch could hide a global change. */
+    persistedGlobals?: true;
+  }
+}
+
 export function scopeReasonRuntime() {
   return isPersisted()
     ? ("_persisted_reason" as const)

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { getProgram } from "@marko/compiler/babel-utils";
+import { getFile, getProgram } from "@marko/compiler/babel-utils";
 
 import type { AccessorPrefix } from "../../common/accessor.debug";
 import { decodeAccessor } from "../../common/helpers";
@@ -836,6 +836,9 @@ export function trackGlobalReference(path: t.NodePath<t.Node>) {
   const section = getOrCreateSection(exprRoot);
   const extra = (exprRoot.node.extra ??= { section });
   extra.readsGlobal = true;
+  // Rolls up through custom-tag analyze so a call site can classify
+  // whether skipping this template's render could hide a global change.
+  getFile().metadata.marko.persistedGlobals = true;
 }
 
 export function mergeReferences<T extends t.Node>(

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { getTagDef } from "@marko/compiler/babel-utils";
+import { getTagDef, loadFileForTag } from "@marko/compiler/babel-utils";
 
 import { isEventHandler } from "../../../common/helpers";
 import evaluate from "../../util/evaluate";
@@ -21,6 +21,7 @@ import {
   hasUndeliverableFillReads,
   hasUnfillablePatchReads,
   isPatchCaptureSection,
+  kPatchClientOwned,
   scopeReasonRuntime,
 } from "../../util/persisted";
 import {
@@ -40,6 +41,7 @@ import {
 import { getScopeReasonDeclaration } from "../../util/serialize-guard";
 import {
   getSerializeSourcesForExpr,
+  getSerializeSourcesForRef,
   isReasonDynamic,
 } from "../../util/serialize-reasons";
 import {
@@ -362,17 +364,87 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
       // Client state participates through value fills: patches never carry
       // state, and holes it feeds recompute through the signal graph.
       if (tagName === "let" || tagName === "const") return;
-      // A templated custom tag re-renders during a patch; a state-fed
-      // attribute would resolve from the server's stale state, so those
-      // fail closed until per-instance classification exists.
+      // A templated custom tag re-renders during a patch, resolving state
+      // from the server's stale defaults. Per-instance classification: an
+      // instance fed ONLY client state and constants is client-owned (the
+      // patch skips its render — nothing inside can change server-side);
+      // mixing state with server-fed attrs stays closed until a per-param
+      // withhold channel exists.
       if (tagDef?.template) {
+        let hasState = false;
+        let hasServer = false;
+        const classify = (
+          extra: t.NodeExtra | undefined,
+          value?: t.Expression,
+        ) => {
+          const sources = getSerializeSourcesForExpr(extra || {});
+          hasState ||= !!sources?.state;
+          hasServer ||= !!(sources?.param || sources?.global);
+          // Capture polarity: a sourceless call bakes a value no client
+          // signal recomputes, so its opacity counts as server-fed. (A
+          // sourced call re-evaluates client-side when its reads change.)
+          if (!sources && value && !evaluate(value).confident) {
+            t.traverseFast(value, (n) => {
+              hasServer ||=
+                t.isCallExpression(n) ||
+                t.isOptionalCallExpression(n) ||
+                t.isNewExpression(n) ||
+                t.isTaggedTemplateExpression(n);
+            });
+          }
+          // Reads inside function values count too: a child may invoke the
+          // fn at render time, so the skip could hide them.
+          const fnRefs = (extra as t.FunctionExtra | undefined)
+            ?.referencedBindingsInFunction;
+          forEach(fnRefs, (binding) => {
+            const fnSources = getSerializeSourcesForRef(binding);
+            hasState ||= !!fnSources?.state;
+            hasServer ||= !!(fnSources?.param || fnSources?.global);
+          });
+        };
         for (const attr of node.attributes) {
-          if (
-            attr.type === "MarkoSpreadAttribute" ||
-            getSerializeSourcesForExpr(attr.value.extra || {})?.state
-          ) {
+          if (attr.type === "MarkoSpreadAttribute") {
             unsupported(attr);
           }
+          classify(attr.value.extra, attr.value);
+        }
+        // Arguments and rest-consumed children (a whole-`input` read, rest
+        // props) merge their reads into the tag's own extra, not per-expr.
+        classify(node.extra);
+        for (const arg of node.arguments || []) {
+          if (!t.isSpreadElement(arg)) classify(arg.extra, arg);
+        }
+        if (hasState) {
+          if (hasServer) {
+            unsupported(
+              node,
+              "client state and server values cannot mix across one tag's input",
+            );
+          }
+          // The skipped render must not hide other change vectors: a tag
+          // variable reads during patch renders, and body content re-renders.
+          if (node.var) {
+            unsupported(
+              node,
+              "a tag variable needs the child render a client-owned tag skips",
+            );
+          }
+          for (const child of tag.get("body").get("body")) {
+            if (!isStatic(child)) {
+              unsupported(
+                child.node,
+                "body content needs the child render a client-owned tag skips",
+              );
+            }
+          }
+          const childFile = loadFileForTag(tag);
+          if (!childFile || childFile.metadata.marko.persistedGlobals) {
+            unsupported(
+              node,
+              "the tag's template reads `$global`, which the skipped render could not keep current",
+            );
+          }
+          (node.extra ??= {})[kPatchClientOwned] = true;
         }
         return;
       }

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -28,7 +28,11 @@ import {
   knownTagTranslateDOM,
   knownTagTranslateHTML,
 } from "../../util/known-tag";
-import { getMarkoOpts, isOutputHTML } from "../../util/marko-config";
+import {
+  getMarkoOpts,
+  isOutputHTML,
+  isPersisted,
+} from "../../util/marko-config";
 import type { Binding } from "../../util/references";
 import {
   BindingType,
@@ -77,6 +81,12 @@ export default {
         throw tag
           .get("name")
           .buildCodeFrameError("Unable to resolve file for tag.");
+      }
+
+      // Global reads roll up the load chain so any ancestor call site can
+      // classify whether skipping this subtree could hide a global change.
+      if (isPersisted() && childFile.metadata.marko.persistedGlobals) {
+        tag.hub.file.metadata.marko.persistedGlobals = true;
       }
 
       const tagExtra = (tag.node.extra ??= {});


### PR DESCRIPTION
Per-instance classification for state-fed custom tag attributes (last tier-1 item). An instance whose input carries only client state and constants is client-owned: the parent wraps the child render + `_patch_child` link in `if (!_writes_patches())`, so patches skip the subtree — the absent entry keeps the live child, its state, and its handlers (prototype research confirmed it has no answer here; the absent-key protocol is the only sound mechanism). Everything else fails closed at compile time: state+server mixing across one tag's input, tag variables, body content, and `$global` anywhere in the child's template chain (`trackGlobalReference` stamps `metadata.marko.persistedGlobals`; custom-tag analyze rolls it up the load chain, transitively, dynamic tags included). Classification covers per-attr extras, tag arguments, AND the tag's own merged extra — the last one closes a silent-stale hole for rest-consumed children (whole-`input` reads) that predates this stage.

Grok 4.5 (high) adversarial review: round 1 HOLD on exactly that rest-path hole (verified by compiled probes); fixed + pinned by `persisted-child-rest-attr`/`-rest-mixed`, its full scorecard otherwise clean (scope accounting, $global recursion/dynamic-tag roll-up, bound `:=`, non-persisted purity). Fixtures: `persisted-child-state-attr` (child param + child-local state survive server patches; frames carry no child entry), `persisted-child-state-arg`, `persisted-child-mixed-attr`, `persisted-child-global-owned`, plus the two rest shapes. The future per-param withhold channel (to lift the mixed rejection) is recorded in the design note. Non-persisted output unchanged.