### PR TITLE
fix(runtime-tags): pass the real branch count at the if translate call sites

### DIFF
--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -2,12 +2,6 @@
 
 Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).
 
-## Make the `getOnlyChildParentTagName` memo order-independent — `branchSize` is ignored after the first call
-
-`packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts` › `getOnlyChildParentTagName` | 2026-07-23 | impact:low | effort:low
-
-The cached `tag.node.extra[kOnlyChildInParent]` is returned before `branchSize` is read, so only the first call per node decides the answer — in practice `IfTag.analyze`, the sole caller passing `branches.length`, since `core/if.ts` translate, `core/for.ts` and `core/show.ts` pass the default `1` and ride the cache across the analyze→translate clone. Any new pass touching an `<if>` before `IfTag.analyze` poisons the memo with `1`, silently costing every multi-branch chain its parent-element marker (an extra `<!>`, walk char and `#text` binding). Nothing catches that: every multi-branch fixture snapshot uses `_if("#text/…")`. Pass the real branch count at the `core/if.ts` translate sites too — keying the memo on `branchSize` alone would break them, since they pass `1` — and add a chain-as-only-child fixture. Distinct from the won't-fix entry "Extend only-child marker elision to `<await>`/`<try>`", which spreads the optimization to more tags rather than fixing this memo's key. Re-verify: compile `<div><if=input.x><p>a</p></if><else-if=input.y><i>c</i></else-if><else><b>b</b></else></div>` with `-o dom -d`; today it yields `_if("#div/0", …)` with `$template === "<div></div>"`.
-
 ## Warn under `MARKO_DEBUG` when `NaN`/`0n` vanish from text and style values
 
 `packages/runtime-tags/src/html/content.ts` › `_to_text` | 2026-07-18 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<button> </button><div></div>";
+const $walks = " D l b";
+const $if = /*@__PURE__*/ _if("#div/2", "<p>a</p>", 0, 0, "<i>b</i>", 0, 0, "<b>c</b>");
+const $count = /*@__PURE__*/ _let("count/3", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$if($scope, $scope.count % 3 === 0 ? 0 : $scope.count % 3 === 1 ? 1 : 2);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $if = /*@__PURE__*/ _if(2, "<p>a</p>", 0, 0, "<i>b</i>", 0, 0, "<b>c</b>");
+const $count = /*@__PURE__*/ _let(3, ($scope) => {
+	_text($scope.b, $scope.d);
+	$if($scope, $scope.d % 3 === 0 ? 0 : $scope.d % 3 === 1 ? 1 : 2);
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, $scope.d + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,28 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}<div>`);
+	_if(() => {
+		if (count % 3 === 0) {
+			const $scope1_id = _scope_id();
+			_html("<p>a</p>");
+			writeScope($scope1_id, {}, "__tests__/template.marko", "7:4");
+			return 0;
+		} else if (count % 3 === 1) {
+			const $scope2_id = _scope_id();
+			_html("<i>b</i>");
+			writeScope($scope2_id, {}, "__tests__/template.marko", "10:4");
+			return 1;
+		} else {
+			const $scope3_id = _scope_id();
+			_html("<b>c</b>");
+			writeScope($scope3_id, {}, "__tests__/template.marko", "13:4");
+			return 2;
+		}
+	}, $scope0_id, "#div/2", 1, 1, 1, "</div>", 1);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/html.bundle.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}<div>`);
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			_html("<p>a</p>");
+			writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "c", 1, 1, 1, "</div>", 1);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { d: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/render.debug.md
@@ -1,0 +1,74 @@
+# Render
+```html
+<button>
+  0
+</button>
+<div>
+  <p>
+    a
+  </p>
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+<div>
+  <i>
+    b
+  </i>
+</div>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+REMOVE: div > p
+INSERT: div > i
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  2
+</button>
+<div>
+  <b>
+    c
+  </b>
+</div>
+```
+## Change
+```
+UPDATE: button::text "1" => "2"
+REMOVE: div > i
+INSERT: div > b
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  3
+</button>
+<div>
+  <p>
+    a
+  </p>
+</div>
+```
+## Change
+```
+UPDATE: button::text "2" => "3"
+REMOVE: div > b
+INSERT: div > p
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/render.md
@@ -1,0 +1,74 @@
+# Render
+```html
+<button>
+  0
+</button>
+<div>
+  <p>
+    a
+  </p>
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+<div>
+  <i>
+    b
+  </i>
+</div>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+REMOVE: div > p
+INSERT: div > i
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  2
+</button>
+<div>
+  <b>
+    c
+  </b>
+</div>
+```
+## Change
+```
+UPDATE: button::text "1" => "2"
+REMOVE: div > i
+INSERT: div > b
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  3
+</button>
+<div>
+  <p>
+    a
+  </p>
+</div>
+```
+## Change
+```
+UPDATE: button::text "2" => "3"
+REMOVE: div > b
+INSERT: div > p
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<button>0<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+<div>
+  <p>a</p><!--M_}1 #div/2 2-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<button>0<!--M_*1 b--></button><!--M_*1 a-->
+<div>
+  <p>a</p><!--M_}1 c 2-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6138,
+      "brotli": 2808
+    }
+  },
+  "html": {
+    "min": 386,
+    "brotli": 264
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/template.marko
@@ -1,0 +1,16 @@
+<let/count=0>
+<button onClick() { count++ }>
+  ${count}
+</button>
+
+<div>
+  <if=count % 3 === 0>
+    <p>a</p>
+  </if>
+  <else-if=count % 3 === 1>
+    <i>b</i>
+  </else-if>
+  <else>
+    <b>c</b>
+  </else>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -129,12 +129,17 @@ export const IfTag = {
         const bodySection = getSectionForBody(tagBody);
 
         if (bodySection) {
-          const [[ifTag]] = getBranches(tag);
+          const branches = getBranches(tag);
+          const [ifTag] = branches[0];
           const ifTagSection = getSection(ifTag);
           resumeOwnerByMarkerWhenStatic(
             ifTagSection,
             bodySection,
-            getOptimizedOnlyChildNodeBinding(ifTag, ifTagSection),
+            getOptimizedOnlyChildNodeBinding(
+              ifTag,
+              ifTagSection,
+              branches.length,
+            ),
             kStatefulReason,
           );
           writer.flushInto(tag);
@@ -148,8 +153,12 @@ export const IfTag = {
           const nodeBinding = getOptimizedOnlyChildNodeBinding(
             ifTag,
             ifTagSection,
+            branches.length,
           );
-          const onlyChildParentTagName = getOnlyChildParentTagName(ifTag);
+          const onlyChildParentTagName = getOnlyChildParentTagName(
+            ifTag,
+            branches.length,
+          );
           const markerSerializeReason = getSerializeReason(
             ifTagSection,
             nodeBinding,
@@ -286,7 +295,11 @@ export const IfTag = {
           const [ifTag] = branches[0];
           const ifTagSection = getSection(ifTag);
           const ifTagExtra = branches[0][0].node.extra!;
-          const nodeRef = getOptimizedOnlyChildNodeBinding(ifTag, ifTagSection);
+          const nodeRef = getOptimizedOnlyChildNodeBinding(
+            ifTag,
+            ifTagSection,
+            branches.length,
+          );
 
           let expr: t.Expression = t.numericLiteral(branches.length);
 


### PR DESCRIPTION
The only-child-in-parent memo returns its cached value before reading `branchSize`, so the translate-time call sites in `core/if.ts` passed the default `1` and only produced correct output because `IfTag.analyze` populated the cache first — any pass touching an `<if>` earlier would silently drop the parent-element marker for multi-branch chains. This passes the real branch count at every `if.ts` call site and adds a multi-branch chain-as-only-child fixture that fails if the marker is lost. Resolves the corresponding `agent-feedback/unclear.md` entry.