### PR TITLE
refactor(runtime-tags): collapse the duplicated for-type and statement tag definitions

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -20,12 +20,6 @@ The test's only two event-handler assertions are commented out (and call a long-
 
 The rule "a repeated attribute tag folds into `attrTags(prev, next)`, a non-repeated one becomes `attrTag(props)`" is implemented four times. `translateAttrTag` and the `isAttributeTag(tag)` branch of `applyAttrObject` are near-verbatim ~35-line copies, including the `t.parenthesizedExpression` mutation trick, differing only in where `repeated` comes from and whether the result is returned or handed to `addStatement`. `translate-attrs.ts` › `translateAttrs` and `addDynamicAttrTagStatements` encode the same rule over `contentProperties` and over an attr-tag identifier assignment. One helper would collapse the two `known-tag.ts` copies and let the other two share the `repeated ? attrTags : attrTag` decision, so a future change cannot land on three of four sites. Re-verify: `rg -n '"attrTags"' packages/runtime-tags/src/translator` lists exactly those four sites.
 
-## Collapse copy-pasted sibling implementations in the `<for>` and scriptlet core tags
-
-`packages/runtime-tags/src/translator/core/for.ts` › `forTypeToDOMRuntime` | 2026-07-23 | impact:low | effort:low
-
-`forTypeToHTMLResumeRuntime` and `forTypeToDOMRuntime` are byte-identical `ForType` switches returning `_for_of|_for_in|_for_to|_for_until`, and both `dom` and `html` export those names, so delete one and point both call sites at the survivor; `forTypeToRuntime` stays as the only distinct mapping. Separately, `translator/core/{client,server,static}.ts` are three 31-line files differing only in the stripped keyword, the third `t.markoScriptlet(body, true, …)` argument, and their autocomplete text — a `createScriptletTag(keyword, target?)` factory would cut ~60 lines and leave the `core/index.ts` registrations untouched. Both edits are output-identical, so no snapshot or `sizes.json` churn. Re-verify: normalize the two function names and `diff` their bodies; `diff core/client.ts core/server.ts` shows only keyword/description lines.
-
 ## Delete or resurrect the dead `test/markoc` suite
 
 `packages/runtime-class/test/markoc/index.test.js` | 2026-07-24 | impact:low | effort:low

--- a/packages/runtime-tags/src/translator/core/client.ts
+++ b/packages/runtime-tags/src/translator/core/client.ts
@@ -1,31 +1,3 @@
-import { types as t } from "@marko/compiler";
-import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
-export default {
-  parse(tag) {
-    const {
-      node,
-      hub: { file },
-    } = tag;
-    const rawValue = node.rawValue!;
-    const code = rawValue.replace(/^client\s*/, "");
-    const start = node.start! + (rawValue.length - code.length);
-    let body = parseStatements(file, code, start, start + code.length);
-    if (body.length === 1 && t.isBlockStatement(body[0])) {
-      body = body[0].body;
-    }
+import { createStatementTag } from "../util/statement-tag";
 
-    tag.replaceWith(t.markoScriptlet(body, true, "client"));
-  },
-  parseOptions: {
-    statement: true,
-    rawOpenTag: true,
-  },
-  autocomplete: [
-    {
-      displayText: "client <statement>",
-      description:
-        "A JavaScript statement which is only evaluated once your template is loaded on the client.",
-      descriptionMoreURL: "https://markojs.com/docs/syntax/#client-javascript",
-    },
-  ],
-} as Tag;
+export default createStatementTag("client");

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -251,7 +251,7 @@ export default {
           | undefined
         )[];
         const forTagHTMLRuntime = branchSerializeReason
-          ? forTypeToHTMLResumeRuntime(forType)
+          ? forTypeToBranchRuntime(forType)
           : forTypeToRuntime(forType);
         forTagArgs.push(
           t.arrowFunctionExpression(params, t.blockStatement(bodyStatements)),
@@ -352,7 +352,7 @@ export default {
         const signal = getSignal(tagSection, nodeRef, "for");
         signal.build = () => {
           return callRuntime(
-            forTypeToDOMRuntime(forType),
+            forTypeToBranchRuntime(forType),
             getScopeAccessorLiteral(nodeRef, true),
             ...replaceNullishAndEmptyFunctionsWith0(
               getBranchRendererArgs(bodySection),
@@ -556,20 +556,7 @@ function forTypeToRuntime(type: ForType) {
   }
 }
 
-function forTypeToHTMLResumeRuntime(type: ForType) {
-  switch (type) {
-    case "of":
-      return "_for_of";
-    case "in":
-      return "_for_in";
-    case "to":
-      return "_for_to";
-    case "until":
-      return "_for_until";
-  }
-}
-
-function forTypeToDOMRuntime(type: ForType) {
+function forTypeToBranchRuntime(type: ForType) {
   switch (type) {
     case "of":
       return "_for_of";

--- a/packages/runtime-tags/src/translator/core/server.ts
+++ b/packages/runtime-tags/src/translator/core/server.ts
@@ -1,31 +1,3 @@
-import { types as t } from "@marko/compiler";
-import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
-export default {
-  parse(tag) {
-    const {
-      node,
-      hub: { file },
-    } = tag;
-    const rawValue = node.rawValue!;
-    const code = rawValue.replace(/^server\s*/, "");
-    const start = node.start! + (rawValue.length - code.length);
-    let body = parseStatements(file, code, start, start + code.length);
-    if (body.length === 1 && t.isBlockStatement(body[0])) {
-      body = body[0].body;
-    }
+import { createStatementTag } from "../util/statement-tag";
 
-    tag.replaceWith(t.markoScriptlet(body, true, "server"));
-  },
-  parseOptions: {
-    statement: true,
-    rawOpenTag: true,
-  },
-  autocomplete: [
-    {
-      displayText: "server <statement>",
-      description:
-        "A JavaScript statement which is only evaluated once your template is loaded on the server.",
-      descriptionMoreURL: "https://markojs.com/docs/syntax/#server-javascript",
-    },
-  ],
-} as Tag;
+export default createStatementTag("server");

--- a/packages/runtime-tags/src/translator/core/static.ts
+++ b/packages/runtime-tags/src/translator/core/static.ts
@@ -1,31 +1,3 @@
-import { types as t } from "@marko/compiler";
-import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
-export default {
-  parse(tag) {
-    const {
-      node,
-      hub: { file },
-    } = tag;
-    const rawValue = node.rawValue!;
-    const code = rawValue.replace(/^static\s*/, "");
-    const start = node.start! + (rawValue.length - code.length);
-    let body = parseStatements(file, code, start, start + code.length);
-    if (body.length === 1 && t.isBlockStatement(body[0])) {
-      body = body[0].body;
-    }
+import { createStatementTag } from "../util/statement-tag";
 
-    tag.replaceWith(t.markoScriptlet(body, true));
-  },
-  parseOptions: {
-    statement: true,
-    rawOpenTag: true,
-  },
-  autocomplete: [
-    {
-      displayText: "static <statement>",
-      description:
-        "A JavaScript statement which is only evaluated once your template is loaded.",
-      descriptionMoreURL: "https://markojs.com/docs/syntax/#static-javascript",
-    },
-  ],
-} as Tag;
+export default createStatementTag("static");

--- a/packages/runtime-tags/src/translator/util/statement-tag.ts
+++ b/packages/runtime-tags/src/translator/util/statement-tag.ts
@@ -1,0 +1,37 @@
+import { types as t } from "@marko/compiler";
+import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
+
+// `<static>` runs everywhere, so it gets no target and no "on the ..." suffix.
+export function createStatementTag(keyword: "client" | "server" | "static") {
+  const target = keyword === "static" ? undefined : keyword;
+  const keywordReg = new RegExp(`^${keyword}\\s*`);
+
+  return {
+    parse(tag) {
+      const {
+        node,
+        hub: { file },
+      } = tag;
+      const rawValue = node.rawValue!;
+      const code = rawValue.replace(keywordReg, "");
+      const start = node.start! + (rawValue.length - code.length);
+      let body = parseStatements(file, code, start, start + code.length);
+      if (body.length === 1 && t.isBlockStatement(body[0])) {
+        body = body[0].body;
+      }
+
+      tag.replaceWith(t.markoScriptlet(body, true, target));
+    },
+    parseOptions: {
+      statement: true,
+      rawOpenTag: true,
+    },
+    autocomplete: [
+      {
+        displayText: `${keyword} <statement>`,
+        description: `A JavaScript statement which is only evaluated once your template is loaded${target ? ` on the ${target}` : ""}.`,
+        descriptionMoreURL: `https://markojs.com/docs/syntax/#${keyword}-javascript`,
+      },
+    ],
+  } as Tag;
+}


### PR DESCRIPTION
Two sets of copy-pasted siblings, both output-identical:

- `forTypeToHTMLResumeRuntime` and `forTypeToDOMRuntime` were byte-identical; merged into `forTypeToBranchRuntime`, since both call sites want the scope-creating `_for_*` helpers. `forTypeToRuntime` stays as the genuinely different mapping.
- `core/{client,server,static}.ts` differed only in the keyword, the `t.markoScriptlet` target, and autocomplete text — all derivable — so they now come from one `createStatementTag` factory. `core/index.ts` is untouched.

Verified by diffing compiled html/dom, debug and optimize output for a template using all three statement tags, and by asserting each tag's autocomplete strings against the originals.