### PR TITLE
refactor(runtime-tags): persisted skip decisions read exported render intrinsics

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -550,3 +550,18 @@ and after resume.
 `packages/runtime-class/src/runtime/helpers/dynamic-tag.js` › `addTagsEvents` | 2026-08-05 | impact:med | effort:high
 
 A _split_ Class component (one with a `component-browser.js`, so `FLAG_WILL_RERENDER_IN_BROWSER` is unset) that passes an inline function to a Tags child — `<tags-pinger onPing(count) { component.handlePing(count) }/>` — resumes with a permanently dead handler: `registerClassFunctions` serializes it as the compat noop, and unlike a rerendering parent the split parent never re-feeds a live one. The string form `onPing("handlePing")` works, because `addTagsEvents` serializes `[CLASS_EVENT_MARKER, componentId, method]` and `runtime-dom.js`'s `setClassEventResolver` revives it by name; an inline closure has no name to bridge, so nothing can revive it. A real fix needs the Marko 5 translator to give each inline handler an id reachable from the browser bundle so it can serialize a marker like the named form; failing that, a compile-time or `MARKO_DEBUG` error on this exact shape beats silently dropping events. Re-verify: copy `interop-event-split-class-to-tags` and replace `onPing("handlePing")` in `components/class-host/index.marko` with an inline body calling `component.handlePing(count)` — the fixture harness reports `Snapshot conflict: "render.debug.md" was written with different content by two tests`, because CSR updates `#class` and resumed SSR does not.
+
+## Circular custom tags TDZ at module evaluation in DOM output
+
+Mutually recursive custom tags (`tags/a-tag` renders `b-tag`, which
+renders `a-tag`) compile per-template but the DOM output's static
+template-string composition (`const $template$1 = ((_w0) =>
+`...${_w0}...`)($template$2)`) references the sibling's module-level
+const across the import cycle; the bundler's concatenation order then
+hits `Cannot access '$template$1' before initialization`at module
+evaluation, before any render. The composition would need to be lazy (or
+bail to a runtime reference) when the child resolves through a cycle.
+Found while building a persisted fixture; reproduces with`persisted:
+false` (the inlining is mode-agnostic). Re-verify: two tags rendering
+each other behind a depth guard, bundle the page, import the dom bundle
+— eval throws.

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
@@ -33,4 +33,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
@@ -30,4 +30,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
@@ -24,4 +24,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		double: "2:8"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
@@ -21,4 +21,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: double
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_outer, $sg__input_outer, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { input_inner: input.inner }, "__tests__/template.marko", 0, { input_inner: ["input.inner"] });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_outer, $sg__input_outer, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { g: input.inner });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, { h: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/__snapshots__/html.bundle.debug.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/__snapshots__/html.bundle.js
@@ -19,4 +19,4 @@ var template_default = _template_persisted("a", (input) => {
 		g: count
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.debug.js
@@ -25,4 +25,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.js
@@ -22,4 +22,4 @@ var template_default = _template_persisted("a", (input) => {
 		g: count
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { input_tag: input.tag }, "__tests__/template.marko", 0, { input_tag: ["input.tag"] }) : _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "input_tag", input.tag);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { g: input.tag }) : _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "g", input.tag);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.debug.js
@@ -41,4 +41,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.js
@@ -38,4 +38,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: count
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.debug.js
@@ -36,4 +36,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.js
@@ -32,4 +32,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.debug.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.js
@@ -20,4 +20,4 @@ var template_default = _template_persisted("a", (input) => {
 		g: count
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
@@ -28,4 +28,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
@@ -28,4 +28,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
@@ -26,4 +26,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { handler }, "__tests__/template.marko", 0, { handler: "2:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
@@ -26,4 +26,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { i: handler });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
@@ -27,4 +27,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
@@ -27,4 +27,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
@@ -25,4 +25,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
@@ -25,4 +25,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a1"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.debug.js
@@ -26,4 +26,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: count
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/2", 1, _source_guard($scope0_reason, 3), $sg__input_a__OR__input_b, void 0, void 0, ["__tests__/template.marko_2_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "c", 1, _source_guard($scope0_reason, 3), $sg__input_a__OR__input_b, void 0, void 0, ["a1"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { input_label: input.label }, "__tests__/template.marko", 0, { input_label: ["input.label"] });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { g: input.label });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.debug.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { input_value: input.value }, "__tests__/template.marko", 0, { input_value: ["input.value"] }) : _owned_guard($scope0_owned, 3) && _patch_write($scope0_id, "input_value", input.value);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { g: input.value }) : _owned_guard($scope0_owned, 3) && _patch_write($scope0_id, "g", input.value);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.debug.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { input_value: input.value }, "__tests__/template.marko", 0, { input_value: ["input.value"] }) : _owned_guard($scope0_owned, 3) && _patch_write($scope0_id, "input_value", input.value);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason ? writeScope($scope0_id, { g: input.value }) : _owned_guard($scope0_owned, 3) && _patch_write($scope0_id, "g", input.value);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
@@ -18,4 +18,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
@@ -18,4 +18,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a2");
 	$scope0_reason && writeScope($scope0_id, { h: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
@@ -15,4 +15,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
@@ -17,4 +17,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, { i: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
@@ -20,4 +20,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: count
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.debug.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", `a&b${input.name}<c`, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1><a${_patch_attr($scope0_id, "#a/1", "title", input.on ? "a\"b" : "c'd", $scope0_owned, 1)}${_patch_attr($scope0_id, "#a/1", "data-x", input.flag && "on", $scope0_owned, 2)}>${_patch_text($scope0_id, "#text/2", input.name, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/2")}</a>${_el_resume($scope0_id, "#a/1")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-capture-escapes/__snapshots__/html.bundle.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<main><h1>${_patch_text($scope0_id, "a", `a&b${input.name}<c`, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1><a${_patch_attr($scope0_id, "b", "title", input.on ? "a\"b" : "c'd", $scope0_owned, 1)}${_patch_attr($scope0_id, "b", "data-x", input.flag && "on", $scope0_owned, 2)}>${_patch_text($scope0_id, "c", input.name, $scope0_owned, 0)}${_el_resume($scope0_id, "c")}</a>${_el_resume($scope0_id, "b")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed-mixed/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var leaf_default = _template_persisted("__tests__/tags/relay/tags/leaf/index.mar
 	const $scope0_id = _scope_id();
 	_html(`<b>${_patch_text($scope0_id, "#text/0", input.text, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</b>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/relay/tags/leaf/index.marko", 0);
-});
+}, 0, 0);
 
 // tags/relay/index.marko
 var relay_default = _template_persisted("__tests__/tags/relay/index.marko", (input) => {
@@ -17,7 +17,7 @@ var relay_default = _template_persisted("__tests__/tags/relay/index.marko", (inp
 	leaf_default({ text: input.val });
 	_html("</section>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/relay/index.marko", 0);
-});
+}, 0, () => [leaf_default]);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -40,4 +40,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.base);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [relay_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed-mixed/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var leaf_default = _template_persisted("c", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<b>${_patch_text($scope0_id, "a", input.text, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</b>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // tags/relay/index.marko
 var relay_default = _template_persisted("b", (input) => {
@@ -17,7 +17,7 @@ var relay_default = _template_persisted("b", (input) => {
 	leaf_default({ text: input.val });
 	_html("</section>");
 	$scope0_reason && writeScope($scope0_id, { a: _existing_scope($childScope) });
-});
+}, 0, () => [leaf_default]);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -37,4 +37,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.base);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [relay_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var leaf_default = _template_persisted("__tests__/tags/relay/tags/leaf/index.mar
 	const $scope0_id = _scope_id();
 	_html(`<b>${_patch_text($scope0_id, "#text/0", input.text, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</b><i>${_patch_text($scope0_id, "#text/1", input.note, $scope0_owned, 1)}${_el_resume($scope0_id, "#text/1")}</i>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/relay/tags/leaf/index.marko", 0);
-});
+}, 0, 0);
 
 // tags/relay/index.marko
 var relay_default = _template_persisted("__tests__/tags/relay/index.marko", (input) => {
@@ -23,7 +23,7 @@ var relay_default = _template_persisted("__tests__/tags/relay/index.marko", (inp
 	});
 	_html("</section>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/relay/index.marko", 0);
-});
+}, 0, () => [leaf_default]);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -48,4 +48,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [relay_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-composed/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var leaf_default = _template_persisted("c", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<b>${_patch_text($scope0_id, "a", input.text, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</b><i>${_patch_text($scope0_id, "b", input.note, $scope0_owned, 1)}${_el_resume($scope0_id, "b")}</i>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // tags/relay/index.marko
 var relay_default = _template_persisted("b", (input) => {
@@ -23,7 +23,7 @@ var relay_default = _template_persisted("b", (input) => {
 	});
 	_html("</section>");
 	$scope0_reason && writeScope($scope0_id, { a: _existing_scope($childScope) });
-});
+}, 0, () => [leaf_default]);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -48,4 +48,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [relay_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (inp
 	}, $scope0_id, "#text/0", 1, $sg__input_label, $sg__input_label, void 0, void 0, ["__tests__/tags/badge/index.marko_1_shell"]);
 	_html(`<i>${_patch_text($scope0_id, "#text/1", input.note, $scope0_owned, 1)}${_el_resume($scope0_id, "#text/1")}</i></div>`);
 	$scope0_reason && writeScope($scope0_id, { input_label: input.label }, "__tests__/tags/badge/index.marko", 0, { input_label: ["input.label"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -36,4 +36,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var badge_default = _template_persisted("b", (input) => {
 	}, $scope0_id, "a", 1, $sg__input_label, $sg__input_label, void 0, void 0, ["b0"]);
 	_html(`<i>${_patch_text($scope0_id, "b", input.note, $scope0_owned, 1)}${_el_resume($scope0_id, "b")}</i></div>`);
 	$scope0_reason && writeScope($scope0_id, { e: input.label });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -36,4 +36,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (inp
 	}, $scope0_id, "#div/0", 1, $sg__input_label, $sg__input_label, void 0, void 0, ["__tests__/tags/badge/index.marko_1_shell"]);
 	_html(`</div>${_el_resume($scope0_id, "#div/0", $sg__input_label)}`);
 	$scope0_reason && writeScope($scope0_id, { input_note: input.note }, "__tests__/tags/badge/index.marko", 0, { input_note: ["input.note"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -39,4 +39,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var badge_default = _template_persisted("b", (input) => {
 	}, $scope0_id, "a", 1, $sg__input_label, $sg__input_label, void 0, void 0, ["b0"]);
 	_html(`</div>${_el_resume($scope0_id, "a", $sg__input_label)}`);
 	$scope0_reason && writeScope($scope0_id, { e: input.note });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -39,4 +39,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/tags/counter/index.marko_1_shell"]);
 	$scope0_reason && writeScope($scope0_id, { input_onCount: input.onCount }, "__tests__/tags/counter/index.marko", 0, { input_onCount: ["input.onCount"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -51,4 +51,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, 0, $scope0_id, "#text/1", 1, _source_guard($scope0_reason, 1), 0, void 0, void 0, 0);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("b", (input) => {
 		}
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["b0"]);
 	$scope0_reason && writeScope($scope0_id, { e: input.onCount });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -51,4 +51,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, 0, $scope0_id, "b", 1, _source_guard($scope0_reason, 1), 0, void 0, void 0, 0);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/tags/counter/index.marko_1_shell"]);
 	$scope0_reason && writeScope($scope0_id, { input_onCount: input.onCount }, "__tests__/tags/counter/index.marko", 0, { input_onCount: ["input.onCount"] });
-});
+}, 0, 0);
 
 // tags/middle/index.marko
 var middle_default = _template_persisted("__tests__/tags/middle/index.marko", (input) => {
@@ -38,7 +38,7 @@ var middle_default = _template_persisted("__tests__/tags/middle/index.marko", (i
 		onCount: input.onCount
 	});
 	$scope0_reason && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/middle/index.marko", 0);
-});
+}, 0, () => [counter_default]);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -61,4 +61,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/2": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [middle_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("b", (input) => {
 		}
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["b0"]);
 	$scope0_reason && writeScope($scope0_id, { e: input.onCount });
-});
+}, 0, 0);
 
 // tags/middle/index.marko
 var middle_default = _template_persisted("c", (input) => {
@@ -38,7 +38,7 @@ var middle_default = _template_persisted("c", (input) => {
 		onCount: input.onCount
 	});
 	$scope0_reason && writeScope($scope0_id, { a: _existing_scope($childScope) });
-});
+}, 0, () => [counter_default]);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -61,4 +61,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { c: _existing_scope($childScope) });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [middle_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
@@ -26,7 +26,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		input_onCount: ["input.onCount"],
 		input_step: ["input.step"]
 	}) : _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "input_step", input.step);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -58,4 +58,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var counter_default = _template_persisted("b", (input) => {
 		e: input.onCount,
 		f: input.step
 	}) : _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "f", input.step);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -55,4 +55,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/tags/counter/index.marko_1_shell"]);
 	$scope0_reason && writeScope($scope0_id, { input_onCount: input.onCount }, "__tests__/tags/counter/index.marko", 0, { input_onCount: ["input.onCount"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -59,4 +59,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/4": _existing_scope($childScope2)
 	}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("b", (input) => {
 		}
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["b0"]);
 	$scope0_reason && writeScope($scope0_id, { e: input.onCount });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -59,4 +59,4 @@ var template_default = _template_persisted("a", (input) => {
 		e: _existing_scope($childScope2)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/tags/counter/index.marko_1_shell"]);
 	$scope0_reason && writeScope($scope0_id, { input_onCount: input.onCount }, "__tests__/tags/counter/index.marko", 0, { input_onCount: ["input.onCount"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -55,4 +55,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		tenfold: "3:8"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("b", (input) => {
 		}
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["b0"]);
 	$scope0_reason && writeScope($scope0_id, { e: input.onCount });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -52,4 +52,4 @@ var template_default = _template_persisted("a", (input) => {
 		c: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/tags/counter/index.marko_1_shell"]);
 	$scope0_reason && writeScope($scope0_id, { input_onCount: input.onCount }, "__tests__/tags/counter/index.marko", 0, { input_onCount: ["input.onCount"] });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -43,4 +43,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/2": _existing_scope($childScope) }, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var counter_default = _template_persisted("b", (input) => {
 		}
 	}, $scope0_id, "a", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["b0"]);
 	$scope0_reason && writeScope($scope0_id, { e: input.onCount });
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -43,4 +43,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { c: _existing_scope($childScope) });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("__tests__/tags/dump/index.marko", (input
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "#text/0", input.format(input.value), $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/dump/index.marko", 0);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -30,4 +30,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-fn-server/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "a", input.format(input.value), $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -27,4 +27,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var g_badge_default = _template_persisted("__tests__/tags/g-badge/index.marko", 
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "#text/0", input.value, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")} <!>${_patch_text($scope0_id, "#text/1", $global().flag)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/g-badge/index.marko", 0);
-});
+}, 0, 1);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -12,10 +12,12 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html("<main>");
-	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
-	_patch_child($scope0_id, "#childScope/0", $childScope);
-	g_badge_default({ value: count });
+	if ($scope0_reason || _must_render(g_badge_default)) {
+		_set_serialize_reason(2);
+		_patch_child($scope0_id, "#childScope/0", $childScope);
+		g_badge_default({ value: count });
+	}
 	_html(`<button>+</button>${_el_resume($scope0_id, "#button/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {
@@ -23,4 +25,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [g_badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-owned/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var g_badge_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "a", input.value, $scope0_owned, 0)}${_el_resume($scope0_id, "a")} <!>${_patch_text($scope0_id, "b", $global().flag)}${_el_resume($scope0_id, "b")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 1);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -12,10 +12,12 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html("<main>");
-	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
-	_patch_child($scope0_id, "a", $childScope);
-	g_badge_default({ value: count });
+	if ($scope0_reason || _must_render(g_badge_default)) {
+		_set_serialize_reason(2);
+		_patch_child($scope0_id, "a", $childScope);
+		g_badge_default({ value: count });
+	}
 	_html(`<button>+</button>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, {
@@ -23,4 +25,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [g_badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var price_card_default = _template_persisted("__tests__/tags/price-card.marko", 
 		qty: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/tags/price-card.marko0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -26,4 +26,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	price_card_default({ label: input.label });
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-intersection/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var price_card_default = _template_persisted("b", (input) => {
 		f: qty
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "b0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -23,4 +23,4 @@ var template_default = _template_persisted("a", (input) => {
 	price_card_default({ label: input.label });
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { b: _existing_scope($childScope) });
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var price_card_default = _template_persisted("__tests__/tags/price-card/index.ma
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "#text/0", input.label, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")} x<!>${_patch_text($scope0_id, "#text/1", input.qty, $scope0_owned, 1)}${_el_resume($scope0_id, "#text/1")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/price-card/index.marko", 0);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -29,4 +29,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-mixed-attr/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var price_card_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "a", input.label, $scope0_owned, 0)}${_el_resume($scope0_id, "a")} x<!>${_patch_text($scope0_id, "b", input.qty, $scope0_owned, 1)}${_el_resume($scope0_id, "b")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -29,4 +29,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("__tests__/tags/dump/index.marko", (input
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "#text/0", JSON.stringify(input), $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/dump/index.marko", 0);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -13,7 +13,8 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(dump_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "#childScope/1", $childScope);
 		dump_default({ value: count });
 	}
@@ -24,4 +25,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/1": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-attr/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "a", JSON.stringify(input), $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -13,7 +13,8 @@ var template_default = _template_persisted("a", (input) => {
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(dump_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "b", $childScope);
 		dump_default({ value: count });
 	}
@@ -24,4 +25,4 @@ var template_default = _template_persisted("a", (input) => {
 		b: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("__tests__/tags/dump/index.marko", (input
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "#text/0", JSON.stringify(input), $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/dump/index.marko", 0);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -30,4 +30,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-rest-mixed/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var dump_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>${_patch_text($scope0_id, "a", JSON.stringify(input), $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -27,4 +27,4 @@ var template_default = _template_persisted("a", (input) => {
 		a: _existing_scope($childScope)
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [dump_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (inp
 	_script($scope0_id, "__tests__/tags/badge/index.marko_0");
 	_patch_effect($scope0_id, "__tests__/tags/badge/index.marko_0", "! brand", 1);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/badge/index.marko", 0);
-});
+}, 0, 1);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -18,4 +18,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	badge_default({});
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", 0);
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var badge_default = _template_persisted("b", (input) => {
 	_script($scope0_id, "b0");
 	_patch_effect($scope0_id, "b0", "! brand", 1);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 1);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -18,4 +18,4 @@ var template_default = _template_persisted("a", (input) => {
 	badge_default({});
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { a: _existing_scope($childScope) });
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var arg_badge_default = _template_persisted("__tests__/tags/arg-badge/index.mark
 	const $scope0_id = _scope_id();
 	_html(`<p>Value <!>${_patch_text($scope0_id, "#text/0", input.value, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/tags/arg-badge/index.marko", 0);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -13,7 +13,8 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(arg_badge_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "#childScope/1", $childScope);
 		arg_badge_default({ value: count });
 	}
@@ -24,4 +25,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/1": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [arg_badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-arg/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var arg_badge_default = _template_persisted("b", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<p>Value <!>${_patch_text($scope0_id, "a", input.value, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</p>`);
 	$scope0_reason && writeScope($scope0_id, {});
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -13,7 +13,8 @@ var template_default = _template_persisted("a", (input) => {
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(arg_badge_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "b", $childScope);
 		arg_badge_default({ value: count });
 	}
@@ -24,4 +25,4 @@ var template_default = _template_persisted("a", (input) => {
 		b: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [arg_badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var counter_default = _template_persisted("__tests__/tags/counter/index.marko", 
 	_script($scope0_id, "__tests__/tags/counter/index.marko_0");
 	$scope0_reason && writeScope($scope0_id, { spins }, "__tests__/tags/counter/index.marko", 0, { spins: "1:6" });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -16,7 +16,8 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(counter_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "#childScope/1", $childScope);
 		counter_default({ value: count });
 	}
@@ -27,4 +28,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/1": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-attr/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var counter_default = _template_persisted("b", (input) => {
 	_script($scope0_id, "b0");
 	$scope0_reason && writeScope($scope0_id, { g: spins });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -16,7 +16,8 @@ var template_default = _template_persisted("a", (input) => {
 	let count = 0;
 	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1>`);
 	const $childScope = _peek_scope_id();
-	if ($scope0_reason) {
+	if ($scope0_reason || _must_render(counter_default)) {
+		_set_serialize_reason(2);
 		_patch_child($scope0_id, "b", $childScope);
 		counter_default({ value: count });
 	}
@@ -27,4 +28,4 @@ var template_default = _template_persisted("a", (input) => {
 		b: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, () => [counter_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var price_card_default = _template_persisted("__tests__/tags/price-card.marko", 
 		qty: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/tags/price-card.marko0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -30,4 +30,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		card,
 		"#childScope/0": _existing_scope($childScope)
 	}, "__tests__/template.marko", 0, { card: "1:13" });
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-var/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var price_card_default = _template_persisted("b", (input) => {
 		f: qty
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "b0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -27,4 +27,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: card,
 		a: _existing_scope($childScope)
 	});
-}, 1);
+}, 1, () => [price_card_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.debug.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		compact: input.on
 	}, $scope0_owned, 2)}${_patch_attr_style($scope0_id, "#span/2", [input.accent, { margin: 0 }], $scope0_owned, 1)}>badge</span>${_el_resume($scope0_id, "#span/2")}</div>${_el_resume($scope0_id, "#div/0")}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-attribute/__snapshots__/html.bundle.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("a", (input) => {
 		compact: input.on
 	}, $scope0_owned, 2)}${_patch_attr_style($scope0_id, "c", [input.accent, { margin: 0 }], $scope0_owned, 1)}>badge</span>${_el_resume($scope0_id, "c")}</div>${_el_resume($scope0_id, "a")}`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
@@ -27,4 +27,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.tone);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
@@ -24,4 +24,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: count
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.tone);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var price_card_default = _template_persisted("__tests__/tags/price-card.marko", 
 		qty: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/tags/price-card.marko0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // tags/promo-tag.marko
 var promo_tag_default = _template_persisted("__tests__/tags/promo-tag.marko", (input) => {
@@ -30,7 +30,7 @@ var promo_tag_default = _template_persisted("__tests__/tags/promo-tag.marko", (i
 		seen: "1:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/tags/promo-tag.marko0", input.text);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // tags/site-footer.marko
 var site_footer_default = _template_persisted("__tests__/tags/site-footer.marko", (input) => {
@@ -40,7 +40,7 @@ var site_footer_default = _template_persisted("__tests__/tags/site-footer.marko"
 	_html(`<footer>${_patch_text($scope0_id, "#text/0", input.year + frozen, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</footer>`);
 	$scope0_reason && writeScope($scope0_id, { frozen }, "__tests__/tags/site-footer.marko", 0, { frozen: "1:6" });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
@@ -65,4 +65,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		"#childScope/4": _existing_scope($childScope2),
 		"#childScope/5": _existing_scope($childScope3)
 	}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-client-intersections/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var price_card_default = _template_persisted("b", (input) => {
 		f: qty
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "b0", input.label);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // tags/promo-tag.marko
 var promo_tag_default = _template_persisted("c", (input) => {
@@ -24,7 +24,7 @@ var promo_tag_default = _template_persisted("c", (input) => {
 		f: seen
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "c0", input.text);
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // tags/site-footer.marko
 var site_footer_default = _template_persisted("d", (input) => {
@@ -34,7 +34,7 @@ var site_footer_default = _template_persisted("d", (input) => {
 	_html(`<footer>${_patch_text($scope0_id, "a", input.year + frozen, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</footer>`);
 	$scope0_reason && writeScope($scope0_id, { e: frozen });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 var template_default = _template_persisted("a", (input) => {
@@ -59,4 +59,4 @@ var template_default = _template_persisted("a", (input) => {
 		e: _existing_scope($childScope2),
 		f: _existing_scope($childScope3)
 	});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko:3:3
+      1 | <section>
+      2 |   <span>${input.value}</span>
+    > 3 |   <${input.content}/>
+        |   ^^^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+      4 | </section>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko:3:3
+      1 | <section>
+      2 |   <span>${input.value}</span>
+    > 3 |   <${input.content}/>
+        |   ^^^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+      4 | </section>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko:3:3
+      1 | <section>
+      2 |   <span>${input.value}</span>
+    > 3 |   <${input.content}/>
+        |   ^^^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+      4 | </section>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko:3:3
+      1 | <section>
+      2 |   <span>${input.value}</span>
+    > 3 |   <${input.content}/>
+        |   ^^^^^^^^^^^^^^^^^^^ Persisted templates currently support only escaped dynamic text and dynamic attributes in native HTML.
+      4 | </section>
+      5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/banner/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/banner/index.marko
@@ -1,0 +1,1 @@
+<div>${$global.brand}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/tags/widget/index.marko
@@ -1,0 +1,4 @@
+<section>
+  <span>${input.value}</span>
+  <${input.content}/>
+</section>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/template.marko
@@ -1,0 +1,6 @@
+import banner from "./tags/banner/index.marko";
+<let/count=0/>
+<main>
+  <widget value=count content=banner/>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+// A `content=` renderer inside a persisted child needs a dynamic tag,
+// which fails closed today: when tier-3 lifts that, this shape must be
+// covered by content-renderer intrinsics before it may compile.
+export const config: TestConfig = {
+  error_compiler: ["tags/widget/index.marko"],
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { input_value: input.value }, "__tests__/template.marko", 0, { input_value: ["input.value"] });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { g: input.value });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
@@ -19,4 +19,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, $scope0_id, "#text/1", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1_shell"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { input_value: input.value }, "__tests__/template.marko", 0, { input_value: ["input.value"] });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
@@ -19,4 +19,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, $scope0_id, "b", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a1"]);
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, { g: input.value });
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.debug.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, "__tests__/template.marko_0/checkedChange"))}${_patch_control($scope0_id, "#input/1", 0, input.agree, $scope0_owned, 1)} type=checkbox>${_el_resume($scope0_id, "#input/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked/__snapshots__/html.bundle.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, "a0"))}${_patch_control($scope0_id, "b", 0, input.agree, $scope0_owned, 1)} type=checkbox>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.debug.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, "__tests__/template.marko_0/openChange"))}${_patch_control($scope0_id, "#details/1", 4, input.show, $scope0_owned, 1)}><summary>More</summary><p>Body</p></details>${_el_resume($scope0_id, "#details/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-details/__snapshots__/html.bundle.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, "a0"))}${_patch_control($scope0_id, "b", 4, input.show, $scope0_owned, 1)}><summary>More</summary><p>Body</p></details>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.debug.js
@@ -13,4 +13,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html(`${_el_resume($scope0_id, "#select/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-multiple/__snapshots__/html.bundle.js
@@ -13,4 +13,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html(`${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.debug.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		input_wire: ["input.wire"],
 		handler: "1:8"
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/__snapshots__/html.bundle.js
@@ -12,4 +12,4 @@ var template_default = _template_persisted("a", (input) => {
 		g: input.wire,
 		h: handler
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.debug.js
@@ -13,4 +13,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html(`${_el_resume($scope0_id, "#select/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-select/__snapshots__/html.bundle.js
@@ -13,4 +13,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html(`${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.debug.js
@@ -21,4 +21,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		plain: "1:8",
 		loud: "2:8"
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/__snapshots__/html.bundle.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: plain,
 		i: loud
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.debug.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, "__tests__/template.marko_0/valueChange"))}</textarea>${_el_resume($scope0_id, "#textarea/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-textarea/__snapshots__/html.bundle.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, "a0"))}</textarea>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.debug.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1><input${_attr_input_value($scope0_id, "#input/1", input.value)}${_patch_control($scope0_id, "#input/1", 2, input.value, $scope0_owned, 1)}>${_el_resume($scope0_id, "#input/1")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-value/__snapshots__/html.bundle.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1><input${_attr_input_value($scope0_id, "b", input.value)}${_patch_control($scope0_id, "b", 2, input.value, $scope0_owned, 1)}>${_el_resume($scope0_id, "b")}</main>`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.debug.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	_html(`<a${_patch_attr($scope0_id, "#a/0", "href", input.href, $scope0_owned, 0)}${_patch_attr($scope0_id, "#a/0", "title", input.title, $scope0_owned, 1)}${_patch_attr($scope0_id, "#a/0", "hidden", input.hidden, $scope0_owned, 2)}>${_patch_text($scope0_id, "#text/1", input.label, $scope0_owned, 3)}${_el_resume($scope0_id, "#text/1")}</a>${_el_resume($scope0_id, "#a/0")}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attribute/__snapshots__/html.bundle.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<a${_patch_attr($scope0_id, "a", "href", input.href, $scope0_owned, 0)}${_patch_attr($scope0_id, "a", "title", input.title, $scope0_owned, 1)}${_patch_attr($scope0_id, "a", "hidden", input.hidden, $scope0_owned, 2)}>${_patch_text($scope0_id, "b", input.label, $scope0_owned, 3)}${_el_resume($scope0_id, "b")}</a>${_el_resume($scope0_id, "a")}`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/__snapshots__/html.bundle.debug.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/__snapshots__/html.bundle.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, { c: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.debug.js
@@ -5,4 +5,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html(`<div><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1><button>Click</button>${_el_resume($scope0_id, "#button/1")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effects/__snapshots__/html.bundle.js
@@ -5,4 +5,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html(`<div><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1><button>Click</button>${_el_resume($scope0_id, "b")}</div>`);
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.debug.js
@@ -44,4 +44,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.js
@@ -40,4 +40,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.debug.js
@@ -50,4 +50,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 4) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.js
@@ -45,4 +45,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $input_items__closures
 	}) : _owned_guard($scope0_owned, 4) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.debug.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.js
@@ -28,4 +28,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: $count__closures
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.debug.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.js
@@ -28,4 +28,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: $count__closures
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.debug.js
@@ -36,4 +36,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 4) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.js
@@ -32,4 +32,4 @@ var template_default = _template_persisted("a", (input) => {
 		m: $count__closures
 	}) : _owned_guard($scope0_owned, 4) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.debug.js
@@ -31,4 +31,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 2) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.js
@@ -28,4 +28,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	}) : _owned_guard($scope0_owned, 2) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.debug.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	_html(`<div><h1${_patch_attr($scope0_id, "#h1/0", "title", $global().locale)}>${_patch_text($scope0_id, "#text/1", $global().brand)}${_el_resume($scope0_id, "#text/1")}</h1>${_el_resume($scope0_id, "#h1/0")}<p>${_patch_text($scope0_id, "#text/2", input.name, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/2")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-reads/__snapshots__/html.bundle.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<div><h1${_patch_attr($scope0_id, "a", "title", $global().locale)}>${_patch_text($scope0_id, "b", $global().brand)}${_el_resume($scope0_id, "b")}</h1>${_el_resume($scope0_id, "a")}<p>${_patch_text($scope0_id, "c", input.name, $scope0_owned, 0)}${_el_resume($scope0_id, "c")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.debug.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/__snapshots__/html.bundle.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, {});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.debug.js
@@ -5,4 +5,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_html(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1><button>read</button>${_el_resume($scope0_id, "#button/1")}</main>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason ? writeScope($scope0_id, { input_title: input.title }, "__tests__/template.marko", 0, { input_title: ["input.title"] }) : _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "input_title", input.title);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-handler-input/__snapshots__/html.bundle.js
@@ -5,4 +5,4 @@ var template_default = _template_persisted("a", (input) => {
 	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1><button>read</button>${_el_resume($scope0_id, "b")}</main>`);
 	_script($scope0_id, "a0");
 	$scope0_reason ? writeScope($scope0_id, { e: input.title }) : _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "e", input.title);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
@@ -22,4 +22,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, 0, $scope0_id, "#text/2", 1, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_2_shell");
 	_html("</div>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
@@ -22,4 +22,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, 0, $scope0_id, "c", 1, $sg__input_items, $sg__input_items, void 0, void 0, "a1");
 	_html("</div>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/__snapshots__/html.bundle.debug.js
@@ -16,4 +16,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		other: "2:6"
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-intersection/__snapshots__/html.bundle.js
@@ -12,4 +12,4 @@ var template_default = _template_persisted("a", (input) => {
 		i: other
 	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.debug.js
@@ -36,4 +36,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.js
@@ -32,4 +32,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { boost }, "__tests__/template.marko", 0, { boost: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, { f: boost });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.debug.js
@@ -36,4 +36,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "__tests__/template.marko0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.js
@@ -32,4 +32,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $count__closures
 	}) : _owned_guard($scope0_owned, 3) && _patch_value($scope0_id, "a0", input.suffix);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.debug.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.js
@@ -20,4 +20,4 @@ var template_default = _template_persisted("a", (input) => {
 		g: count
 	}) : _owned_guard($scope0_owned, 1) && _patch_value($scope0_id, "a0", input.title);
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, 0, $scope0_id, "#ul/0", 1, $sg__input_labels, $sg__input_labels, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0", $sg__input_labels)}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, 0, $scope0_id, "a", 1, $sg__input_labels, $sg__input_labels, void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a", $sg__input_labels)}`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
@@ -26,4 +26,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, "id", $scope0_id, "#ul/0", 1, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0", $sg__input_items)}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
@@ -26,4 +26,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, "id", $scope0_id, "a", 1, $sg__input_items, $sg__input_items, void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a", $sg__input_items)}`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, "id", $scope0_id, "#ul/0", 1, $sg__input_items, $sg__input_items, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html(`</ul>${_el_resume($scope0_id, "#ul/0", $sg__input_items)}`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, "id", $scope0_id, "a", 1, $sg__input_items, $sg__input_items, void 0, void 0, "a0");
 	_html(`</ul>${_el_resume($scope0_id, "a", $sg__input_items)}`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
@@ -32,4 +32,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
@@ -29,4 +29,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: count
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, { g: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
@@ -11,4 +11,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	});
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
@@ -11,4 +11,4 @@ var template_default = _template_persisted("a", (input) => {
 	});
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
@@ -11,4 +11,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	}, 0, $scope0_id, "#text/1", 1, _source_guard($scope0_reason, 1), 0, void 0, void 0, "__tests__/template.marko_1_shell");
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
@@ -11,4 +11,4 @@ var template_default = _template_persisted("a", (input) => {
 	}, 0, $scope0_id, "b", 1, _source_guard($scope0_reason, 1), 0, void 0, void 0, "a0");
 	_html("</main>");
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
@@ -14,4 +14,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a1");
 	$scope0_reason && writeScope($scope0_id, { i: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var badge_default = _template_persisted("__tests__/tags/badge.marko", (input) =>
 	_script($scope0_id, "__tests__/tags/badge.marko_0");
 	$scope0_reason && writeScope($scope0_id, { seen }, "__tests__/tags/badge.marko", 0, { seen: "1:6" });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 _renderer_shells({
@@ -67,4 +67,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		input_summary: ["input.summary"],
 		input_detail: ["input.detail"]
 	});
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var badge_default = _template_persisted("b", (input) => {
 	_script($scope0_id, "b0");
 	$scope0_reason && writeScope($scope0_id, { g: seen });
 	_resume_branch($scope0_id);
-});
+}, 0, 0);
 
 // template.marko
 _renderer_shells({
@@ -64,4 +64,4 @@ var template_default = _template_persisted("a", (input) => {
 		k: $input_detail__closures,
 		c: _existing_scope($childScope)
 	});
-}, 1);
+}, 1, () => [badge_default]);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
@@ -23,4 +23,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		count: "1:6"
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
@@ -20,4 +20,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: count
 	});
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/__snapshots__/html.bundle.debug.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	_patch_effect($scope0_id, "__tests__/template.marko_0", "! brand locale", 1);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/__snapshots__/html.bundle.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "! brand locale", 1);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/__snapshots__/html.bundle.debug.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	_patch_effect($scope0_id, "__tests__/template.marko_0", "!", 1);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/__snapshots__/html.bundle.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "!", 1);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/__snapshots__/html.bundle.debug.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	_patch_effect($scope0_id, "__tests__/template.marko_0", "! brand", 1);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/__snapshots__/html.bundle.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "! brand", 1);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.debug.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0_input_announce");
 	_patch_effect($scope0_id, "__tests__/template.marko_0_input_announce", "input_announce");
 	$scope0_reason ? writeScope($scope0_id, { input_announce: input.announce }, "__tests__/template.marko", 0, { input_announce: ["input.announce"] }) : _owned_guard($scope0_owned, 1) && _patch_write($scope0_id, "input_announce", input.announce);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/__snapshots__/html.bundle.js
@@ -6,4 +6,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	_patch_effect($scope0_id, "a0", "e");
 	$scope0_reason ? writeScope($scope0_id, { e: input.announce }) : _owned_guard($scope0_owned, 1) && _patch_write($scope0_id, "e", input.announce);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.debug.js
@@ -12,4 +12,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		input_a: ["input.a"],
 		input_b: ["input.b"]
 	}) : (_owned_guard($scope0_owned, 1) && _patch_write($scope0_id, "input_a", input.a), _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "input_b", input.b));
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/__snapshots__/html.bundle.js
@@ -9,4 +9,4 @@ var template_default = _template_persisted("a", (input) => {
 		e: input.a,
 		f: input.b
 	}) : (_owned_guard($scope0_owned, 1) && _patch_write($scope0_id, "e", input.a), _owned_guard($scope0_owned, 2) && _patch_write($scope0_id, "f", input.b));
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
@@ -22,4 +22,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 		input_hidden: ["input.hidden"],
 		input_label: ["input.label"]
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
@@ -18,4 +18,4 @@ var template_default = _template_persisted("a", (input) => {
 		h: input.hidden,
 		i: input.label
 	});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.debug.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	_script($scope0_id, "__tests__/template.marko_0");
 	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-state/__snapshots__/html.bundle.js
@@ -7,4 +7,4 @@ var template_default = _template_persisted("a", (input) => {
 	_script($scope0_id, "a0");
 	$scope0_reason && writeScope($scope0_id, { g: count });
 	_resume_branch($scope0_id);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.debug.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 	const $scope0_id = _scope_id();
 	_html(`<div class=card><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1><p>${_patch_text($scope0_id, "#text/1", input.body, $scope0_owned, 1)}${_el_resume($scope0_id, "#text/1")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-text-holes/__snapshots__/html.bundle.js
@@ -4,4 +4,4 @@ var template_default = _template_persisted("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<div class=card><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1><p>${_patch_text($scope0_id, "b", input.body, $scope0_owned, 1)}${_el_resume($scope0_id, "b")}</p></div>`);
 	$scope0_reason && writeScope($scope0_id, {});
-}, 1);
+}, 1, 0);

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -42,7 +42,7 @@ export { _content, _content_resume, _dynamic_tag } from "./html/dynamic-tag";
 export { forIn, forOf, forTo, forUntil } from "./html/for";
 export { _renderer_shells } from "./html/renderer-shells";
 export { _template } from "./html/template";
-export { _template_persisted, renderPatch } from "./html/patch";
+export { _must_render, _template_persisted, renderPatch } from "./html/patch";
 export {
   _attr_content,
   _await,

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -17,16 +17,70 @@ import {
   writePatch,
 } from "./writer";
 
+// Intrinsic render summary: what a template's render could depend on
+// beyond its inputs, as ONE self-resolving value. `1` = must render
+// (reads globals / opaque); `0` = whole subtree proven clean; a lazy
+// child-renderer thunk = locally clean, resolved to 0/1 on first query
+// (lazy: module cycles must not evaluate eagerly). An ABSENT summary
+// means unknown (foreign renderer) — never clean.
+type Intrinsics = 0 | 1 | (() => unknown[]);
+const kIntrinsics = Symbol();
+type WithIntrinsics = { [kIntrinsics]?: Intrinsics };
+
 export function _template_persisted(
   templateId: string,
   renderer: ServerRenderer,
-  page?: 1,
+  page?: 0 | 1,
+  intrinsics?: Intrinsics,
 ) {
   enablePatchWrites();
-  const template = _template(templateId, renderer, page);
+  const template = _template(templateId, renderer, page as 1) as Template &
+    ServerRenderer &
+    WithIntrinsics;
   template.renderPatch = renderPatch;
+  if (intrinsics !== undefined) template[kIntrinsics] = intrinsics;
   return template;
 }
+
+// A patch must render a child unless its summary proves the whole subtree
+// clean; steady state is one property read (the walk overwrites the thunk
+// with its answer). `1` resolves always; `0` only when the walk closed
+// without an unresolved cycle back-edge (a tainted answer may depend on
+// an in-progress ancestor).
+export function _must_render(child: unknown) {
+  const intrinsics = (child as WithIntrinsics | undefined)?.[kIntrinsics];
+  if (intrinsics === undefined) return true;
+  if (typeof intrinsics !== "function") return !!intrinsics;
+  return mustRenderWalk(child as WithIntrinsics, new Set(), { t: false });
+}
+
+const mustRenderWalk = (
+  holder: WithIntrinsics,
+  visiting: Set<() => unknown[]>,
+  taint: { t: boolean },
+): boolean => {
+  const intrinsics = holder?.[kIntrinsics];
+  if (intrinsics === undefined) return true;
+  if (typeof intrinsics !== "function") return !!intrinsics;
+  if (visiting.has(intrinsics)) {
+    taint.t = true;
+    return false;
+  }
+  visiting.add(intrinsics);
+  const outerTaint = taint.t;
+  taint.t = false;
+  let result = false;
+  for (const nested of intrinsics()) {
+    if (mustRenderWalk(nested as WithIntrinsics, visiting, taint)) {
+      result = true;
+      break;
+    }
+  }
+  visiting.delete(intrinsics);
+  if (result || !taint.t) holder[kIntrinsics] = result ? 1 : 0;
+  taint.t ||= outerTaint;
+  return result;
+};
 
 export function renderPatch(
   this: Template & ServerRenderer,

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -27,6 +27,7 @@ import {
   toIter,
 } from "./optional";
 import {
+  addPersistedChildRenderer,
   getPersistedServerRequiredParams,
   kPatchClientOwned,
   recordPersistedServerRequired,
@@ -235,6 +236,9 @@ export function knownTagTranslateHTML(
     section,
     childScopeBinding,
   );
+  // Every child renderer joins this template's intrinsics union, so a
+  // parent's patch-skip decision sees the whole subtree at render time.
+  if (isPersisted()) addPersistedChildRenderer(tagIdentifier);
   // A client-owned instance renders nothing into a patch: the link and the
   // child render skip together, and the absent entry keeps the live child.
   let clientOwnedStatements: t.Statement[] | undefined =
@@ -298,12 +302,13 @@ export function knownTagTranslateHTML(
     let childSerializeReasonExpr: t.Expression | undefined;
     if (isPersisted()) {
       // Pages serialize fully, so the ambient slot carries the ownership
-      // mask instead; a skipped instance leaves the all-server default.
-      if (!clientOwnedStatements) {
-        const ownership = getPersistedGroupOwnership(tagExtra);
-        if (ownership) {
-          childSerializeReasonExpr = buildOwnershipMaskExpr(section, ownership);
-        }
+      // mask instead. A client-owned candidate needs it exactly when it
+      // RENDERS (`_must_render` can render it on a patch, and all-server
+      // ambient would ship its client-owned values); a skipped instance
+      // leaves the all-server default.
+      const ownership = getPersistedGroupOwnership(tagExtra);
+      if (ownership) {
+        childSerializeReasonExpr = buildOwnershipMaskExpr(section, ownership);
       }
     } else if (contentSection.paramReasonGroups.length === 1) {
       // Special case single reason to pass either 1 or undefined.
@@ -366,11 +371,14 @@ export function knownTagTranslateHTML(
     }
 
     if (childSerializeReasonExpr) {
-      tag.insertBefore(
-        t.expressionStatement(
-          callRuntime("_set_serialize_reason", childSerializeReasonExpr),
-        ),
+      const setReason = t.expressionStatement(
+        callRuntime("_set_serialize_reason", childSerializeReasonExpr),
       );
+      if (clientOwnedStatements) {
+        clientOwnedStatements.unshift(setReason);
+      } else {
+        tag.insertBefore(setReason);
+      }
     }
   }
 
@@ -390,13 +398,19 @@ export function knownTagTranslateHTML(
     translateVar(tag, callExpression(tagIdentifier, ...getArgs()), "let");
   } else if (clientOwnedStatements) {
     // The render-wide persisted reason is the page-vs-patch bit: truthy on
-    // a page render (serialize + render the child), falsy on a patch.
+    // a page render (serialize + render the child), falsy on a patch. A
+    // patch still renders when the child's intrinsics demand it (global
+    // reads anywhere in its subtree, or an unknown renderer).
     let rootSection = section;
     while (rootSection.parent) rootSection = rootSection.parent;
     clientOwnedStatements.push(callStatement(tagIdentifier, ...getArgs()));
     statements.push(
       t.ifStatement(
-        scopeReasonIdentifier(rootSection),
+        t.logicalExpression(
+          "||",
+          scopeReasonIdentifier(rootSection),
+          callRuntime("_must_render", t.cloneNode(tagIdentifier)),
+        ),
         t.blockStatement(clientOwnedStatements),
       ),
     );

--- a/packages/runtime-tags/src/translator/util/persisted.ts
+++ b/packages/runtime-tags/src/translator/util/persisted.ts
@@ -25,12 +25,34 @@ declare module "@marko/compiler/dist/types" {
     [kPatchClientOwned]?: true;
   }
 }
+// The template's child renderers, collected at translate for the runtime
+// intrinsics export: transitive global knowledge composes at RENDER time
+// (exact under module cycles and dynamic dispatch), never at compile.
+const [getPersistedChildRenderers] = createProgramState(() => ({
+  names: new Set<string>(),
+  opaque: false,
+}));
+
+export function addPersistedChildRenderer(expr: t.Node) {
+  const state = getPersistedChildRenderers();
+  if (expr.type === "Identifier") {
+    state.names.add(expr.name);
+  } else {
+    // An unaddressable renderer cannot join the union: the template goes
+    // opaque so parents always render through it.
+    state.opaque = true;
+  }
+}
+
+export function getPersistedIntrinsics() {
+  return getPersistedChildRenderers();
+}
+
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
-    /** This template (or one it renders) reads `$global`: skipping its
-     * render in a patch could hide a global change. Analyze-internal,
-     * read cross-file off the cached child program. */
-    persistedGlobals?: true;
+    /** This template ITSELF reads `$global` (local, no roll-up): exported
+     * as the html template's intrinsics for render-time composition. */
+    readsGlobals?: true;
   }
 }
 

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1079,10 +1079,9 @@ export function finalizeReferences() {
     // membership, no closures — reads compile verbatim.
     if (binding.type === BindingType.global) {
       resolveBindingSources(binding);
-      // Derived cross-file bit: custom-tag analyze rolls it up so a call
-      // site can classify whether skipping this render could hide a
-      // global change.
-      if (isPersisted()) getProgram().node.extra!.persistedGlobals = true;
+      // LOCAL-only bit (no cross-file roll-up): the html output exports it
+      // as the template's intrinsics, composed across templates at render.
+      if (isPersisted()) getProgram().node.extra!.readsGlobals = true;
       continue;
     }
     if (binding.type !== BindingType.dom) {

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -23,6 +23,7 @@ import { forEach } from "../../util/optional";
 import {
   getConstructInitClosures,
   getPatchFillBindings,
+  getPersistedIntrinsics,
   hasUndeliverableFillReads,
   hasUnfillablePatchReads,
   isPatchCaptureSection,
@@ -261,16 +262,23 @@ export default {
         [t.identifier("input")],
         t.blockStatement(renderContent),
       );
+      // A non-page template gets a randomized render id ("embed") so several
+      // can share a document without colliding; without linkAssets, use a fixed page id.
+      const pageArg =
+        program.node.extra!.page || !getMarkoOpts().linkAssets
+          ? t.numericLiteral(1)
+          : undefined;
       const exportDefault = t.exportDefaultDeclaration(
         callRuntime(
           persisted ? "_template_persisted" : "_template",
           t.stringLiteral(program.hub.file.metadata.marko.id),
           contentId ? t.identifier(contentId) : contentFn,
-          // A non-page template gets a randomized render id ("embed") so several
-          // can share a document without colliding; without linkAssets, use a fixed page id.
-          program.node.extra!.page || !getMarkoOpts().linkAssets
-            ? t.numericLiteral(1)
-            : undefined,
+          // Persisted templates always carry their intrinsics (absent =
+          // FOREIGN renderer, which parents must render through): the local
+          // globals/opaque bit plus lazily-referenced child renderers.
+          ...(persisted
+            ? buildIntrinsicsArgs(program, pageArg ?? t.numericLiteral(0))
+            : [pageArg]),
         ),
       );
 
@@ -287,6 +295,28 @@ export default {
     },
   },
 } satisfies TemplateVisitor<t.Program>;
+
+// The intrinsics trailing arg, one self-resolving value: `1` = reads
+// globals or opaque (children irrelevant once true), a lazy child list
+// (an arrow: module cycles must not evaluate eagerly) = locally clean
+// but transitively unresolved, `0` = proven clean.
+function buildIntrinsicsArgs(
+  program: t.NodePath<t.Program>,
+  pageArg: t.Expression,
+) {
+  const { names, opaque } = getPersistedIntrinsics();
+  return [
+    pageArg,
+    opaque || program.node.extra!.readsGlobals
+      ? t.numericLiteral(1)
+      : names.size
+        ? t.arrowFunctionExpression(
+            [],
+            t.arrayExpression([...names].map((name) => t.identifier(name))),
+          )
+        : t.numericLiteral(0),
+  ];
+}
 
 export function assertSupportedPatch(program: t.NodePath<t.Program>) {
   const unsupported = (node: t.Node, detail?: string) => {
@@ -501,12 +531,10 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
             for (const child of tag.get("body").get("body")) {
               skips &&= isStatic(child);
             }
-            const childFile = loadFileForTag(tag);
-            if (
-              skips &&
-              childFile &&
-              !childFile.path.node.extra?.persistedGlobals
-            ) {
+            // Transitive global knowledge is a RENDER-time question (the
+            // child's exported intrinsics); classification only needs a
+            // resolvable child whose groups analyzed above.
+            if (skips && loadFileForTag(tag)) {
               (node.extra ??= {})[kPatchClientOwned] = true;
             }
           }

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -28,11 +28,7 @@ import {
   knownTagTranslateDOM,
   knownTagTranslateHTML,
 } from "../../util/known-tag";
-import {
-  getMarkoOpts,
-  isOutputHTML,
-  isPersisted,
-} from "../../util/marko-config";
+import { getMarkoOpts, isOutputHTML } from "../../util/marko-config";
 import type { Binding } from "../../util/references";
 import {
   BindingType,
@@ -81,12 +77,6 @@ export default {
         throw tag
           .get("name")
           .buildCodeFrameError("Unable to resolve file for tag.");
-      }
-
-      // Global reads roll up the load chain so any ancestor call site can
-      // classify whether skipping this subtree could hide a global change.
-      if (isPersisted() && childFile.path.node.extra?.persistedGlobals) {
-        getProgram().node.extra!.persistedGlobals = true;
       }
 
       const tagExtra = (tag.node.extra ??= {});


### PR DESCRIPTION
Each persisted template's html output exports its intrinsic render summary — a local reads-globals/opaque bit plus lazily-referenced child renderers — and a client-owned candidate's patch skip asks `_must_render` at the call site, which unions summaries across the render graph with a memoized cycle-safe walk (absent summary = foreign = render). This replaces the eagerly rolled-up `persistedGlobals` bit and its cross-file ordering hazards with render-time composition, and widens skip candidacy to global-reading children (the runtime check renders them); a rendering candidate now carries its ownership mask so patch writers stay gated. A latent `content=` hole is pinned fail-closed behind the dynamic-tag reject.