### PR TITLE
refactor(runtime-tags): track $global reads through the reference graph

### DIFF
--- a/packages/runtime-tags/src/translator/util/constants/binding-type.ts
+++ b/packages/runtime-tags/src/translator/util/constants/binding-type.ts
@@ -8,6 +8,9 @@ export const param = 3;
 export const local = 4;
 export const derived = 5;
 export const constant = 6;
+// `$global` and its property aliases: tracked for provenance, inert in
+// the signal graph (no slot, no subscription, no closure, no ordinal).
+export const global = 7;
 
 type Self = typeof import("./binding-type");
 export type Value = Self[keyof Self];

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -84,7 +84,16 @@ export { BindingType };
 export interface Sources {
   state: Opt<Binding>;
   param: Opt<InputBinding | ParamBinding>;
+  global: true | undefined;
 }
+
+// `$global` is request identity: sources carry one bit (granularity lives
+// in the global bindings' property aliases, not in invalidation).
+export const globalSources: Sources = {
+  state: undefined,
+  param: undefined,
+  global: true,
+};
 
 export interface Binding {
   id: number;
@@ -169,6 +178,9 @@ declare module "@marko/compiler/dist/types" {
     isEffect?: true;
     invokeOnly?: true;
     lazyBindings?: ReferencedBindings;
+    /** `$global` bindings this expression reads: the root means an opaque
+     * (dynamic/aliased) read, a property alias names the key. */
+    globalBindings?: ReferencedBindings;
     spreadFrom?: Binding;
     nativeTagSpread?: true;
     nativeTagSpreadMerged?: true;
@@ -621,6 +633,21 @@ export function setReferencesScope(path: t.NodePath<any>) {
   }
 }
 
+// One signal-inert root binding per template, minted on first access.
+const [getGlobalBinding] = createProgramState(() =>
+  createBinding(
+    "$global",
+    BindingType.global,
+    getOrCreateSection(getProgram()),
+  ),
+);
+
+// `$global` reads route through the reference graph, so property
+// aliases record the keys read.
+export function trackGlobalReference(path: t.NodePath<t.Identifier>) {
+  trackReference(path, getGlobalBinding());
+}
+
 function createBindingsAndTrackReferences(
   lVal: t.LVal,
   type: BindingType,
@@ -928,6 +955,7 @@ export function finalizeReferences() {
       );
       expr.referencedBindings = exprBindings.referencedBindings;
       expr.lazyBindings = exprBindings.lazyBindings;
+      expr.globalBindings = exprBindings.globalBindings;
       if (!exprBindings.referencedBindings) {
         // With no resolved references, any statement this expression keys
         // lands in its section's setup signal.
@@ -1013,6 +1041,13 @@ export function finalizeReferences() {
 
   for (const binding of bindings) {
     const { name, section } = binding;
+    // `$global` bindings resolve sources only: no collision rename (it
+    // would burn a UID and shift later generated names), no section
+    // membership, no closures — reads compile verbatim.
+    if (binding.type === BindingType.global) {
+      resolveBindingSources(binding);
+      continue;
+    }
     if (binding.type !== BindingType.dom) {
       resolveBindingSources(binding);
 
@@ -1516,6 +1551,9 @@ function resolveBindingSources(binding: Binding) {
         getCanonicalBinding(binding) as ParamBinding,
       );
       return;
+    case BindingType.global:
+      binding.sources = globalSources;
+      return;
   }
 
   const aliasRoot = getAliasRoot(binding);
@@ -1567,18 +1605,21 @@ function resolveDerivedSources(binding: Binding) {
 export function createSources(
   state: Sources["state"],
   param: Sources["param"],
+  global?: Sources["global"],
 ): Sources {
-  if (!(state || param)) {
+  if (!(state || param || global)) {
     throw new Error(
-      "Cannot create a serialize reason that does not reference state or a param.",
+      "Cannot create a serialize reason that does not reference state, a param, or $global.",
     );
   }
 
-  return { state, param };
+  return { state, param, global };
 }
 
 export function compareSources(a: Sources, b: Sources) {
   let delta: number;
+
+  if (a.global !== b.global) return a.global ? 1 : -1;
 
   if (a.param) {
     if (!b.param) return 1;
@@ -1600,10 +1641,13 @@ export function compareSources(a: Sources, b: Sources) {
 export function mergeSources(a: undefined | Sources, b: undefined | Sources) {
   if (!a) return b;
   if (!b) return a;
-  if (a.state === b.state && a.param === b.param) return a;
+  if (a.state === b.state && a.param === b.param && a.global === b.global) {
+    return a;
+  }
   return createSources(
     bindingUtil.union(a.state, b.state),
     unionParamSources(a.param, b.param),
+    a.global || b.global,
   );
 }
 
@@ -2233,7 +2277,10 @@ function resolveReferencedBindingsInFunction(
           if (bindingUtil.find(refs, binding)) {
             constantBindings = bindingUtil.add(constantBindings, binding);
           }
-        } else if (binding.type !== BindingType.dom) {
+        } else if (
+          binding.type !== BindingType.dom &&
+          binding.type !== BindingType.global
+        ) {
           referencedBindings = bindingUtil.add(
             referencedBindings,
             findClosestReference(read.binding, refs)!,
@@ -2248,7 +2295,10 @@ function resolveReferencedBindingsInFunction(
         if (bindingUtil.find(refs, binding)) {
           constantBindings = binding;
         }
-      } else if (binding.type !== BindingType.dom) {
+      } else if (
+        binding.type !== BindingType.dom &&
+        binding.type !== BindingType.global
+      ) {
         referencedBindings = findClosestReference(binding, refs);
       }
     }
@@ -2356,6 +2406,7 @@ function resolveReferencedBindings(
   let hoistedBindings: ReferencedBindings;
   let allBindings: ReferencedBindings;
   let lazyBindings: ReferencedBindings;
+  let globalBindings: ReferencedBindings;
 
   if (Array.isArray(reads)) {
     const rootBindings = getRootBindings(reads);
@@ -2380,14 +2431,18 @@ function resolveReferencedBindings(
           if (upstreamRoot) {
             binding = upstreamRoot;
           }
-        } else {
+        } else if (binding.type !== BindingType.global) {
           extra.section = expr.section;
           ({ binding } = extra.read ??= resolveExpressionReference(
             rootBindings,
             binding,
           ));
         }
-        if (isLazyRead(expr, read, binding, isChangeHandlerRead)) {
+        if (binding.type === BindingType.global) {
+          // `$global` reads stay verbatim member chains: no read slot,
+          // no signal, no register-id participation.
+          globalBindings = bindingUtil.add(globalBindings, binding);
+        } else if (isLazyRead(expr, read, binding, isChangeHandlerRead)) {
           lazyBindings = bindingUtil.add(lazyBindings, binding);
         } else if (binding.type === BindingType.constant) {
           constantBindings = bindingUtil.add(constantBindings, binding);
@@ -2407,6 +2462,10 @@ function resolveReferencedBindings(
         binding.hoists = sectionUtil.add(binding.hoists, getter.hoisted);
         hoistedBindings = bindingUtil.add(hoistedBindings, binding);
       }
+    } else if (binding.type === BindingType.global) {
+      // `$global` reads stay verbatim member chains: no read slot,
+      // no signal, no register-id participation.
+      globalBindings = binding;
     } else {
       extra.read = createRead(binding, undefined, ownVar);
       if (isLazyRead(expr, reads, binding, extra.assignmentTo === binding)) {
@@ -2479,6 +2538,7 @@ function resolveReferencedBindings(
     hoistedBindings,
     allBindings,
     lazyBindings,
+    globalBindings,
   };
 }
 

--- a/packages/runtime-tags/src/translator/util/serialize-guard.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-guard.ts
@@ -1,13 +1,11 @@
 import { types as t } from "@marko/compiler";
 
 import { generateUid, getSharedUid } from "./generate-uid";
-import { type OneMany, type Opt, some, Sorted } from "./optional";
+import { type Opt, some, Sorted } from "./optional";
 import {
   compareSources,
   getDebugNames,
   getDebugNamesAsIdentifier,
-  type InputBinding,
-  type ParamBinding,
   type Sources,
 } from "./references";
 import { callRuntime, type HTMLRuntimeHelpers } from "./runtime";
@@ -27,10 +25,7 @@ import { withLeadingComment } from "./with-comment";
 
 const sourcesUtil = new Sorted(compareSources);
 
-type DynamicSerializeReason = {
-  state: undefined;
-  param: OneMany<InputBinding | ParamBinding>;
-};
+type DynamicSerializeReason = Sources & { state: undefined };
 
 interface SectionReasonState {
   if: TypeState;
@@ -142,7 +137,7 @@ function getOrHoist(
       return t.identifier(tracking.names.get(existingFound)!);
     }
 
-    const guard = buildGuardExpr(onlySection, reason.param, isGuard);
+    const guard = buildGuardExpr(onlySection, reason.param!, isGuard);
     const seenFound = sourcesUtil.find(tracking.seenReasons, reason);
     if (!seenFound) {
       const expr = t.parenthesizedExpression(guard);
@@ -178,7 +173,7 @@ function getOrHoist(
 
 function buildGuardExpr(
   paramsSection: Section,
-  params: DynamicSerializeReason["param"],
+  params: NonNullable<Sources["param"]>,
   isGuard: boolean,
 ) {
   const serializeIdentifier = t.identifier(

--- a/packages/runtime-tags/src/translator/util/serialize-reasons.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-reasons.ts
@@ -11,10 +11,8 @@ import {
   type Binding,
   compareSources,
   getCanonicalBinding,
-  type InputBinding,
   isReferencedExtra,
   mergeSources,
-  type ParamBinding,
   type ReferencedBindings,
   type Sources,
 } from "./references";
@@ -160,7 +158,7 @@ export function addOwnerSerializeReason(
 
 export function isReasonDynamic(
   reason: undefined | SerializeReason,
-): reason is { state: undefined; param: OneMany<InputBinding | ParamBinding> } {
+): reason is Sources & { state: undefined } {
   return !!reason && reason !== true && !reason.state;
 }
 

--- a/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
+++ b/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
@@ -3,7 +3,7 @@ import { types as t } from "@marko/compiler";
 import { getAccessorProp } from "../util/get-accessor-enums";
 import { getExprRoot } from "../util/get-root";
 import { isOutputHTML } from "../util/marko-config";
-import { setReferencesScope } from "../util/references";
+import { setReferencesScope, trackGlobalReference } from "../util/references";
 import { importRuntime } from "../util/runtime";
 import { getOrCreateSection, getSection } from "../util/sections";
 import { addStatement } from "../util/signals";
@@ -57,6 +57,7 @@ export default {
     if (identifier.scope.hasBinding(name)) return;
     if (name === "$global") {
       setReferencesScope(identifier);
+      trackGlobalReference(identifier);
     } else if (name === "$signal") {
       const section = getOrCreateSection(identifier);
       section.hasAbortSignal = true;


### PR DESCRIPTION
`$global` reads now route through the reference graph as a signal-inert root binding per template: member chains mint property aliases recording the static keys read, expression extras carry the global bindings they read, and `Sources` gains a request-identity `global` dimension.

Compiled output is unchanged — the binding joins no signal graph, closure, accessor ordinal, serialization, or name-collision rename, and reads still compile verbatim through the existing identifier substitution. This replaces bespoke global-read flags downstream and gives serialization provenance a uniform view of global reads, with multi-level member tracking for free.