### PR TITLE
fix(runtime-class): serialize class state when no tags chunk is already rendering

### DIFF
--- a/.changeset/quiet-pugs-hear.md
+++ b/.changeset/quiet-pugs-hear.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Fix a `Cannot read properties of undefined (reading 'serializeState')` crash when a Class-API component rendering Tags-API content is rendered directly — through `renderToString` or `@marko/testing-library` — rather than as a page with `<init-components>`.

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js
@@ -55,18 +55,23 @@ exports.p = function (htmlCompat) {
     }
 
     if (componentDefs?.length) {
-      const initComponents = () =>
-        ___getInitComponentsCodeForDefs($global, componentDefs);
-      // Serializing a bridged handler registers the tags scope it closes over,
-      // so it must run against the chunk carrying this flush's resume scripts.
-      scripts = chunk
-        ? htmlCompat.withChunk(chunk, initComponents)
-        : initComponents();
+      // Serializing a bridged handler registers a tags scope, so it needs a chunk:
+      // this flush's, else the one rendering, else a new one for a direct render.
+      const live = chunk || htmlCompat.getChunk();
+      const target = live || htmlCompat.createChunk($global);
+      scripts = htmlCompat.withChunk(target, () =>
+        ___getInitComponentsCodeForDefs($global, componentDefs),
+      );
       if (scripts) {
         htmlCompat.ensureState($global).walkOnNextFlush = true;
 
         if (!chunk) {
-          scripts = concatScripts(htmlCompat.flushScript($global), scripts);
+          scripts = concatScripts(
+            live
+              ? htmlCompat.flushScript($global)
+              : htmlCompat.flushScript($global, target),
+            scripts,
+          );
         }
       }
     }

--- a/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/class-child.marko
+++ b/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/class-child.marko
@@ -1,0 +1,7 @@
+class {
+  handleClick() {
+    this.emit("change");
+  }
+}
+
+<button on-click("handleClick")>Change</button>

--- a/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/tags-child.marko
+++ b/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/tags-child.marko
@@ -1,0 +1,6 @@
+// use tags
+import ClassChild from "./class-child.marko";
+
+<ClassChild on-change() {
+  input.onChange?.();
+}/>

--- a/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/template.marko
+++ b/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/template.marko
@@ -1,0 +1,9 @@
+import TagsChild from "./tags-child.marko";
+
+class {
+  handleChange() {}
+}
+
+<TagsChild onChange() {
+  component.handleChange();
+}/>

--- a/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/test.js
+++ b/packages/runtime-class/test/components-server/fixtures/classToTagsToClassRender/test.js
@@ -1,0 +1,11 @@
+module.exports = function (helpers, done) {
+  // Rendering a component directly reaches the compat flush with no chunk of its
+  // own; serializing the bridged handler must not depend on one already existing.
+  require("./template.marko").default.renderToString({}, function (err, html) {
+    if (err) return done(err);
+    if (!/<button/.test(html)) {
+      return done(new Error("expected the class child to render"));
+    }
+    done();
+  });
+};

--- a/packages/runtime-tags/src/html/compat.ts
+++ b/packages/runtime-tags/src/html/compat.ts
@@ -41,6 +41,7 @@ export const compat = {
   peekNextScopeId: _peek_scope_id,
   isInResumedBranch,
   withChunk,
+  getChunk,
   ensureState($global: any) {
     let state: State | undefined = ($global[K_TAGS_API_STATE] ||=
       getChunk()?.boundary.state);
@@ -92,11 +93,12 @@ export const compat = {
       return compatRegistered;
     };
   },
+  createChunk($global: any) {
+    const state = this.ensureState($global);
+    return new Chunk(new Boundary(state), null, null, state);
+  },
   flushScript($global: any, chunk?: Chunk) {
-    if (!chunk) {
-      const state = this.ensureState($global);
-      chunk = new Chunk(new Boundary(state), null, null, state);
-    }
+    chunk ||= this.createChunk($global);
 
     const { boundary } = chunk;
     switch (boundary.flush()) {


### PR DESCRIPTION
Rendering a Class component that contains Tags-API content directly — through `renderToString` or `@marko/testing-library`'s `render`, rather than as a page with `<init-components>` — throws `Cannot read properties of undefined (reading 'serializeState')`. #3759 fixed the page shape and left this one broken.

That path reaches `flushScripts` with no pending tags chunk and no chunk already rendering, so the bridged-handler serialization ran outside any chunk. It now opens a chunk for that case, keeping the chunk the flush already owns, or the one already rendering, when either exists.

The regression test is in `runtime-class/test/components-server` because the interop fixtures render through the streaming iterator, which does not reach this branch.