### PR TITLE
docs: record why the mocha patch prints the swallowed require error

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ pnpm run change                                           # add a changeset (req
 
 ## Repo invariants
 
-- **Babel is patched.** `patches/` (applied by pnpm patchedDependencies on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping a `@babel/*` version requires regenerating its patch.
+- **Dependencies are patched.** `patches/` (applied by pnpm patchedDependencies on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`, and makes mocha print the `require()` error it otherwise drops when its `import()` fallback rescues a spec. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping any patched dependency requires regenerating its patch.
 - **Bundle size is a feature.** The pre-commit hook runs lint-staged, a full build, and `build:sizes`, staging `.sizes.json`/`.sizes/` — that diff is the size impact of the change. Commits are slow by design. Lint rules whose fix rewrites runtime code into larger output stay off in `.oxlintrc.json` (`unicorn/prefer-string-starts-ends-with`, `unicorn/no-new-array`); enabling one means checking `build:sizes` first.
 - **Snapshots and sizes are generated.** Never hand-edit _or delete_ `__snapshots__/**`, fixture `sizes.json`, or `.sizes*`; regenerate with `pnpm run test:update` (which also prunes stale snapshots) and the commit hook.
 - **CI** (`.github/workflows/ci.yml`): build + lint on Node 26; tests on Node 22/24/26 (`MARKO_DEBUG=1`, zcov coverage). Releases go out via changesets on push to `main`.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -32,12 +32,6 @@ Three pure deletes with no behavior change. `isScopeIdentifier` has no callers l
 
 `forTypeToHTMLResumeRuntime` and `forTypeToDOMRuntime` are byte-identical `ForType` switches returning `_for_of|_for_in|_for_to|_for_until`, and both `dom` and `html` export those names, so delete one and point both call sites at the survivor; `forTypeToRuntime` stays as the only distinct mapping. Separately, `translator/core/{client,server,static}.ts` are three 31-line files differing only in the stripped keyword, the third `t.markoScriptlet(body, true, …)` argument, and their autocomplete text — a `createScriptletTag(keyword, target?)` factory would cut ~60 lines and leave the `core/index.ts` registrations untouched. Both edits are output-identical, so no snapshot or `sizes.json` churn. Re-verify: normalize the two function names and `diff` their bodies; `diff core/client.ts core/server.ts` shows only keyword/description lines.
 
-## Stray debug `console.error` in the mocha patch
-
-`patches/mocha@11.7.6.patch` › `requireModule` | 2026-07-23 | impact:low | effort:low
-
-The patch's only change adds `console.error(requireErr)` to `lib/nodejs/esm-utils.js`'s `requireModule` catch block, so any spec that fails plain `require()` and then loads fine via mocha's `import()` fallback prints a full stack trace for a passing file. Upstream already rethrows `requireErr` for the cases where it is the informative error, so the line adds nothing but noise, and it arrived with the npm→pnpm conversion (`0187289c71`) rather than as intentional patching. Fix: delete the patch file and its `pnpm-workspace.yaml` `patchedDependencies` entry, then `pnpm install`. Re-verify: `cat patches/mocha@11.7.6.patch` — the one-line hunk is the entire patch.
-
 ## Delete or resurrect the dead `test/markoc` suite
 
 `packages/runtime-class/test/markoc/index.test.js` | 2026-07-24 | impact:low | effort:low

--- a/patches/mocha@11.7.6.patch
+++ b/patches/mocha@11.7.6.patch
@@ -1,11 +1,13 @@
 diff --git a/lib/nodejs/esm-utils.js b/lib/nodejs/esm-utils.js
-index d1bbb95..ec68e36 100644
+index d1bbb95f06689e16a866bdb304cad55b9f3b99a0..c4de4e616a09bcfd128d16f8a3e4676990a38fe4 100644
 --- a/lib/nodejs/esm-utils.js
 +++ b/lib/nodejs/esm-utils.js
-@@ -99,6 +99,7 @@ const requireModule = async (file, esmDecorator) => {
+@@ -99,6 +99,9 @@ const requireModule = async (file, esmDecorator) => {
    } catch (requireErr) {
      debug("requireModule caught err: %O", requireErr.message);
      try {
++      // A require() failure that import() then rescues would otherwise vanish,
++      // hiding module-scope compile and syntax errors. Keep this print.
 +      console.error(requireErr);
        return dealWithExports(await formattedImport(file, esmDecorator));
      } catch (importErr) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,7 +10,7 @@ patchedDependencies:
   '@babel/traverse@7.29.7': 831f9092cade155e5b2c5b6b6109643387b1b7a674245caa9073652b8eac637c
   '@babel/types@7.29.7': 600297d6e82d0bae1c281caf15e85f8012e0c4faf86de92b0e2fe0de8652104e
   mocha-autotest@1.1.3: 8ed132c3bc8563849f2fc1a6d4b83cc2d73b9e5c2b6b59ddb9957fd11e23078f
-  mocha@11.7.6: b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f
+  mocha@11.7.6: f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600
 
 importers:
 
@@ -126,10 +126,10 @@ importers:
         version: 17.0.8
       mocha:
         specifier: ^11.7.6
-        version: 11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f)
+        version: 11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600)
       mocha-autotest:
         specifier: ^1.1.3
-        version: 1.1.3(patch_hash=8ed132c3bc8563849f2fc1a6d4b83cc2d73b9e5c2b6b59ddb9957fd11e23078f)(mocha@11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f))
+        version: 1.1.3(patch_hash=8ed132c3bc8563849f2fc1a6d4b83cc2d73b9e5c2b6b59ddb9957fd11e23078f)(mocha@11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600))
       oxfmt:
         specifier: 0.60.0
         version: 0.60.0
@@ -5130,10 +5130,10 @@ snapshots:
 
   isexe@2.0.0: {}
 
-  it-fails@1.0.9(mocha@11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f)):
+  it-fails@1.0.9(mocha@11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600)):
     dependencies:
       diff: 3.5.1
-      mocha: 11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f)
+      mocha: 11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600)
       ms: 2.1.3
 
   jackspeak@3.4.3:
@@ -5313,15 +5313,15 @@ snapshots:
 
   minipass@7.1.3: {}
 
-  mocha-autotest@1.1.3(patch_hash=8ed132c3bc8563849f2fc1a6d4b83cc2d73b9e5c2b6b59ddb9957fd11e23078f)(mocha@11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f)):
+  mocha-autotest@1.1.3(patch_hash=8ed132c3bc8563849f2fc1a6d4b83cc2d73b9e5c2b6b59ddb9957fd11e23078f)(mocha@11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600)):
     dependencies:
       '@babel/runtime': 7.29.7
       callsites: 3.1.0
-      it-fails: 1.0.9(mocha@11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f))
+      it-fails: 1.0.9(mocha@11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600))
     transitivePeerDependencies:
       - mocha
 
-  mocha@11.7.6(patch_hash=b3e4f15f12d97a08baa2e50a623ac88abeaa4b6b7d24e12a874f43a9d66a7e4f):
+  mocha@11.7.6(patch_hash=f72212bff7d4deb783ff457de9e3f682de7c0a615036d8b77ac3221fa6673600):
     dependencies:
       browser-stdout: 1.3.1
       chokidar: 4.0.3


### PR DESCRIPTION
The mocha patch is a bare `console.error(requireErr)` with no explanation, which reads as debug residue — it was proposed for deletion. It is load-bearing: when `require()` fails and mocha's `import()` fallback then succeeds, the original error is dropped entirely, so a spec with a module-scope compile or syntax error can load and report as passing with no output. Upstream's rethrows only cover the case where the fallback *also* throws.

Adds that reason as a comment in the patched hunk, and widens the `patches/` invariant in AGENTS.md, which read as Babel-only.

Regenerated via `pnpm patch`; the lockfile diff is only the patch hash.