### PR TITLE
feat(runtime-tags): warn when a script body returns a cleanup function

### DIFF
--- a/.changeset/warn-script-return-cleanup.md
+++ b/.changeset/warn-script-return-cleanup.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Warn at compile time when a `<script>` body returns a cleanup function, which is discarded; point at `$signal.onabort` and `<lifecycle onDestroy>`.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -80,12 +80,6 @@ The `after(cleanupSnapshots)` hook `fs.rmSync`s every entry of any `__snapshots_
 
 `stats.dom` is filled only by the `dom` test and `stats.html` only by the `ssr` test, yet the optimize `after()` hook always compares the whole `stats` object — so a run scoped to one mode asserts `{}` against a populated file and reports `sizes.json out of date for "attr-class" — run pnpm run test:update`. Following that advice with the same grep writes `{}\n` over a file AGENTS.md marks generated and never hand-editable. Skip the gate when mocha's options carry `--grep`/`--fgrep`, and say the numbers are incomplete because the run was scoped. The matching snapshot-prune defect is the entry "Prune only snapshots whose tests actually ran; `test:update` deletes snapshots for skipped or bailed tests", which owns the `utils/snap.ts` anchor; fix both together. The same hook's `!hasCompilerError` gate is a separate defect — see "Delete or assert the absence of `sizes.json` for `error_compiler` fixtures" — whose fix must sit outside the mode loop. Re-verify: `pnpm test -- --grep "runtime-tags/translator attr-class optimize html"` → false "out of date" failure.
 
-## Warn when a `<script>` body returns a cleanup function — the value is discarded
-
-`packages/runtime-tags/src/translator/core/script.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low
-
-The React `useEffect` habit compiles clean and leaks: `<script>const id = setInterval(() => n++, 1000); return () => clearInterval(id);</script>` becomes `_script(..., $scope => (() => { ... return () => clearInterval(id); })())` — the top-level `return` blocks inlining, so the IIFE fallback drops the cleanup and the interval outlives the component with no error, warning or `meta.diagnostics` entry. Marko's cleanup channel is `$signal.onabort` (`cheatsheet.md`, "Client-side effects") or `<lifecycle onDestroy>`, and nothing in the output points there. `translate.exit` already runs `traverseContains(value.body, isReturnStatement)`; narrow a variant of it to a `return` whose argument is a function or arrow — a bare `return;` must stay silent — and `diagnosticWarn` naming both APIs. Re-verify: `pnpm run compile -o dom -d file.marko` on that template and observe the returned arrow inside the emitted IIFE with empty diagnostics.
-
 ## Reject unknown attribute tags on `<try>` — a `<@placholder>`/`<@cath>` typo compiles clean and silently drops the pending/error UI
 
 `packages/runtime-tags/src/translator/core/try.ts` › `analyze` | 2026-07-27 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/diagnostics.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/diagnostics.md
@@ -1,0 +1,3 @@
+# Diagnostics
+
+- `template.marko` warning: The value returned from a [`<script>`](https://markojs.com/docs/reference/core-tag#script) body is discarded, so this cleanup function will never run. Register it with [`$signal.onabort`](https://markojs.com/docs/reference/language#signal) or use [`<lifecycle onDestroy>`](https://markojs.com/docs/reference/core-tag#lifecycle) instead.

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$n($scope, $scope.n + 1);
+	});
+	(() => {
+		const handler = () => {};
+		window.addEventListener("resize", handler);
+		return () => window.removeEventListener("resize", handler);
+	})();
+});
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/dom.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.a, "click", function() {
+		$n($scope, $scope.c + 1);
+	});
+	(() => {
+		const handler = () => {};
+		window.addEventListener("resize", handler);
+		return () => window.removeEventListener("resize", handler);
+	})();
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/render.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/render.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<button>0<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<button>0<!--M_*1 b--></button><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2713,
+      "brotli": 1361
+    }
+  },
+  "html": {
+    "min": 352,
+    "brotli": 246
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/template.marko
@@ -1,0 +1,7 @@
+<let/n=0>
+<button onClick() { n++ }>${n}</button>
+<script>
+  const handler = () => {};
+  window.addEventListener("resize", handler);
+  return () => window.removeEventListener("resize", handler);
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/core/script.ts
+++ b/packages/runtime-tags/src/translator/core/script.ts
@@ -3,6 +3,7 @@ import {
   assertNoArgs,
   assertNoAttributeTags,
   assertNoParams,
+  diagnosticWarn,
   getProgram,
   parseStatements,
   type Tag,
@@ -106,6 +107,19 @@ export default {
       const section = getSection(tag);
       const { value } = valueAttr;
       const referencedBindings = value.extra?.referencedBindings;
+
+      // The React `useEffect` habit: a returned cleanup function is discarded,
+      // so the effect leaks with no signal at compile or run time.
+      if (
+        (t.isFunctionExpression(value) || t.isArrowFunctionExpression(value)) &&
+        t.isBlockStatement(value.body) &&
+        traverseContains(value.body, isReturnedFunction)
+      ) {
+        diagnosticWarn(tag, {
+          label:
+            "The value returned from a [`<script>`](https://markojs.com/docs/reference/core-tag#script) body is discarded, so this cleanup function will never run. Register it with [`$signal.onabort`](https://markojs.com/docs/reference/language#signal) or use [`<lifecycle onDestroy>`](https://markojs.com/docs/reference/core-tag#lifecycle) instead.",
+        });
+      }
       if (isOutputDOM()) {
         const isFunction =
           t.isFunctionExpression(value) || t.isArrowFunctionExpression(value);
@@ -173,6 +187,25 @@ function isAwaitExpression(node: t.Node) {
       return skip;
     case "AwaitExpression":
       return true;
+    default:
+      return false;
+  }
+}
+
+function isReturnedFunction(node: t.Node) {
+  switch (node.type) {
+    case "FunctionDeclaration":
+    case "FunctionExpression":
+    case "ArrowFunctionExpression":
+    case "ClassMethod":
+    case "ObjectMethod":
+    case "ClassPrivateMethod":
+      return skip;
+    case "ReturnStatement":
+      return (
+        t.isFunctionExpression(node.argument) ||
+        t.isArrowFunctionExpression(node.argument)
+      );
     default:
       return false;
   }


### PR DESCRIPTION
A top-level `return () => …` from a `<script>` body — the React `useEffect` cleanup habit — compiles clean but the returned function is discarded, so the effect leaks with no signal at compile or run time. The translator now emits a `diagnosticWarn` pointing at Marko's cleanup channels (`$signal.onabort`, `<lifecycle onDestroy>`); a bare `return;` stays silent. Fixture snapshots the diagnostic. Resolves the corresponding `agent-feedback/dx.md` entry.