### PR TITLE
cheatsheet: parenthesized comparison in the control-flow example

### DIFF
--- a/packages/runtime-tags/cheatsheet.md
+++ b/packages/runtime-tags/cheatsheet.md
@@ -58,7 +58,7 @@ Marko 6 = HTML superset. NOT JSX, NOT old Marko 4/5. `.marko` files are componen
 ## Control flow
 
 ```marko
-<if=cond> A </if>
+<if=(count > 10)> A </if>   // parenthesize comparisons — a bare `>` ends the tag (rule 2)
 <else if=other> B </else>
 <else> C </else>
 


### PR DESCRIPTION
The control-flow example showed `<if=cond>` with no comparison in sight, while the `>`-ends-the-tag trap is only covered in prose (golden rule 2 and the DON'T table). An A/B test with small-model agents writing Marko showed a single parenthesized comparison example eliminates the trap on first attempt (6/8 agents wrote the broken unenclosed form without it, 0/8 with it), so the canonical example now demonstrates the idiom directly.