### PR TITLE
Fix getTagDefForTagName seen tag tracking

### DIFF
--- a/.changeset/tagdef-seen.md
+++ b/.changeset/tagdef-seen.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix `getTagDefForTagName` tracking seen tags by name while checking by definition, which re-ran the watch file check on every call and pushed duplicate watch file entries.

--- a/packages/compiler/src/babel-utils/taglib.js
+++ b/packages/compiler/src/babel-utils/taglib.js
@@ -14,7 +14,7 @@ export function getTagDefForTagName(file, tagName) {
     }
 
     if (!seen.has(tagDef)) {
-      seen.add(tagName);
+      seen.add(tagDef);
       const { filePath } = tagDef;
       const len = filePath.length;
 


### PR DESCRIPTION
The seen set in `getTagDefForTagName` was checked by tag definition but populated with tag name, so the guard never hit: the watch file check re-ran on every call and duplicate watch file entries piled up. Fixing the mismatch improves a 400-template `compileSync` benchmark from ~222ms to ~188ms (median).