### PR TITLE
fix(runtime-tags): name the real handler attribute in the SSR controllable assertion

### DIFF
--- a/.changeset/ssr-controllable-handler-name.md
+++ b/.changeset/ssr-controllable-handler-name.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Name the actual handler attribute (`checkedChange`, `checkedValueChange`, `openChange`, …) in the server-side controllable debug assertion instead of always reporting `valueChange`.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -116,12 +116,6 @@ The React `useEffect` habit compiles clean and leaks: `<script>const id = setInt
 
 `parseVar` parses a tag variable as `(${str})=>{}` to reuse Babel's binding-pattern grammar and relays Babel's raw message, so `<div/my-el>hi</div>` and `<input/card-input>` compile-fail with `Binding invalid left-hand side in function parameter list.` — naming a parameter list the author never wrote and never mentioning tag variables. That is below the repo's own standard (`packages/runtime-tags/AGENTS.md`: backticked names plus a markojs.com docs link); `<let x=0>` gets a fully tailored message. Detect the parameter-list family of parse errors in `parseVar` and rethrow as e.g. "`my-el` is not a valid [tag variable](https://markojs.com/docs/reference/language#tag-variables); use a JavaScript identifier or destructuring pattern". Distinct from the `parser.js` › `onError`/`onText` entries, which cover htmljs-parser messages. Re-verify: `pnpm run compile -o dom -d file.marko` on `<div/my-el>hi</div>` and observe the Babel message.
 
-## Name the actual handler attribute in SSR's controllable assertion instead of hardcoding `valueChange`
-
-`packages/runtime-tags/src/html/attrs.ts` › `writeControlledScope` | 2026-07-27 | impact:low | effort:low
-
-All six typed SSR controllable helpers (`_attr_input_checked`, `_attr_input_checkedValue`, `_attr_details_or_dialog_open`, `_attr_select_value`, `_attr_input_value`, `_attr_textarea_value`) funnel into `writeControlledScope`, whose MARKO_DEBUG guard calls `assertHandlerIsFunction("valueChange", valueChange)`, so a non-function `checkedChange`, `checkedValueChange` or `openChange` throws naming an attribute the author never wrote. `dom/controllable.ts` passes the real name at all five of its call sites, so the identical authoring mistake reads correctly on the client and misdirects on the server — the one an SSR-first render surfaces. `writeControlledScope` already receives the `ControlledType`, which maps 1:1 onto the handler name (`common/constants/controlled-type.ts`), so derive it there under debug or thread the name in per call site. Re-verify: `_attr_input_checked(0, "#input/0", true, "oops")` must report `checkedChange`, not `valueChange`.
-
 ## Reject unknown attribute tags on `<try>` — a `<@placholder>`/`<@cath>` typo compiles clean and silently drops the pending/error UI
 
 `packages/runtime-tags/src/translator/core/try.ts` › `analyze` | 2026-07-27 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/html-attrs.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-attrs.test.ts
@@ -280,4 +280,27 @@ describe("runtime-tags/html/attrs", () => {
       );
     });
   });
+
+  describe("controlled handler assertions", () => {
+    it("names the handler attribute the author wrote", () => {
+      assert.throws(
+        () => helpers._attr_input_checked(0, "#input/0", true, "oops"),
+        /`checkedChange`/,
+      );
+      assert.throws(
+        () =>
+          helpers._attr_input_checkedValue(0, "#input/0", true, "oops", "x"),
+        /`checkedValueChange`/,
+      );
+      assert.throws(
+        () =>
+          helpers._attr_details_or_dialog_open(0, "#details/0", true, "oops"),
+        /`openChange`/,
+      );
+      assert.throws(
+        () => helpers._attr_input_value(0, "#input/0", "x", "oops"),
+        /`valueChange`/,
+      );
+    });
+  });
 });

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -430,7 +430,18 @@ function writeControlledScope(
   serializeType?: 1,
 ) {
   if (MARKO_DEBUG) {
-    assertHandlerIsFunction("valueChange", valueChange);
+    // Indexed by `ControlledType` so the error names the attribute the
+    // author wrote, matching the client-side assertions in dom/controllable.ts.
+    assertHandlerIsFunction(
+      [
+        "checkedChange",
+        "checkedValueChange",
+        "valueChange",
+        "valueChange",
+        "openChange",
+      ][type]!,
+      valueChange,
+    );
   }
 
   _scope(


### PR DESCRIPTION
The six typed SSR controllable helpers all funnel into `writeControlledScope`, whose `MARKO_DEBUG` guard hardcoded `valueChange` in `assertHandlerIsFunction`, so a non-function `checkedChange`, `checkedValueChange` or `openChange` threw naming an attribute the author never wrote — while the client-side assertions in `dom/controllable.ts` already report the right name. The name is now derived from the `ControlledType` the function already receives. Debug-only, no optimized-bundle impact. Resolves the corresponding `agent-feedback/dx.md` entry.