### PR TITLE
refactor(runtime-tags): persisted captures render their own output (experimental)

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	const $count__closures = new Set();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.outer) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = /* @__PURE__ */ new Set();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.outer) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	let count = 0;
 	const double = count * 2;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	const double = count * 2;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_inner = _serialize_guard($scope0_reason, 2), $sg__input_outer = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.outer) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_inner = _serialize_guard($scope0_reason, 2), $sg__input_outer = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.outer) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a0: ",`a0 a1; ;<button>read</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	let handler = _resume((next) => {
 		last = next;
 	}, "__tests__/template.marko_0/handler", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("a", (input) => {
 	let handler = _resume((next) => {
 		last = next;
 	}, "a0", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a1: ",`a1 a2;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_a = _serialize_guard($scope0_reason, 1), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_b = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.a) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_a = _serialize_guard($scope0_reason, 1), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_b = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.a) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
@@ -3,12 +3,12 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
 			let frozen = 1;
-			_html(`<p>Value <!>${_patch_text($scope1_id, "#text/0", frozen)}${_escape(frozen)}${_el_resume($scope1_id, "#text/0")}</p>`);
+			_html(`<p>Value <!>${_patch_text($scope1_id, "#text/0", frozen)}${_el_resume($scope1_id, "#text/0")}</p>`);
 			writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
@@ -3,12 +3,11 @@ _renderer_shells({ a0: ",`a0;Db%;<p>Value <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			let frozen = 1;
-			_html(`<p>Value <!>${_patch_text($scope1_id, "a", frozen)}${_escape(frozen)}${_el_resume($scope1_id, "a")}</p>`);
+			_html(`<p>Value <!>${_patch_text($scope1_id, "a", 1)}${_el_resume($scope1_id, "a")}</p>`);
 			writeScope($scope1_id, {});
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a0: ",`a0 a1;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
@@ -3,11 +3,11 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<span>${_patch_text($scope1_id, "#text/1", input.label)}${_escape(input.label)}${_el_resume($scope1_id, "#text/1")}</span>${_el_resume($scope1_id, "#span/0")}`);
+			_html(`<span>${_patch_text($scope1_id, "#text/1", input.label)}${_el_resume($scope1_id, "#text/1")}</span>${_el_resume($scope1_id, "#span/0")}`);
 			_script($scope1_id, "__tests__/template.marko_1");
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:4");
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
@@ -3,11 +3,11 @@ _renderer_shells({ a0: ",`a0 a1; D ;<span> </span>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<span>${_patch_text($scope1_id, "b", input.label)}${_escape(input.label)}${_el_resume($scope1_id, "b")}</span>${_el_resume($scope1_id, "a")}`);
+			_html(`<span>${_patch_text($scope1_id, "b", input.label)}${_el_resume($scope1_id, "b")}</span>${_el_resume($scope1_id, "a")}`);
 			_script($scope1_id, "a1");
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
@@ -4,11 +4,11 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_promo = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.promo) {
 			const $scope1_id = _scope_id();
-			_html(`<aside class="promo banner">${_patch_text($scope1_id, "#text/0", input.promo)}${_escape(input.promo)}${_el_resume($scope1_id, "#text/0")}</aside>`);
+			_html(`<aside class="promo banner">${_patch_text($scope1_id, "#text/0", input.promo)}${_el_resume($scope1_id, "#text/0")}</aside>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:4");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
@@ -4,11 +4,11 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_promo = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.promo) {
 			const $scope1_id = _scope_id();
-			_html(`<aside class="promo banner">${_patch_text($scope1_id, "a", input.promo)}${_escape(input.promo)}${_el_resume($scope1_id, "a")}</aside>`);
+			_html(`<aside class="promo banner">${_patch_text($scope1_id, "a", input.promo)}${_el_resume($scope1_id, "a")}</aside>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<main><h1> </h1><a> </a></main>";
+const $walks = "E l D m";
+const $setup = () => {};
+const $input_name = ($scope, input_name) => {
+	_text($scope["#text/0"], `a&b${input_name}<c`);
+	_text($scope["#text/2"], input_name);
+};
+const $input_on = ($scope, input_on) => _attr($scope["#a/1"], "title", input_on ? "a\"b" : "c'd");
+const $input_flag = ($scope, input_flag) => _attr($scope["#a/1"], "data-x", input_flag && "on");
+const $input = ($scope, input) => {
+	$input_name($scope, input.name);
+	$input_on($scope, input.on);
+	$input_flag($scope, input.flag);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", `a&b${input.name}<c`)}${_el_resume($scope0_id, "#text/0")}</h1><a${_patch_attr($scope0_id, "#a/1", "title", input.on ? "a\"b" : "c'd")}${_patch_attr($scope0_id, "#a/1", "data-x", input.flag && "on")}>${_patch_text($scope0_id, "#text/2", input.name)}${_el_resume($scope0_id, "#text/2")}</a>${_el_resume($scope0_id, "#a/1")}</main>`);
+	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<main><h1>${_patch_text($scope0_id, "a", `a&b${input.name}<c`)}${_el_resume($scope0_id, "a")}</h1><a${_patch_attr($scope0_id, "b", "title", input.on ? "a\"b" : "c'd")}${_patch_attr($scope0_id, "b", "data-x", input.flag && "on")}>${_patch_text($scope0_id, "c", input.name)}${_el_resume($scope0_id, "c")}</a>${_el_resume($scope0_id, "b")}</main>`);
+	$scope0_reason && writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+// PATCH
+{
+  "PatchText:#text/0": "a&by&z\x3Cc",
+  "PatchAttr:#a/1 title": "c'd",
+  "PatchAttr:#a/1 data-x": 0,
+  "PatchText:#text/2": "y&z"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+// PATCH
+{
+  ta: "a&by&z\x3Cc",
+  "ab title": "c'd",
+  "ab data-x": 0,
+  tc: "y&z"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/render.debug.md
@@ -1,0 +1,35 @@
+# Render `{"name":"x","on":true,"flag":true}`
+```html
+<main>
+  <h1>
+    a&bx&lt;c
+  </h1>
+  <a
+    data-x="on"
+    title="a\"b"
+  >
+    x
+  </a>
+</main>
+```
+
+# Update `{"name":"y&z","on":false,"flag":false}`
+```html
+<main>
+  <h1>
+    a&by&z&lt;c
+  </h1>
+  <a
+    title="c'd"
+  >
+    y&z
+  </a>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "a&bx<c" => "a&by&z<c"
+UPDATE: main > a[title] "a\"b" => "c'd"
+UPDATE: main > a[data-x] "on" => null
+UPDATE: main > a::text "x" => "y&z"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/render.md
@@ -1,0 +1,35 @@
+# Render `{"name":"x","on":true,"flag":true}`
+```html
+<main>
+  <h1>
+    a&bx&lt;c
+  </h1>
+  <a
+    data-x="on"
+    title="a\"b"
+  >
+    x
+  </a>
+</main>
+```
+
+# Update `{"name":"y&z","on":false,"flag":false}`
+```html
+<main>
+  <h1>
+    a&by&z&lt;c
+  </h1>
+  <a
+    title="c'd"
+  >
+    y&z
+  </a>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "a&bx<c" => "a&by&z<c"
+UPDATE: main > a[title] "a\"b" => "c'd"
+UPDATE: main > a[data-x] "on" => null
+UPDATE: main > a::text "x" => "y&z"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/writes.debug.html
@@ -1,0 +1,8 @@
+<main>
+  <h1>a&amp;bx&lt;c<!--M_*1 #text/0--></h1><a title='a"b'
+    data-x=on>x<!--M_*1 #text/2--></a><!--M_*1 #a/1-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<main>
+  <h1>a&amp;bx&lt;c<!--M_*1 a--></h1><a title='a"b'
+    data-x=on>x<!--M_*1 c--></a><!--M_*1 b-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2162,
+      "brotli": 1100
+    }
+  },
+  "html": {
+    "min": 384,
+    "brotli": 259
+  },
+  "patch": {
+    "min": 59,
+    "brotli": 63
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/template.marko
@@ -1,0 +1,4 @@
+<main>
+  <h1>${`a&b${input.name}<c`}</h1>
+  <a title=(input.on ? 'a"b' : "c'd") data-x=(input.flag && "on")>${input.name}</a>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+// Captured holes and attrs render through the capture helpers: escaping of
+// static template parts and conditional/logical attr shapes must match the
+// factored writers they replace.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { name: "x", on: true, flag: true },
+    { name: "y&z", on: false, flag: false },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
@@ -26,11 +26,11 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
 		let hits = 0;
-		_html(`<p>${_patch_text($scope1_id, "#text/0", name)}${_escape(name)}${_el_resume($scope1_id, "#text/0")} hit <!>${_escape(hits)}${_el_resume($scope1_id, "#text/1")}</p>`);
+		_html(`<p>${_patch_text($scope1_id, "#text/0", name)}${_el_resume($scope1_id, "#text/0")} hit <!>${_escape(hits)}${_el_resume($scope1_id, "#text/1")}</p>`);
 		_set_serialize_reason({
 			0: $sg__input_show,
 			1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
@@ -26,11 +26,11 @@ var counter_default = _template_persisted("b", (input) => {
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
 		let hits = 0;
-		_html(`<p>${_patch_text($scope1_id, "a", name)}${_escape(name)}${_el_resume($scope1_id, "a")} hit <!>${_escape(hits)}${_el_resume($scope1_id, "b")}</p>`);
+		_html(`<p>${_patch_text($scope1_id, "a", name)}${_el_resume($scope1_id, "a")} hit <!>${_escape(hits)}${_el_resume($scope1_id, "b")}</p>`);
 		_set_serialize_reason({
 			0: $sg__input_show,
 			1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
@@ -45,7 +45,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
@@ -45,7 +45,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
@@ -30,7 +30,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const onCount = _resume((next) => {
 		last = next;
 	}, "__tests__/template.marko_0/onCount", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
 		_set_serialize_reason({

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
@@ -30,7 +30,7 @@ var template_default = _template_persisted("a", (input) => {
 	const onCount = _resume((next) => {
 		last = next;
 	}, "a0", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
 		_set_serialize_reason({

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
@@ -28,7 +28,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	let first = 0;
 	let second = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>First <!>${_escape(first)}${_el_resume($scope0_id, "#text/1")} Second <!>${_escape(second)}${_el_resume($scope0_id, "#text/2")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>First <!>${_escape(first)}${_el_resume($scope0_id, "#text/1")} Second <!>${_escape(second)}${_el_resume($scope0_id, "#text/2")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
@@ -28,7 +28,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	let first = 0;
 	let second = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>First <!>${_escape(first)}${_el_resume($scope0_id, "b")} Second <!>${_escape(second)}${_el_resume($scope0_id, "c")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>First <!>${_escape(first)}${_el_resume($scope0_id, "b")} Second <!>${_escape(second)}${_el_resume($scope0_id, "c")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
@@ -33,7 +33,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const tenfold = _resume((next) => {
 		last = next * 10;
 	}, "__tests__/template.marko_0/tenfold", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
@@ -33,7 +33,7 @@ var template_default = _template_persisted("a", (input) => {
 	const tenfold = _resume((next) => {
 		last = next * 10;
 	}, "a1", $scope0_id);
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_set_serialize_reason({
 		0: _serialize_guard($scope0_reason, 0),
 		1: _serialize_guard($scope0_reason, 1),

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
@@ -27,7 +27,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
@@ -27,7 +27,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let last = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>Last <!>${_escape(last)}${_el_resume($scope0_id, "b")}</p>`);
 	_set_serialize_reason({
 		0: $sg__input_show,
 		1: $sg__input_show

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,7 @@ var price_card_default = _template_persisted("__tests__/tags/price-card.marko", 
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	const $childScope = _peek_scope_id();
 	_patch_child($scope0_id, "#childScope/1", $childScope);
 	price_card_default({ label: input.label });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var price_card_default = _template_persisted("b", (input) => {
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	const $childScope = _peek_scope_id();
 	_patch_child($scope0_id, "b", $childScope);
 	price_card_default({ label: input.label });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	let card = price_card_default({ label: input.label });
 	_patch_child($scope0_id, "#childScope/0", $childScope);
 	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_card/var");
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/2", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/2")}</h1><button class=read>read</button>${_el_resume($scope0_id, "#button/3")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/2", input.title)}${_el_resume($scope0_id, "#text/2")}</h1><button class=read>read</button>${_el_resume($scope0_id, "#button/3")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {
 		card,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var template_default = _template_persisted("a", (input) => {
 	let card = price_card_default({ label: input.label });
 	_patch_child($scope0_id, "a", $childScope);
 	_var($scope0_id, "b", $childScope, "a0");
-	_html(`<main><h1>${_patch_text($scope0_id, "c", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "c")}</h1><button class=read>read</button>${_el_resume($scope0_id, "d")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "c", input.title)}${_el_resume($scope0_id, "c")}</h1><button class=read>read</button>${_el_resume($scope0_id, "d")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {
 		i: card,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
@@ -2,9 +2,9 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div${_patch_attr_class($scope0_id, "#div/0", input.theme)}${_attr_class(input.theme)}><p${_patch_attr_style($scope0_id, "#p/1", input.accent)}${_attr_style(input.accent)}>content</p>${_el_resume($scope0_id, "#p/1")}<span${_patch_attr_class($scope0_id, "#span/2", {
+	_html(`<div${_patch_attr_class($scope0_id, "#div/0", input.theme)}><p${_patch_attr_style($scope0_id, "#p/1", input.accent)}>content</p>${_el_resume($scope0_id, "#p/1")}<span${_patch_attr_class($scope0_id, "#span/2", {
 		base: true,
 		compact: input.on
-	})} class=${input.on ? "\"base compact\"" : "base"}${_patch_attr_style($scope0_id, "#span/2", [input.accent, { margin: 0 }])}${_attr_style([input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "#span/2")}</div>${_el_resume($scope0_id, "#div/0")}`);
+	})}${_patch_attr_style($scope0_id, "#span/2", [input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "#span/2")}</div>${_el_resume($scope0_id, "#div/0")}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
@@ -2,9 +2,9 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div${_patch_attr_class($scope0_id, "a", input.theme)}${_attr_class(input.theme)}><p${_patch_attr_style($scope0_id, "b", input.accent)}${_attr_style(input.accent)}>content</p>${_el_resume($scope0_id, "b")}<span${_patch_attr_class($scope0_id, "c", {
+	_html(`<div${_patch_attr_class($scope0_id, "a", input.theme)}><p${_patch_attr_style($scope0_id, "b", input.accent)}>content</p>${_el_resume($scope0_id, "b")}<span${_patch_attr_class($scope0_id, "c", {
 		base: true,
 		compact: input.on
-	})} class=${input.on ? "\"base compact\"" : "base"}${_patch_attr_style($scope0_id, "c", [input.accent, { margin: 0 }])}${_attr_style([input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "c")}</div>${_el_resume($scope0_id, "a")}`);
+	})}${_patch_attr_style($scope0_id, "c", [input.accent, { margin: 0 }])}>badge</span>${_el_resume($scope0_id, "c")}</div>${_el_resume($scope0_id, "a")}`);
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<em${_patch_attr_class($scope1_id, "#em/0", input.tone)}${_attr_class(input.tone)}>note</em>${_el_resume($scope1_id, "#em/0")}`);
+			_html(`<em${_patch_attr_class($scope1_id, "#em/0", input.tone)}>note</em>${_el_resume($scope1_id, "#em/0")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "8:4");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template_persisted("a", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<em${_patch_attr_class($scope1_id, "a", input.tone)}${_attr_class(input.tone)}>note</em>${_el_resume($scope1_id, "a")}`);
+			_html(`<em${_patch_attr_class($scope1_id, "a", input.tone)}>note</em>${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.debug.js
@@ -37,7 +37,7 @@ var site_footer_default = _template_persisted("__tests__/tags/site-footer.marko"
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let frozen = 0;
-	_html(`<footer>${_patch_text($scope0_id, "#text/0", input.year + frozen)}${_escape(input.year + frozen)}${_el_resume($scope0_id, "#text/0")}</footer>`);
+	_html(`<footer>${_patch_text($scope0_id, "#text/0", input.year + frozen)}${_el_resume($scope0_id, "#text/0")}</footer>`);
 	$scope0_reason && writeScope($scope0_id, { frozen }, "__tests__/tags/site-footer.marko", 0, { frozen: "1:6" });
 	_resume_branch($scope0_id);
 });
@@ -46,7 +46,7 @@ var site_footer_default = _template_persisted("__tests__/tags/site-footer.marko"
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p${_patch_attr($scope0_id, "#p/1", "title", $global().locale)}${_attr("title", $global().locale)}>${_patch_text($scope0_id, "#text/2", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "#text/2")}</p>${_el_resume($scope0_id, "#p/1")}`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p${_patch_attr($scope0_id, "#p/1", "title", $global().locale)}>${_patch_text($scope0_id, "#text/2", $global().brand)}${_el_resume($scope0_id, "#text/2")}</p>${_el_resume($scope0_id, "#p/1")}`);
 	const $childScope = _peek_scope_id();
 	_patch_child($scope0_id, "#childScope/3", $childScope);
 	price_card_default({ label: input.label });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.js
@@ -31,7 +31,7 @@ var site_footer_default = _template_persisted("d", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let frozen = 0;
-	_html(`<footer>${_patch_text($scope0_id, "a", input.year + frozen)}${_escape(input.year + frozen)}${_el_resume($scope0_id, "a")}</footer>`);
+	_html(`<footer>${_patch_text($scope0_id, "a", input.year + frozen)}${_el_resume($scope0_id, "a")}</footer>`);
 	$scope0_reason && writeScope($scope0_id, { e: frozen });
 	_resume_branch($scope0_id);
 });
@@ -40,7 +40,7 @@ var site_footer_default = _template_persisted("d", (input) => {
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p${_patch_attr($scope0_id, "b", "title", $global().locale)}${_attr("title", $global().locale)}>${_patch_text($scope0_id, "c", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "c")}</p>${_el_resume($scope0_id, "b")}`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p${_patch_attr($scope0_id, "b", "title", $global().locale)}>${_patch_text($scope0_id, "c", $global().brand)}${_el_resume($scope0_id, "c")}</p>${_el_resume($scope0_id, "b")}`);
 	const $childScope = _peek_scope_id();
 	_patch_child($scope0_id, "d", $childScope);
 	price_card_default({ label: input.label });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a0: ",`a0; ;<input>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ _renderer_shells({ a1: ",`a1 a2; ;<input>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_checked($scope0_id, "#input/1", input.agree, _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_checked($scope0_id, "#input/1", input.agree, _resume(function(next) {
 		document.querySelector("main").dataset.agree = String(next);
 	}, "__tests__/template.marko_0/checkedChange"))}${_patch_bind($scope0_id, "ControlledHandler:#input/1", _resume(function(next) {
 		document.querySelector("main").dataset.agree = String(next);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_checked($scope0_id, "b", input.agree, _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_checked($scope0_id, "b", input.agree, _resume(function(next) {
 		document.querySelector("main").dataset.agree = String(next);
 	}, "a0"))}${_patch_bind($scope0_id, "Eb", _resume(function(next) {
 		document.querySelector("main").dataset.agree = String(next);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><details${_attr_details_or_dialog_open($scope0_id, "#details/1", input.show, _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><details${_attr_details_or_dialog_open($scope0_id, "#details/1", input.show, _resume(function(next) {
 		document.querySelector("main").dataset.open = String(next);
 	}, "__tests__/template.marko_0/openChange"))}${_patch_bind($scope0_id, "ControlledHandler:#details/1", _resume(function(next) {
 		document.querySelector("main").dataset.open = String(next);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><details${_attr_details_or_dialog_open($scope0_id, "b", input.show, _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><details${_attr_details_or_dialog_open($scope0_id, "b", input.show, _resume(function(next) {
 		document.querySelector("main").dataset.open = String(next);
 	}, "a0"))}${_patch_bind($scope0_id, "Eb", _resume(function(next) {
 		document.querySelector("main").dataset.open = String(next);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.debug.js
@@ -2,13 +2,13 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_attr_select_value($scope0_id, "#select/1", input.choice, _resume(function(next) {
 		document.querySelector("main").dataset.choice = String(next);
 	}, "__tests__/template.marko_0/valueChange"), () => {
 		_html(`<select${_patch_bind($scope0_id, "ControlledHandler:#select/1", _resume(function(next) {
 			document.querySelector("main").dataset.choice = String(next);
-		}, "__tests__/template.marko_0/valueChange"))}${_patch_control($scope0_id, "#select/1", 3, input.choice)}${_patch_attr($scope0_id, "#select/1", "multiple", input.many)}${_attr("multiple", input.many)}><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
+		}, "__tests__/template.marko_0/valueChange"))}${_patch_control($scope0_id, "#select/1", 3, input.choice)}${_patch_attr($scope0_id, "#select/1", "multiple", input.many)}><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
 	});
 	_html(`${_el_resume($scope0_id, "#select/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.js
@@ -2,13 +2,13 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_attr_select_value($scope0_id, "b", input.choice, _resume(function(next) {
 		document.querySelector("main").dataset.choice = String(next);
 	}, "a0"), () => {
 		_html(`<select${_patch_bind($scope0_id, "Eb", _resume(function(next) {
 			document.querySelector("main").dataset.choice = String(next);
-		}, "a0"))}${_patch_control($scope0_id, "b", 3, input.choice)}${_patch_attr($scope0_id, "b", "multiple", input.many)}${_attr("multiple", input.many)}><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
+		}, "a0"))}${_patch_control($scope0_id, "b", 3, input.choice)}${_patch_attr($scope0_id, "b", "multiple", input.many)}><option${_attr_option_value("a")}>A</option><option${_attr_option_value("b")}>B</option></select>`);
 	});
 	_html(`${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const handler = _resume((next) => {
 		document.querySelector("main").dataset.got = next;
 	}, "__tests__/template.marko_0/handler");
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value, input.wire ? handler : undefined)}${_patch_bind($scope0_id, "ControlledHandler:#input/1", input.wire ? handler : undefined)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value, input.wire ? handler : undefined)}${_patch_bind($scope0_id, "ControlledHandler:#input/1", input.wire ? handler : undefined)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {
 		input_value: input.value,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.js
@@ -5,7 +5,7 @@ var template_default = _template_persisted("a", (input) => {
 	const handler = _resume((next) => {
 		document.querySelector("main").dataset.got = next;
 	}, "a0");
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value, input.wire ? handler : void 0)}${_patch_bind($scope0_id, "Eb", input.wire ? handler : void 0)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value, input.wire ? handler : void 0)}${_patch_bind($scope0_id, "Eb", input.wire ? handler : void 0)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {
 		f: input.value,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_attr_select_value($scope0_id, "#select/1", input.choice, _resume(function(next) {
 		document.querySelector("main").dataset.choice = next;
 	}, "__tests__/template.marko_0/valueChange"), () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_attr_select_value($scope0_id, "b", input.choice, _resume(function(next) {
 		document.querySelector("main").dataset.choice = next;
 	}, "a0"), () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const loud = _resume((next) => {
 		document.querySelector("main").dataset.got = next.toUpperCase();
 	}, "__tests__/template.marko_0/loud");
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value, input.big ? loud : plain)}${_patch_bind($scope0_id, "ControlledHandler:#input/1", input.big ? loud : plain)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value, input.big ? loud : plain)}${_patch_bind($scope0_id, "ControlledHandler:#input/1", input.big ? loud : plain)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {
 		input_value: input.value,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var template_default = _template_persisted("a", (input) => {
 	const loud = _resume((next) => {
 		document.querySelector("main").dataset.got = next.toUpperCase();
 	}, "a1");
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value, input.big ? loud : plain)}${_patch_bind($scope0_id, "Eb", input.big ? loud : plain)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value, input.big ? loud : plain)}${_patch_bind($scope0_id, "Eb", input.big ? loud : plain)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a2");
 	$scope0_reason && writeScope($scope0_id, {
 		f: input.value,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><textarea${_patch_bind($scope0_id, "ControlledHandler:#textarea/1", _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><textarea${_patch_bind($scope0_id, "ControlledHandler:#textarea/1", _resume(function(next) {
 		document.querySelector("main").dataset.text = next;
 	}, "__tests__/template.marko_0/valueChange"))}${_patch_control($scope0_id, "#textarea/1", 2, input.text)}>${_attr_textarea_value($scope0_id, "#textarea/1", input.text, _resume(function(next) {
 		document.querySelector("main").dataset.text = next;

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><textarea${_patch_bind($scope0_id, "Eb", _resume(function(next) {
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><textarea${_patch_bind($scope0_id, "Eb", _resume(function(next) {
 		document.querySelector("main").dataset.text = next;
 	}, "a0"))}${_patch_control($scope0_id, "b", 2, input.text)}>${_attr_textarea_value($scope0_id, "b", input.text, _resume(function(next) {
 		document.querySelector("main").dataset.text = next;

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.debug.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value)}${_patch_control($scope0_id, "#input/1", 2, input.value)}>${_el_resume($scope0_id, "#input/1")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value)}${_patch_control($scope0_id, "b", 2, input.value)}>${_el_resume($scope0_id, "b")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<a${_patch_attr($scope0_id, "#a/0", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope0_id, "#a/0", "title", input.title)}${_attr("title", input.title)}${_patch_attr($scope0_id, "#a/0", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope0_id, "#text/1", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "#text/1")}</a>${_el_resume($scope0_id, "#a/0")}`);
+	_html(`<a${_patch_attr($scope0_id, "#a/0", "href", input.href)}${_patch_attr($scope0_id, "#a/0", "title", input.title)}${_patch_attr($scope0_id, "#a/0", "hidden", input.hidden)}>${_patch_text($scope0_id, "#text/1", input.label)}${_el_resume($scope0_id, "#text/1")}</a>${_el_resume($scope0_id, "#a/0")}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<a${_patch_attr($scope0_id, "a", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope0_id, "a", "title", input.title)}${_attr("title", input.title)}${_patch_attr($scope0_id, "a", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope0_id, "b", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "b")}</a>${_el_resume($scope0_id, "a")}`);
+	_html(`<a${_patch_attr($scope0_id, "a", "href", input.href)}${_patch_attr($scope0_id, "a", "title", input.title)}${_patch_attr($scope0_id, "a", "hidden", input.hidden)}>${_patch_text($scope0_id, "b", input.label)}${_el_resume($scope0_id, "b")}</a>${_el_resume($scope0_id, "a")}`);
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>Click</button>${_el_resume($scope0_id, "#button/1")}</div>`);
+	_html(`<div><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>Click</button>${_el_resume($scope0_id, "#button/1")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><button>Click</button>${_el_resume($scope0_id, "b")}</div>`);
+	_html(`<div><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><button>Click</button>${_el_resume($scope0_id, "b")}</div>`);
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.debug.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div><h1${_patch_attr($scope0_id, "#h1/0", "title", $global().locale)}${_attr("title", $global().locale)}>${_patch_text($scope0_id, "#text/1", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "#text/1")}</h1>${_el_resume($scope0_id, "#h1/0")}<p>${_patch_text($scope0_id, "#text/2", input.name)}${_escape(input.name)}${_el_resume($scope0_id, "#text/2")}</p></div>`);
+	_html(`<div><h1${_patch_attr($scope0_id, "#h1/0", "title", $global().locale)}>${_patch_text($scope0_id, "#text/1", $global().brand)}${_el_resume($scope0_id, "#text/1")}</h1>${_el_resume($scope0_id, "#h1/0")}<p>${_patch_text($scope0_id, "#text/2", input.name)}${_el_resume($scope0_id, "#text/2")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div><h1${_patch_attr($scope0_id, "a", "title", $global().locale)}${_attr("title", $global().locale)}>${_patch_text($scope0_id, "b", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "b")}</h1>${_el_resume($scope0_id, "a")}<p>${_patch_text($scope0_id, "c", input.name)}${_escape(input.name)}${_el_resume($scope0_id, "c")}</p></div>`);
+	_html(`<div><h1${_patch_attr($scope0_id, "a", "title", $global().locale)}>${_patch_text($scope0_id, "b", $global().brand)}${_el_resume($scope0_id, "b")}</h1>${_el_resume($scope0_id, "a")}<p>${_patch_text($scope0_id, "c", input.name)}${_el_resume($scope0_id, "c")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let read = "";
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "#text/0")}</h1><button>read</button>${_el_resume($scope0_id, "#button/1")}<p>${_escape(read)}${_el_resume($scope0_id, "#text/2")}</p></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", $global().brand)}${_el_resume($scope0_id, "#text/0")}</h1><button>read</button>${_el_resume($scope0_id, "#button/1")}<p>${_escape(read)}${_el_resume($scope0_id, "#text/2")}</p></main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", $global().brand)}${_escape($global().brand)}${_el_resume($scope0_id, "a")}</h1><button>read</button>${_el_resume($scope0_id, "b")}<p>${_escape("")}${_el_resume($scope0_id, "c")}</p></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", $global().brand)}${_el_resume($scope0_id, "a")}</h1><button>read</button>${_el_resume($scope0_id, "b")}<p>${_escape("")}${_el_resume($scope0_id, "c")}</p></main>`);
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, {});
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>read</button>${_el_resume($scope0_id, "#button/1")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>read</button>${_el_resume($scope0_id, "#button/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason ? writeScope($scope0_id, { input_title: input.title }, "__tests__/template.marko", 0, { input_title: ["input.title"] }) : _patch_write($scope0_id, "input_title", input.title);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><button>read</button>${_el_resume($scope0_id, "b")}</main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><button>read</button>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a0");
 	$scope0_reason ? writeScope($scope0_id, { e: input.title }) : _patch_write($scope0_id, "e", input.title);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0), $sg__input_items = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<div class=wrap><h1>Hello <!>${_patch_text($scope0_id, "#text/0", input.name)}${_escape(input.name)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<div class=wrap><h1>Hello <!>${_patch_text($scope0_id, "#text/0", input.name)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
@@ -17,7 +17,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_for_of(input.items, (item) => {
 		const $scope2_id = _scope_id();
-		_html(`<li>${_patch_text($scope2_id, "#text/0", item)}${_escape(item)}${_el_resume($scope2_id, "#text/0")}</li>`);
+		_html(`<li>${_patch_text($scope2_id, "#text/0", item)}${_el_resume($scope2_id, "#text/0")}</li>`);
 		writeScope($scope2_id, {}, "__tests__/template.marko", "6:4");
 	}, 0, $scope0_id, "#text/2", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_2_shell");
 	_html("</div>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ _renderer_shells({
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 0), $sg__input_items = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html(`<div class=wrap><h1>Hello <!>${_patch_text($scope0_id, "a", input.name)}${_escape(input.name)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<div class=wrap><h1>Hello <!>${_patch_text($scope0_id, "a", input.name)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
@@ -17,7 +17,7 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", $sg__input_show, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_for_of(input.items, (item) => {
 		const $scope2_id = _scope_id();
-		_html(`<li>${_patch_text($scope2_id, "a", item)}${_escape(item)}${_el_resume($scope2_id, "a")}</li>`);
+		_html(`<li>${_patch_text($scope2_id, "a", item)}${_el_resume($scope2_id, "a")}</li>`);
 		writeScope($scope2_id, {});
 	}, 0, $scope0_id, "c", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "a1");
 	_html("</div>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("<ul>");
 	_for_of(input.labels, (label) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "#text/0", label)}${_escape(label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(boost)}${_el_resume($scope1_id, "#text/1")}</span></li>`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(boost)}${_el_resume($scope1_id, "#text/1")}</span></li>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:4");
 	}, 0, $scope0_id, "#ul/0", 1, 1, _serialize_guard($scope0_reason, 0), void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0")}<button>+</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("a", (input) => {
 	_html("<ul>");
 	_for_of(input.labels, (label) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "a", label)}${_escape(label)}${_el_resume($scope1_id, "a")}<span>${_escape(boost)}${_el_resume($scope1_id, "b")}</span></li>`);
+		_html(`<li>${_patch_text($scope1_id, "a", label)}${_el_resume($scope1_id, "a")}<span>${_escape(boost)}${_el_resume($scope1_id, "b")}</span></li>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 	}, 0, $scope0_id, "a", 1, 1, _serialize_guard($scope0_reason, 0), void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a")}<button>+</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_for_of(input.labels, (label) => {
 		const $scope1_id = _scope_id();
 		let picks = 0;
-		_html(`<li>${_patch_text($scope1_id, "#text/0", label)}${_escape(label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(picks)}${_el_resume($scope1_id, "#text/1")}</span><button>+</button>${_el_resume($scope1_id, "#button/2")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(picks)}${_el_resume($scope1_id, "#text/1")}</span><button>+</button>${_el_resume($scope1_id, "#button/2")}</li>`);
 		_script($scope1_id, "__tests__/template.marko_1");
 		_patch_value($scope1_id, "__tests__/template.marko0", picks, 1);
 		writeScope($scope1_id, { picks }, "__tests__/template.marko", "2:4", { picks: "5:12" });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("a", (input) => {
 	_for_of(input.labels, (label) => {
 		const $scope1_id = _scope_id();
 		let picks = 0;
-		_html(`<li>${_patch_text($scope1_id, "a", label)}${_escape(label)}${_el_resume($scope1_id, "a")}<span>${_escape(picks)}${_el_resume($scope1_id, "b")}</span><button>+</button>${_el_resume($scope1_id, "c")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "a", label)}${_el_resume($scope1_id, "a")}<span>${_escape(picks)}${_el_resume($scope1_id, "b")}</span><button>+</button>${_el_resume($scope1_id, "c")}</li>`);
 		_script($scope1_id, "a1");
 		_patch_value($scope1_id, "a0", picks, 1);
 		writeScope($scope1_id, { f: picks });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("<ul>");
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "#text/0")}`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_el_resume($scope1_id, "#text/0")}`);
 		_if(() => {
 			if (item.detailed) {
 				const $scope2_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var template_default = _template_persisted("a", (input) => {
 	_html("<ul>");
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "a")}`);
+		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_el_resume($scope1_id, "a")}`);
 		_if(() => {
 			if (item.detailed) {
 				const $scope2_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
 		let votes = item.start;
-		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(votes)}${_el_resume($scope1_id, "#text/1")}</span><button>+</button>${_el_resume($scope1_id, "#button/2")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_el_resume($scope1_id, "#text/0")}<span>${_escape(votes)}${_el_resume($scope1_id, "#text/1")}</span><button>+</button>${_el_resume($scope1_id, "#button/2")}</li>`);
 		_script($scope1_id, "__tests__/template.marko_1");
 		_patch_value($scope1_id, "__tests__/template.marko0", votes, 1);
 		writeScope($scope1_id, { votes }, "__tests__/template.marko", "2:4", { votes: "5:12" });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("a", (input) => {
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
 		let votes = item.start;
-		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "a")}<span>${_escape(votes)}${_el_resume($scope1_id, "b")}</span><button>+</button>${_el_resume($scope1_id, "c")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_el_resume($scope1_id, "a")}<span>${_escape(votes)}${_el_resume($scope1_id, "b")}</span><button>+</button>${_el_resume($scope1_id, "c")}</li>`);
 		_script($scope1_id, "a1");
 		_patch_value($scope1_id, "a0", votes, 1);
 		writeScope($scope1_id, { h: votes });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
@@ -10,19 +10,19 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope2_id = _scope_id();
-		_html(`<li>${_patch_text($scope2_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope2_id, "#text/0")}</li>`);
+		_html(`<li>${_patch_text($scope2_id, "#text/0", item.label)}${_el_resume($scope2_id, "#text/0")}</li>`);
 		writeScope($scope2_id, {}, "__tests__/template.marko", "4:6");
 	}, "id", $scope0_id, "#ul/0", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_2_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0", $sg__input_items)}`);
 	_if(() => {
 		if (input.promo) {
 			const $scope1_id = _scope_id();
-			_html(`<aside>${_patch_text($scope1_id, "#text/0", input.promo)}${_escape(input.promo)}${_el_resume($scope1_id, "#text/0")}</aside>`);
+			_html(`<aside>${_patch_text($scope1_id, "#text/0", input.promo)}${_el_resume($scope1_id, "#text/0")}</aside>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "8:4");
 			return 0;
 		}
 	}, $scope0_id, "#text/1", $sg__input_promo, $sg__input_promo, $sg__input_promo, void 0, void 0, ["__tests__/template.marko_1_shell"]);
-	_html(`<p>${_patch_text($scope0_id, "#text/2", input.note)}${_escape(input.note)}${_el_resume($scope0_id, "#text/2")}</p><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/4")}</button>${_el_resume($scope0_id, "#button/3")}</main>`);
+	_html(`<p>${_patch_text($scope0_id, "#text/2", input.note)}${_el_resume($scope0_id, "#text/2")}</p><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/4")}</button>${_el_resume($scope0_id, "#button/3")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {
 		input_promo: input.promo,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
@@ -10,19 +10,19 @@ var template_default = _template_persisted("a", (input) => {
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope2_id = _scope_id();
-		_html(`<li>${_patch_text($scope2_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope2_id, "a")}</li>`);
+		_html(`<li>${_patch_text($scope2_id, "a", item.label)}${_el_resume($scope2_id, "a")}</li>`);
 		writeScope($scope2_id, {});
 	}, "id", $scope0_id, "a", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a", $sg__input_items)}`);
 	_if(() => {
 		if (input.promo) {
 			const $scope1_id = _scope_id();
-			_html(`<aside>${_patch_text($scope1_id, "a", input.promo)}${_escape(input.promo)}${_el_resume($scope1_id, "a")}</aside>`);
+			_html(`<aside>${_patch_text($scope1_id, "a", input.promo)}${_el_resume($scope1_id, "a")}</aside>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}
 	}, $scope0_id, "b", $sg__input_promo, $sg__input_promo, $sg__input_promo, void 0, void 0, ["a1"]);
-	_html(`<p>${_patch_text($scope0_id, "c", input.note)}${_escape(input.note)}${_el_resume($scope0_id, "c")}</p><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "e")}</button>${_el_resume($scope0_id, "d")}</main>`);
+	_html(`<p>${_patch_text($scope0_id, "c", input.note)}${_el_resume($scope0_id, "c")}</p><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "e")}</button>${_el_resume($scope0_id, "d")}</main>`);
 	_script($scope0_id, "a2");
 	$scope0_reason && writeScope($scope0_id, {
 		i: input.promo,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "#text/0")} (<!>${_escape(count)}${_el_resume($scope1_id, "#text/1")})</li>`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_el_resume($scope1_id, "#text/0")} (<!>${_escape(count)}${_el_resume($scope1_id, "#text/1")})</li>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:6");
 	}, "id", $scope0_id, "#ul/0", 1, 1, _serialize_guard($scope0_reason, 0), void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0")}<button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template_persisted("a", (input) => {
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "a")} (<!>${_escape(count)}${_el_resume($scope1_id, "b")})</li>`);
+		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_el_resume($scope1_id, "a")} (<!>${_escape(count)}${_el_resume($scope1_id, "b")})</li>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 	}, "id", $scope0_id, "a", 1, 1, _serialize_guard($scope0_reason, 0), void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a")}<button>Count <!>${_escape(count)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
@@ -3,10 +3,10 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	forOf(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
-		_html(`<p>item <!>${_patch_text($scope1_id, "#text/0", name)}${_escape(name)}${_el_resume($scope1_id, "#text/0")}</p>`);
+		_html(`<p>item <!>${_patch_text($scope1_id, "#text/0", name)}${_el_resume($scope1_id, "#text/0")}</p>`);
 		writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
 	});
 	_html("</main>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
@@ -3,10 +3,10 @@ _renderer_shells({ a0: ",`a0;Db%;<p>item <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	forOf(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
-		_html(`<p>item <!>${_patch_text($scope1_id, "a", name)}${_escape(name)}${_el_resume($scope1_id, "a")}</p>`);
+		_html(`<p>item <!>${_patch_text($scope1_id, "a", name)}${_el_resume($scope1_id, "a")}</p>`);
 		writeScope($scope1_id, {});
 	});
 	_html("</main>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
@@ -3,10 +3,10 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_note = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
-		_html(`<p>${_patch_text($scope1_id, "#text/0", name)}${_escape(name)}${_el_resume($scope1_id, "#text/0")} <!>${_patch_text($scope1_id, "#text/1", input.note)}${_escape(input.note)}${_el_resume($scope1_id, "#text/1")}</p>`);
+		_html(`<p>${_patch_text($scope1_id, "#text/0", name)}${_el_resume($scope1_id, "#text/0")} <!>${_patch_text($scope1_id, "#text/1", input.note)}${_el_resume($scope1_id, "#text/1")}</p>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:4");
 	}, 0, $scope0_id, "#text/1", $sg__input_note, $sg__input_note, 0, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html("</main>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
@@ -3,10 +3,10 @@ _renderer_shells({ a0: ",`a0;D%c%;<p><!> <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_note = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_for_of(["a", "b"], (name) => {
 		const $scope1_id = _scope_id();
-		_html(`<p>${_patch_text($scope1_id, "a", name)}${_escape(name)}${_el_resume($scope1_id, "a")} <!>${_patch_text($scope1_id, "b", input.note)}${_escape(input.note)}${_el_resume($scope1_id, "b")}</p>`);
+		_html(`<p>${_patch_text($scope1_id, "a", name)}${_el_resume($scope1_id, "a")} <!>${_patch_text($scope1_id, "b", input.note)}${_el_resume($scope1_id, "b")}</p>`);
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 	}, 0, $scope0_id, "b", $sg__input_note, $sg__input_note, 0, void 0, void 0, "a0");
 	_html("</main>");

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
@@ -4,10 +4,10 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason(), $sg__input_items = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><ul>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><ul>`);
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "#text/0")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "#text/0", item.label)}${_el_resume($scope1_id, "#text/0")}</li>`);
 		writeScope($scope1_id, {}, "__tests__/template.marko", "5:6");
 	}, "id", $scope0_id, "#ul/1", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/1", $sg__input_items)}<button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/3")}</button>${_el_resume($scope0_id, "#button/2")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
@@ -4,10 +4,10 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_items = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><ul>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><ul>`);
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope1_id, "a")}</li>`);
+		_html(`<li>${_patch_text($scope1_id, "a", item.label)}${_el_resume($scope1_id, "a")}</li>`);
 		writeScope($scope1_id, {});
 	}, "id", $scope0_id, "b", $sg__input_items, $sg__input_items, $sg__input_items, void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "b", $sg__input_items)}<button>Count <!>${_escape(count)}${_el_resume($scope0_id, "d")}</button>${_el_resume($scope0_id, "c")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var badge_default = _template_persisted("__tests__/tags/badge.marko", (input) =>
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let seen = 0;
-	_html(`<footer><span>${_patch_text($scope0_id, "#text/0", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "#text/0")} (<!>${_escape(seen)}${_el_resume($scope0_id, "#text/1")})</span><button>ack</button>${_el_resume($scope0_id, "#button/2")}</footer>`);
+	_html(`<footer><span>${_patch_text($scope0_id, "#text/0", input.label)}${_el_resume($scope0_id, "#text/0")} (<!>${_escape(seen)}${_el_resume($scope0_id, "#text/1")})</span><button>ack</button>${_el_resume($scope0_id, "#button/2")}</footer>`);
 	_script($scope0_id, "__tests__/tags/badge.marko_0");
 	$scope0_reason && writeScope($scope0_id, { seen }, "__tests__/tags/badge.marko", 0, { seen: "1:6" });
 	_resume_branch($scope0_id);
@@ -23,7 +23,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope3_id = _scope_id();
-		_html(`<li>${_patch_text($scope3_id, "#text/0", item.label)}${_escape(item.label)}${_el_resume($scope3_id, "#text/0")}`);
+		_html(`<li>${_patch_text($scope3_id, "#text/0", item.label)}${_el_resume($scope3_id, "#text/0")}`);
 		_if(() => {
 			if (item.sale) {
 				const $scope4_id = _scope_id();
@@ -39,11 +39,11 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_if(() => {
 		if (input.summary) {
 			const $scope1_id = _scope_id();
-			_html(`<section>${_patch_text($scope1_id, "#text/0", input.summary)}${_escape(input.summary)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`<section>${_patch_text($scope1_id, "#text/0", input.summary)}${_el_resume($scope1_id, "#text/0")}`);
 			_if(() => {
 				if (input.detail) {
 					const $scope2_id = _scope_id();
-					_html(`<small>${_patch_text($scope2_id, "#text/0", input.detail)}${_escape(input.detail)}${_el_resume($scope2_id, "#text/0")}</small>`);
+					_html(`<small>${_patch_text($scope2_id, "#text/0", input.detail)}${_el_resume($scope2_id, "#text/0")}</small>`);
 					_subscribe(_serialize_if($scope0_reason, 3) && $input_detail__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "15:8"));
 					return 0;
 				}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var badge_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let seen = 0;
-	_html(`<footer><span>${_patch_text($scope0_id, "a", input.label)}${_escape(input.label)}${_el_resume($scope0_id, "a")} (<!>${_escape(seen)}${_el_resume($scope0_id, "b")})</span><button>ack</button>${_el_resume($scope0_id, "c")}</footer>`);
+	_html(`<footer><span>${_patch_text($scope0_id, "a", input.label)}${_el_resume($scope0_id, "a")} (<!>${_escape(seen)}${_el_resume($scope0_id, "b")})</span><button>ack</button>${_el_resume($scope0_id, "c")}</footer>`);
 	_script($scope0_id, "b0");
 	$scope0_reason && writeScope($scope0_id, { g: seen });
 	_resume_branch($scope0_id);
@@ -23,7 +23,7 @@ var template_default = _template_persisted("a", (input) => {
 	_html("<main><ul>");
 	_for_of(input.items, (item) => {
 		const $scope3_id = _scope_id();
-		_html(`<li>${_patch_text($scope3_id, "a", item.label)}${_escape(item.label)}${_el_resume($scope3_id, "a")}`);
+		_html(`<li>${_patch_text($scope3_id, "a", item.label)}${_el_resume($scope3_id, "a")}`);
 		_if(() => {
 			if (item.sale) {
 				const $scope4_id = _scope_id();
@@ -39,11 +39,11 @@ var template_default = _template_persisted("a", (input) => {
 	_if(() => {
 		if (input.summary) {
 			const $scope1_id = _scope_id();
-			_html(`<section>${_patch_text($scope1_id, "a", input.summary)}${_escape(input.summary)}${_el_resume($scope1_id, "a")}`);
+			_html(`<section>${_patch_text($scope1_id, "a", input.summary)}${_el_resume($scope1_id, "a")}`);
 			_if(() => {
 				if (input.detail) {
 					const $scope2_id = _scope_id();
-					_html(`<small>${_patch_text($scope2_id, "a", input.detail)}${_escape(input.detail)}${_el_resume($scope2_id, "a")}</small>`);
+					_html(`<small>${_patch_text($scope2_id, "a", input.detail)}${_el_resume($scope2_id, "a")}</small>`);
 					_subscribe(_serialize_if($scope0_reason, 3) && $input_detail__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }));
 					return 0;
 				}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<span>hi <!>${_patch_text($scope1_id, "#text/0", input.msg)}${_escape(input.msg)}${_el_resume($scope1_id, "#text/0")}</span>`);
+			_html(`<span>hi <!>${_patch_text($scope1_id, "#text/0", input.msg)}${_el_resume($scope1_id, "#text/0")}</span>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:6");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var template_default = _template_persisted("a", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<span>hi <!>${_patch_text($scope1_id, "a", input.msg)}${_escape(input.msg)}${_el_resume($scope1_id, "a")}</span>`);
+			_html(`<span>hi <!>${_patch_text($scope1_id, "a", input.msg)}${_el_resume($scope1_id, "a")}</span>`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1></main>`);
 	_script($scope0_id, "__tests__/template.marko_0_input_announce");
 	_patch_effect($scope0_id, "__tests__/template.marko_0_input_announce", "input_announce");
 	$scope0_reason ? writeScope($scope0_id, { input_announce: input.announce }, "__tests__/template.marko", 0, { input_announce: ["input.announce"] }) : _patch_write($scope0_id, "input_announce", input.announce);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1></main>`);
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "e");
 	$scope0_reason ? writeScope($scope0_id, { e: input.announce }) : _patch_write($scope0_id, "e", input.announce);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1></main>`);
 	_script($scope0_id, "__tests__/template.marko_0_input_a_input_b");
 	_patch_effect($scope0_id, "__tests__/template.marko_0_input_a_input_b", "input_a input_b");
 	$scope0_reason ? writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1></main>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1></main>`);
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "e f");
 	$scope0_reason ? writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
@@ -3,11 +3,11 @@ _renderer_shells({ "__tests__/template.marko_1_shell": ",`__tests__/template.mar
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<a${_patch_attr($scope1_id, "#a/0", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope1_id, "#a/0", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope1_id, "#text/1", input.label)}${_escape(input.label)}${_el_resume($scope1_id, "#text/1")}</a>${_el_resume($scope1_id, "#a/0")}`);
+			_html(`<a${_patch_attr($scope1_id, "#a/0", "href", input.href)}${_patch_attr($scope1_id, "#a/0", "hidden", input.hidden)}>${_patch_text($scope1_id, "#text/1", input.label)}${_el_resume($scope1_id, "#text/1")}</a>${_el_resume($scope1_id, "#a/0")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:4");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
@@ -3,11 +3,11 @@ _renderer_shells({ a0: ",`a0; D ;<a> </a>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1>`);
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1>`);
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`<a${_patch_attr($scope1_id, "a", "href", input.href)}${_attr("href", input.href)}${_patch_attr($scope1_id, "a", "hidden", input.hidden)}${_attr("hidden", input.hidden)}>${_patch_text($scope1_id, "b", input.label)}${_escape(input.label)}${_el_resume($scope1_id, "b")}</a>${_el_resume($scope1_id, "a")}`);
+			_html(`<a${_patch_attr($scope1_id, "a", "href", input.href)}${_patch_attr($scope1_id, "a", "hidden", input.hidden)}>${_patch_text($scope1_id, "b", input.label)}${_el_resume($scope1_id, "b")}</a>${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<div><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}</div>`);
+	_html(`<div><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/2")}</button>${_el_resume($scope0_id, "#button/1")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_html(`<div><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}</div>`);
+	_html(`<div><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "c")}</button>${_el_resume($scope0_id, "b")}</div>`);
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, { g: count });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.debug.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div class=card><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>${_patch_text($scope0_id, "#text/1", input.body)}${_escape(input.body)}${_el_resume($scope0_id, "#text/1")}</p></div>`);
+	_html(`<div class=card><h1>${_patch_text($scope0_id, "#text/0", input.title)}${_el_resume($scope0_id, "#text/0")}</h1><p>${_patch_text($scope0_id, "#text/1", input.body)}${_el_resume($scope0_id, "#text/1")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.js
@@ -2,6 +2,6 @@
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();
-	_html(`<div class=card><h1>${_patch_text($scope0_id, "a", input.title)}${_escape(input.title)}${_el_resume($scope0_id, "a")}</h1><p>${_patch_text($scope0_id, "b", input.body)}${_escape(input.body)}${_el_resume($scope0_id, "b")}</p></div>`);
+	_html(`<div class=card><h1>${_patch_text($scope0_id, "a", input.title)}${_el_resume($scope0_id, "a")}</h1><p>${_patch_text($scope0_id, "b", input.body)}${_el_resume($scope0_id, "b")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {});
 }, 1);

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -448,7 +448,7 @@ function writeControlledScope(
   );
 }
 
-function stringAttr(name: string, value: string) {
+export function stringAttr(name: string, value: string) {
   return value && " " + name + attrAssignment(value);
 }
 

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -24,11 +24,11 @@ import {
   ResumeSymbol,
 } from "../common/types";
 import { RendererProp } from "../common/types";
-import { attrAssignment } from "./attrs";
+import { _attr, attrAssignment, stringAttr } from "./attrs";
 import * as FlushStatus from "./constants/flush-status";
 import * as Mark from "./constants/mark";
 import * as RuntimeKey from "./constants/runtime-key";
-import { _to_text } from "./content";
+import { _escape, _to_text } from "./content";
 import { forInBy, forOfBy, forStepBy } from "./for";
 import {
   REORDER_RUNTIME_CODE,
@@ -288,6 +288,8 @@ export function patchPartial(state: State, scopeId: number) {
   return partial;
 }
 
+// Patch writers double as the output writers so the compiled template
+// evaluates each captured expression once.
 export function _patch_attr(
   scopeId: number,
   accessor: Accessor,
@@ -305,7 +307,7 @@ export function _patch_attr(
     $chunk.needsWalk = true;
   }
 
-  return "";
+  return _attr(name, value);
 }
 
 // Class/style normalize on the server into the same string the dom helper
@@ -315,11 +317,11 @@ export function _patch_attr_class(
   accessor: Accessor,
   value: unknown,
 ) {
-  return _patch_attr(
+  return patchStringAttr(
     scopeId,
     accessor,
     "class",
-    toDelimitedString(value, " ", stringifyClassObject) || undefined,
+    toDelimitedString(value, " ", stringifyClassObject),
   );
 }
 
@@ -328,12 +330,30 @@ export function _patch_attr_style(
   accessor: Accessor,
   value: unknown,
 ) {
-  return _patch_attr(
+  return patchStringAttr(
     scopeId,
     accessor,
     "style",
-    toDelimitedString(value, ";", stringifyStyleObject) || undefined,
+    toDelimitedString(value, ";", stringifyStyleObject),
   );
+}
+
+function patchStringAttr(
+  scopeId: number,
+  accessor: Accessor,
+  name: string,
+  value: string,
+) {
+  const { state } = $chunk.boundary;
+  if (state.writesPatches) {
+    writePatch(scopeId, {
+      [PatchKey.Attr + accessor + " " + name]: value || 0,
+    });
+  } else {
+    $chunk.needsWalk = true;
+  }
+
+  return stringAttr(name, value);
 }
 
 // Links a child scope into its parent's entry: immediately when already
@@ -521,7 +541,7 @@ export function _patch_text(
     $chunk.needsWalk = true;
   }
 
-  return "";
+  return _escape(value);
 }
 
 export function _sep(shouldResume: number) {

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -227,18 +227,19 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     }
 
     if (isHTML) {
-      if (isPatchText) {
-        write`${callRuntime(
-          "_patch_text",
-          getScopeIdIdentifier(section),
-          getScopeAccessorLiteral(nodeBinding),
-          value,
-        )}`;
-      }
+      // The capture writes the escaped text itself, so the expression
+      // appears (and evaluates) once.
       write`${
-        method === "_escape"
-          ? buildEscapedTextExpression(value)
-          : callRuntime(method as HTMLMethod | DOMMethod, value)
+        isPatchText
+          ? callRuntime(
+              "_patch_text",
+              getScopeIdIdentifier(section),
+              getScopeAccessorLiteral(nodeBinding),
+              value,
+            )
+          : method === "_escape"
+            ? buildEscapedTextExpression(value)
+            : callRuntime(method as HTMLMethod | DOMMethod, value)
       }`;
       if (nodeBinding) {
         writer.markNode(placeholder, nodeBinding, markerSerializeReason);

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -681,6 +681,8 @@ export default {
               if (confident) {
                 write`${getHTMLRuntime()[helper](computed)}`;
               } else {
+                // The capture renders the attribute itself, so the
+                // expression appears (and normalizes) once.
                 if (capturesPatchAttr(name, value)) {
                   write`${callRuntime(
                     `_patch_attr_${name as "class" | "style"}`,
@@ -688,6 +690,7 @@ export default {
                     getScopeAccessorLiteral(nodeBinding!),
                     value,
                   )}`;
+                  break;
                 }
                 write`${factorAttrConditional(
                   buildAttrExpression(
@@ -713,6 +716,8 @@ export default {
               } else if (isEventHandler(name)) {
                 addHTMLEffectCall(tagSection, valueReferences);
               } else {
+                // The capture renders the attribute itself, so the
+                // expression appears (and evaluates) once.
                 if (capturesPatchAttr(name, value)) {
                   write`${callRuntime(
                     "_patch_attr",
@@ -721,6 +726,7 @@ export default {
                     t.stringLiteral(name),
                     value,
                   )}`;
+                  break;
                 }
                 write`${factorAttrConditional(
                   buildAttrExpression(


### PR DESCRIPTION
Persisted capture helpers now double as the output writers: `_patch_text` returns the escaped text, `_patch_attr` returns the rendered attribute, and `_patch_attr_class`/`_patch_attr_style` share one normalization between the patch entry and the returned attribute (previously normalized twice). Compiled templates emit a single interpolation per captured hole/attr instead of a capture call beside a duplicated expression, so each user expression appears and evaluates once.

Rendered HTML and patch payloads are byte-identical (no `writes*.html` changes); persisted server bundles shrink (e.g. −148 bytes on `persisted-class-attribute`, −46 on `persisted-branch`). Non-captured attrs and non-persisted templates keep the factored/static-escape paths. A new `persisted-capture-escapes` fixture pins escaping of static template parts and conditional/logical attr shapes through the fused helpers.