### PR TITLE
refactor(runtime-tags): derive persisted global guards from the reference graph

### DIFF
--- a/packages/runtime-tags/src/translator/core/script.ts
+++ b/packages/runtime-tags/src/translator/core/script.ts
@@ -13,6 +13,7 @@ import { isOutputDOM, isPersisted } from "../util/marko-config";
 import {
   dropNodes,
   getAllTagReferenceNodes,
+  getGlobalReadKeys,
   mergeGlobalReads,
 } from "../util/references";
 import runtimeInfo from "../util/runtime-info";
@@ -112,7 +113,9 @@ export default {
       const referencedBindings = value.extra?.referencedBindings;
       // A persisted script's DIRECT `$global` reads re-queue when a frame's
       // globals change; global-derived binding reads reject instead.
-      const globalReads = isPersisted() ? value.extra?.readsGlobal : undefined;
+      const globalReads = isPersisted()
+        ? getGlobalReadKeys(value.extra?.globalBindings)
+        : undefined;
       if (isOutputDOM()) {
         const isFunction =
           t.isFunctionExpression(value) || t.isArrowFunctionExpression(value);

--- a/packages/runtime-tags/src/translator/util/persisted.ts
+++ b/packages/runtime-tags/src/translator/util/persisted.ts
@@ -25,10 +25,11 @@ declare module "@marko/compiler/dist/types" {
     [kPatchClientOwned]?: true;
   }
 }
-declare module "@marko/compiler" {
-  export interface MarkoMeta {
+declare module "@marko/compiler/dist/types" {
+  export interface ProgramExtra {
     /** This template (or one it renders) reads `$global`: skipping its
-     * render in a patch could hide a global change. */
+     * render in a patch could hide a global change. Analyze-internal,
+     * read cross-file off the cached child program. */
     persistedGlobals?: true;
   }
 }

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { getFile, getProgram } from "@marko/compiler/babel-utils";
+import { getProgram } from "@marko/compiler/babel-utils";
 
 import type { AccessorPrefix } from "../../common/accessor.debug";
 import { decodeAccessor } from "../../common/helpers";
@@ -649,36 +649,25 @@ const [getGlobalBinding] = createProgramState(() =>
 );
 
 // `$global` reads route through the reference graph, so property
-// aliases record the keys read. Persisted compiles additionally stamp
-// the expression so serialize sources see the request-derived dimension.
+// aliases record the keys read.
 export function trackGlobalReference(path: t.NodePath<t.Identifier>) {
   trackReference(path, getGlobalBinding());
-  if (isPersisted()) {
-    const exprRoot = getExprRoot(getFnRoot(path) || path);
-    const section = getOrCreateSection(exprRoot);
-    const extra = (exprRoot.node.extra ??= { section });
-    // A direct static member read records its key; anything else (aliased,
-    // dynamic, escaping) is opaque and guards on the whole bag.
-    const { parent } = path;
-    const key =
-      (t.isMemberExpression(parent) || t.isOptionalMemberExpression(parent)) &&
-      parent.object === path.node
-        ? parent.computed
-          ? t.isStringLiteral(parent.property)
-            ? parent.property.value
-            : undefined
-          : t.isIdentifier(parent.property)
-            ? parent.property.name
-            : undefined
-        : undefined;
-    extra.readsGlobal =
-      key === undefined || extra.readsGlobal === true
-        ? true
-        : (extra.readsGlobal ?? new Set()).add(key);
-    // Rolls up through custom-tag analyze so a call site can classify
-    // whether skipping this template's render could hide a global change.
-    getFile().metadata.marko.persistedGlobals = true;
-  }
+}
+
+// The persisted guard grain for an expression's global reads: first-hop
+// property keys, or `true` when the bag itself was read (opaque).
+export function getGlobalReadKeys(globalBindings: ReferencedBindings) {
+  let keys: true | Set<string> | undefined;
+  forEach(globalBindings, (binding) => {
+    if (keys === true) return;
+    let hop: Binding | undefined;
+    for (let cur: Binding | undefined = binding; cur; cur = cur.upstreamAlias) {
+      if (cur.upstreamAlias) hop = cur;
+    }
+    const key = hop?.property;
+    keys = key === undefined ? true : (keys ?? new Set()).add(key);
+  });
+  return keys;
 }
 
 function createBindingsAndTrackReferences(
@@ -904,12 +893,6 @@ export function mergeReferences<T extends t.Node>(
     // create a `merged` cycle and double its reads.
     if (extra === targetExtra) continue;
     extra.merged = targetExtra;
-    if (extra.readsGlobal) {
-      targetExtra.readsGlobal = mergeGlobalReads(
-        targetExtra.readsGlobal,
-        extra.readsGlobal,
-      );
-    }
     if (isReferencedExtra(extra)) {
       const additionalReads = readsByExpression.get(extra);
       const additionalExprFnReads = fnReadsByExpression.get(extra);
@@ -1096,6 +1079,10 @@ export function finalizeReferences() {
     // membership, no closures — reads compile verbatim.
     if (binding.type === BindingType.global) {
       resolveBindingSources(binding);
+      // Derived cross-file bit: custom-tag analyze rolls it up so a call
+      // site can classify whether skipping this render could hide a
+      // global change.
+      if (isPersisted()) getProgram().node.extra!.persistedGlobals = true;
       continue;
     }
     if (binding.type !== BindingType.dom) {
@@ -1654,7 +1641,7 @@ function resolveDerivedSources(binding: Binding) {
   } else if (exprs) {
     const seen = new Set<Binding>();
     forEach(exprs, (expr) => {
-      if (expr.readsGlobal) {
+      if (isPersisted() && expr.globalBindings) {
         binding.sources = mergeSources(binding.sources, globalSources);
       }
       if (isReferencedExtra(expr)) {

--- a/packages/runtime-tags/src/translator/util/serialize-reasons.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-reasons.ts
@@ -6,6 +6,7 @@ import {
   AccessorProp,
 } from "../../common/types";
 import { getAccessorProp } from "./get-accessor-enums";
+import { isPersisted } from "./marko-config";
 import { concat, forEach, type OneMany, type Opt } from "./optional";
 import {
   type Binding,
@@ -195,7 +196,10 @@ export function getSerializeSourcesForExpr(expr: t.NodeExtra) {
   const sources = isReferencedExtra(expr)
     ? getSerializeSourcesForRef(expr.referencedBindings)
     : undefined;
-  return expr.readsGlobal ? mergeSources(sources, globalSources) : sources;
+  // Gated: the global dimension only exists for persisted classification.
+  return isPersisted() && expr.globalBindings
+    ? mergeSources(sources, globalSources)
+    : sources;
 }
 
 export function getSerializeSourcesForExprs(exprs: Opt<t.NodeExtra> | boolean) {

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -505,7 +505,7 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
             if (
               skips &&
               childFile &&
-              !childFile.metadata.marko.persistedGlobals
+              !childFile.path.node.extra?.persistedGlobals
             ) {
               (node.extra ??= {})[kPatchClientOwned] = true;
             }

--- a/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
+++ b/packages/runtime-tags/src/translator/visitors/referenced-identifier.ts
@@ -16,10 +16,6 @@ declare module "@marko/compiler/dist/types" {
     /** `$signal` abort id for this expression root, allocated in analyze
      * (see below) so every translate reads the same id. */
     abortId?: number;
-    /** A persisted `$global` read: the expression's serialize sources gain
-     * the request-derived global dimension. A set holds the static member
-     * keys read; `true` means an opaque (dynamic/aliased/escaping) read. */
-    readsGlobal?: true | Set<string>;
   }
 }
 

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -85,8 +85,8 @@ export default {
 
       // Global reads roll up the load chain so any ancestor call site can
       // classify whether skipping this subtree could hide a global change.
-      if (isPersisted() && childFile.metadata.marko.persistedGlobals) {
-        tag.hub.file.metadata.marko.persistedGlobals = true;
+      if (isPersisted() && childFile.path.node.extra?.persistedGlobals) {
+        getProgram().node.extra!.persistedGlobals = true;
       }
 
       const tagExtra = (tag.node.extra ??= {});


### PR DESCRIPTION
The persisted machinery now consumes the `$global` binding graph that landed on main: script guard keys derive from the global bindings' first-hop property aliases, derived sources and expression serialize sources merge off `globalBindings` (persisted-gated, since the graph tracks unconditionally), and the `persistedGlobals` cross-file bit is derived at reference finalize from the binding's existence and carried on the program AST extra rather than the public compile metadata.

Deleted: the bespoke parent-node key capture, the `readsGlobal` extra and its type declaration, its `mergeReferences` plumbing, and the `MarkoMeta.persistedGlobals` augmentation. Wire output is unchanged.