### PR TITLE
fix(runtime-tags): repair the dead markojs.com links in errors and autocomplete

### DIFF
--- a/.changeset/fix-dead-docs-links.md
+++ b/.changeset/fix-dead-docs-links.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix dead markojs.com links in compile errors and editor autocomplete: `/docs/syntax/` URLs now point at the language reference, and core-tag anchors account for headings that differ from the tag name.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -74,12 +74,6 @@ The `after(cleanupSnapshots)` hook `fs.rmSync`s every entry of any `__snapshots_
 
 When `startSection(tagBody)` returns undefined, `analyze` calls `dropNodes(getAllTagReferenceNodes(tag.node))` and returns, so `<div><for|x| of=input.list/></div>` compiles to `_html("<div></div>")` — the `of=` expression is never evaluated — with no diagnostic in any mode. Every other body-requiring core tag raises a code frame for the same mistake: `core/if.ts` › `assertHasBody`, `core/show.ts` › `assertHasBody`, `core/try.ts` › `analyze`, `core/await.ts` › `analyze`. A `<for>` body is the tag's only output, so an empty one is always an authoring mistake, and today it costs a debugging cycle where `<if>` gives an immediate caret. Add the same check before the `dropNodes` fast path plus an `error-for-empty-body` fixture — the `error-for-*` family has ten cases and none is an empty body. Re-verify: `pnpm run compile -o html -d` that template succeeds, while `<div><if=input.list/></div>` fails.
 
-## Fix the dead markojs.com links core tags hand to users: `/docs/syntax/` and synthesized `core-tag#<tagName>` anchors
-
-`packages/runtime-tags/src/translator/core/import.ts` › `autocomplete` | 2026-07-23 | impact:low | effort:low
-
-`import.ts` (both its error message and `descriptionMoreURL`), `static.ts`, `server.ts` and `client.ts` point at `https://markojs.com/docs/syntax/#…`, which now returns 404; the live targets are `docs/reference/language#import`, `#static` and `#server-and-client`. The same breakage lives in `packages/runtime-tags/src/translator/util/assert.ts` › `assertNoSpreadAttrs` and `assertNoBodyContent`, which build the anchor as `core-tag#${tagName}` — only correct when a tag's docs heading is its bare name. Compiling `<if=input.x ...input.attrs>a</if>` emits `core-tag#if` when the real anchor is `#if--else`, and `<else>`, `<else-if>`, `<effect>` and `<attrs>` (all callers of these helpers) have no anchor at all. Replace the `/docs/syntax/` URLs and give the assert helpers an explicit anchor argument or tag-name→anchor map instead of interpolating the tag name. Re-verify: `rg -n "docs/syntax" packages/runtime-tags/src` lists the call sites, and the `<if>` spread compile prints `core-tag#if`.
-
 ## Raise the unresolvable-tag-name error during analyze; at translate its `<let>`/`<const>` hint is lost and only the first bad tag reports
 
 `packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `tagNotFoundError` | 2026-07-23 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag#effect) tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag#effect) tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag#effect) tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-effect-body-content/template.marko:1:2
     > 1 | <effect=(() => {})>Hello</effect>
-        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag#effect) tag does not support body content.
+        |  ^^^^^^ The [`<effect>`](https://markojs.com/docs/reference/core-tag) tag does not support body content.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.debug.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
     > 1 | import { a } from "./a.js"; import { b } from "./b.js"
-        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/reference/language#import) takes a single import statement.
       2 | <div>${a}${b}</div>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-dom.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
     > 1 | import { a } from "./a.js"; import { b } from "./b.js"
-        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/reference/language#import) takes a single import statement.
       2 | <div>${a}${b}</div>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.debug.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
     > 1 | import { a } from "./a.js"; import { b } from "./b.js"
-        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/reference/language#import) takes a single import statement.
       2 | <div>${a}${b}</div>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/__snapshots__/error-compile-html.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-import-multiple-statements/template.marko:1:29
     > 1 | import { a } from "./a.js"; import { b } from "./b.js"
-        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.
+        |                             ^^^^^^^^^^^^^^^^^^^^^^^^^^ The [`<import>` tag](https://markojs.com/docs/reference/language#import) takes a single import statement.
       2 | <div>${a}${b}</div>
       3 |

--- a/packages/runtime-tags/src/translator/core/import.ts
+++ b/packages/runtime-tags/src/translator/core/import.ts
@@ -13,7 +13,7 @@ export default {
     if (statements.length > 1) {
       throw tag.hub.buildError(
         statements[1],
-        "The [`<import>` tag](https://markojs.com/docs/syntax/#importing-external-files) takes a single import statement.",
+        "The [`<import>` tag](https://markojs.com/docs/reference/language#import) takes a single import statement.",
       );
     }
 
@@ -29,8 +29,7 @@ export default {
       description:
         "Use to import external modules, follows the same syntax as JavaScript imports.",
       snippet: 'import ${2} from "${1:path}"',
-      descriptionMoreURL:
-        "https://markojs.com/docs/syntax/#importing-external-files",
+      descriptionMoreURL: "https://markojs.com/docs/reference/language#import",
     },
   ],
 } as Tag;

--- a/packages/runtime-tags/src/translator/util/assert.ts
+++ b/packages/runtime-tags/src/translator/util/assert.ts
@@ -1,11 +1,26 @@
 import type { types as t } from "@marko/compiler";
 
+// Tags whose docs heading is not their bare name; "" links the page root
+// for tags with no heading of their own.
+const docsAnchors: Record<string, string | undefined> = {
+  if: "if--else",
+  "else-if": "if--else",
+  else: "if--else",
+  effect: "",
+  attrs: "",
+};
+
+function coreTagDocsURL(tagName: string) {
+  const anchor = docsAnchors[tagName] ?? tagName;
+  return `https://markojs.com/docs/reference/core-tag${anchor && "#" + anchor}`;
+}
+
 export function assertNoSpreadAttrs(tag: t.NodePath<t.MarkoTag>) {
   for (const attr of tag.get("attributes")) {
     if (attr.isMarkoSpreadAttribute()) {
       const tagName = (tag.get("name").node as t.StringLiteral).value;
       throw attr.buildCodeFrameError(
-        `The [\`<${tagName}>\`](https://markojs.com/docs/reference/core-tag#${tagName}) tag does not support \`...spread\` attributes.`,
+        `The [\`<${tagName}>\`](${coreTagDocsURL(tagName)}) tag does not support \`...spread\` attributes.`,
       );
     }
   }
@@ -35,7 +50,7 @@ export function assertNoBodyContent(tag: t.NodePath<t.MarkoTag>) {
     const tagName = tag.get("name");
     const tagNameLiteral = (tagName.node as t.StringLiteral).value;
     throw tagName.buildCodeFrameError(
-      `The [\`<${tagNameLiteral}>\`](https://markojs.com/docs/reference/core-tag#${tagNameLiteral}) tag does not support body content.`,
+      `The [\`<${tagNameLiteral}>\`](${coreTagDocsURL(tagNameLiteral)}) tag does not support body content.`,
     );
   }
 }

--- a/packages/runtime-tags/src/translator/util/statement-tag.ts
+++ b/packages/runtime-tags/src/translator/util/statement-tag.ts
@@ -30,7 +30,7 @@ export function createStatementTag(keyword: "client" | "server" | "static") {
       {
         displayText: `${keyword} <statement>`,
         description: `A JavaScript statement which is only evaluated once your template is loaded${target ? ` on the ${target}` : ""}.`,
-        descriptionMoreURL: `https://markojs.com/docs/syntax/#${keyword}-javascript`,
+        descriptionMoreURL: `https://markojs.com/docs/reference/language#${keyword === "static" ? "static" : "server-and-client"}`,
       },
     ],
   } as Tag;


### PR DESCRIPTION
The `/docs/syntax/#…` URLs in `core/import.ts` and `util/statement-tag.ts` return 404; they now point at the live `docs/reference/language` anchors (`#import`, `#static`, `#server-and-client`). The assert helpers in `util/assert.ts` synthesized `core-tag#<tagName>` anchors, wrong for the `<if>`/`<else-if>`/`<else>` chain (real anchor `#if--else`) and for `<effect>`/`<attrs>` which have no heading — a small anchor map now handles those. Affected error-fixture snapshots regenerated. Resolves the corresponding `agent-feedback/dx.md` entry.