### PR TITLE
fix(runtime-tags): warn in debug when NaN/0n text and style values are dropped

### DIFF
--- a/.changeset/warn-dropped-nan-bigint.md
+++ b/.changeset/warn-dropped-nan-bigint.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Warn in debug builds when a `NaN` or bigint `0n` text or style value is silently dropped from the output.

--- a/agent-feedback/unclear.md
+++ b/agent-feedback/unclear.md
@@ -2,12 +2,6 @@
 
 Things that were hard to understand, and what would have clarified them. Format and rules: [README.md](README.md).
 
-## Warn under `MARKO_DEBUG` when `NaN`/`0n` vanish from text and style values
-
-`packages/runtime-tags/src/html/content.ts` › `_to_text` | 2026-07-18 | impact:low | effort:low
-
-Text and style-object values use `val || val === 0`, so `NaN` and `0n` render as nothing (`_to_text`/`_escape` in `html/content.ts`, `_to_text` in `dom/dom.ts`, `stringifyStyleObject` in `common/helpers.ts`), while attributes skip only `null`/`undefined`/`false` (`isVoid` → `nonVoidAttr`) and write `data-a=NaN`, `data-b=0`. A stray `NaN` therefore blanks a text node or drops an entire `width:` declaration with no signal: `assertValidTextValue` rejects only symbols and objects, so `MARKO_DEBUG` is silent too. Direction: warn in `MARKO_DEBUG` when `NaN` reaches a text or style value, alongside the existing camelCase-key warn in `stringifyStyleObject`. Distinct from the controlled-value selection path, where `normalizeStrAttrValue` (`html/attrs.ts`) already mirrors the DOM for `NaN`/`0n` — the drop survives only in text and style positions. The coercion-table half of this entry has been ported to the markojs.com website repo, which documents the drop rules for text and `style=`. Re-verify: `rg -n "val \|\| val === 0|value \|\| value === 0" packages/runtime-tags/src` beside `isVoid` in `common/helpers.ts`.
-
 ## Add a head-contribution primitive, or state that nested `<title>`/`<meta>`/`<link>` never hoist
 
 `packages/runtime-tags/src/html/assets.ts` › `_flush_head` | 2026-07-19 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/common-helpers.test.ts
+++ b/packages/runtime-tags/src/__tests__/common-helpers.test.ts
@@ -153,5 +153,16 @@ describe("runtime-tags/common/helpers", () => {
       });
       assert.equal(calls.length, 0);
     });
+
+    it("warns when NaN or 0n drops a declaration", () => {
+      const calls = captureWarns(() => {
+        assert.equal(styleValue({ width: NaN }), "");
+        assert.equal(styleValue({ width: 0n }), "");
+        assert.equal(styleValue({ width: 0 }), "width:0");
+      });
+      assert.equal(calls.length, 2);
+      assert.match(calls[0], /`width` style value `NaN` drops the declaration/);
+      assert.match(calls[1], /`width` style value `0n` drops the declaration/);
+    });
   });
 });

--- a/packages/runtime-tags/src/__tests__/html-content.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-content.test.ts
@@ -156,4 +156,45 @@ describe("runtime-tags/html/content", () => {
       );
     });
   });
+
+  describe("silently dropped text values", () => {
+    const captureWarns = (fn: () => void) => {
+      const calls: string[] = [];
+      const original = console.warn;
+      console.warn = (msg: string) => calls.push(msg);
+      try {
+        fn();
+      } finally {
+        console.warn = original;
+      }
+      return calls;
+    };
+
+    it("warns when NaN renders as nothing", () => {
+      const calls = captureWarns(() => {
+        assert.equal(helpers._to_text(NaN), "");
+        assert.equal(helpers._escape(NaN), "");
+      });
+      assert.equal(calls.length, 2);
+      assert.match(calls[0], /`NaN` renders as nothing/);
+    });
+
+    it("warns when 0n renders as nothing", () => {
+      const calls = captureWarns(() => {
+        assert.equal(helpers._to_text(0n), "");
+      });
+      assert.equal(calls.length, 1);
+      assert.match(calls[0], /`0n` renders as nothing/);
+    });
+
+    it("does not warn for values that render", () => {
+      const calls = captureWarns(() => {
+        assert.equal(helpers._to_text(0), "0");
+        assert.equal(helpers._to_text(1n), "1");
+        assert.equal(helpers._to_text(""), "");
+        assert.equal(helpers._to_text(null), "");
+      });
+      assert.equal(calls.length, 0);
+    });
+  });
 });

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -36,6 +36,21 @@ export function assertValidTextValue(value: unknown) {
   if (unrenderable) {
     throw new Error(`Text content cannot be ${unrenderable}.`);
   }
+  if (isSilentlyDropped(value)) {
+    console.warn(
+      `Text content of \`${describeDropped(value)}\` renders as nothing; convert it to a string or number to render it.`,
+    );
+  }
+}
+
+// `NaN` and bigint `0n` are dropped by the falsiness checks in the writers
+// (only numeric 0 is special-cased there), so surface the drop in debug.
+function isSilentlyDropped(value: unknown) {
+  return value !== value || (typeof value === "bigint" && !value);
+}
+
+function describeDropped(value: unknown) {
+  return value !== value ? "NaN" : "0n";
 }
 
 function describeUnrenderable(value: unknown) {

--- a/packages/runtime-tags/src/common/helpers.ts
+++ b/packages/runtime-tags/src/common/helpers.ts
@@ -72,6 +72,16 @@ export function stringifyStyleObject(name: string, value: unknown) {
         .replace(/^ms-/, "-ms-")}\`.`,
     );
   }
+  // `NaN`/`0n` fail the falsiness check below (only numeric 0 is
+  // special-cased), silently dropping the whole declaration.
+  if (
+    MARKO_DEBUG &&
+    (value !== value || (typeof value === "bigint" && !value))
+  ) {
+    console.warn(
+      `The \`${name}\` style value \`${value !== value ? "NaN" : "0n"}\` drops the declaration; convert it to a string or number to render it.`,
+    );
+  }
   // Escape `;`/`\` in name and value so neither can inject another declaration
   // (SSR); other chars aren't structural in a style attribute. `width:0` renders.
   return value || value === 0


### PR DESCRIPTION
Text and style-object writers use `value || value === 0`, so `NaN` and bigint `0n` render as nothing with no signal — `assertValidTextValue` only rejects symbols and objects — while attributes stringify them. This adds a `MARKO_DEBUG`-only `console.warn` in `assertValidTextValue` (covering the html and dom text paths) and `stringifyStyleObject` when such a value is dropped. No optimized-bundle size impact. Resolves the corresponding `agent-feedback/unclear.md` entry.