### PR TITLE
fix(runtime-tags): name the variable and the rule in reference-tracker errors

### DIFF
--- a/.changeset/reword-references-errors.md
+++ b/.changeset/reword-references-errors.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Reword the tag-variable compile errors in the reference tracker to name the variable and link the docs — including the former "Cannot assign to hoisted tag variable.", which now explains the positional rule.

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -44,12 +44,6 @@ Positional file args are unioned with the configured `spec` glob rather than rep
 
 Neither type has a case in `writeUnknownObject`, and `writeFormData` aborts on any non-string entry ("`File`/`Blob` entries aren't serializable yet"), so a resumed form carrying an upload cannot be represented at all. Both hold binary content the existing `writeArrayBuffer`/`writeTypedArray` path already encodes and both rebuild from a constructor call (`new File([bytes], name, { type, lastModified })`); the work is reading the bytes and threading the async read through the boundary the way `writeReadableStream` does. Verify: `serializer.test.ts`'s "aborts on File/Blob values instead of dropping them" pins today's behavior, and a bare `new Blob(["hi"])` hits `throwUnserializable`.
 
-## Name the variable and the positional rule in `Cannot assign to hoisted tag variable.`
-
-`packages/runtime-tags/src/translator/util/references.ts` › `trackReferencesForBinding` | 2026-07-23 | impact:med | effort:low
-
-Assigning a `<let>` from a handler that sits _above_ the `<let>` fails with that bare message: "hoisted" is compiler jargon and it names neither the variable nor the fix, which is simply to move the declaration above the assignment. It is one of nine user-facing errors in `references.ts`, none of which follow the backticked-name-plus-markojs.com-link convention `packages/runtime-tags/AGENTS.md` documents and `core/if.ts` demonstrates; `Duplicate declaration "x"` even uses `JSON.stringify` quotes where house style is backticks. Reword to name the variable and the positional rule and link `https://markojs.com/docs/reference/language#tag-variables`. Verify: compile `<button onClick() { x = 2 }>b</button>` above `<let/x=1/>` for the jargon-only message; swapping the two lines compiles cleanly.
-
 ## Unit-test the pure `Opt`/`Sorted` helpers in `translator/util/optional.ts`
 
 `packages/runtime-tags/src/translator/util/optional.ts` › `Sorted` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.debug.txt
@@ -3,7 +3,7 @@
       1 | <button onClick() {
       2 |   lastClickCount = clickCount;
     > 3 |   clickCount++;
-        |   ^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^ `clickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
@@ -11,7 +11,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
       1 | <button onClick() {
     > 2 |   lastClickCount = clickCount;
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `lastClickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       3 |   clickCount++;
       4 | }>+</button>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-dom.txt
@@ -3,7 +3,7 @@
       1 | <button onClick() {
       2 |   lastClickCount = clickCount;
     > 3 |   clickCount++;
-        |   ^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^ `clickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
@@ -11,7 +11,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
       1 | <button onClick() {
     > 2 |   lastClickCount = clickCount;
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `lastClickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       3 |   clickCount++;
       4 | }>+</button>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.debug.txt
@@ -3,7 +3,7 @@
       1 | <button onClick() {
       2 |   lastClickCount = clickCount;
     > 3 |   clickCount++;
-        |   ^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^ `clickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
@@ -11,7 +11,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
       1 | <button onClick() {
     > 2 |   lastClickCount = clickCount;
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `lastClickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       3 |   clickCount++;
       4 | }>+</button>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/__snapshots__/error-compile-html.txt
@@ -3,7 +3,7 @@
       1 | <button onClick() {
       2 |   lastClickCount = clickCount;
     > 3 |   clickCount++;
-        |   ^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^ `clickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       4 | }>+</button>
       5 |
       6 | <let/clickCount = 0/>
@@ -11,7 +11,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/assignment-before-tag-var/template.marko:2:3
       1 | <button onClick() {
     > 2 |   lastClickCount = clickCount;
-        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ Cannot assign to hoisted tag variable.
+        |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `lastClickCount` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.
       3 |   clickCount++;
       4 | }>+</button>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-dom.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/template.marko:2:10
       1 | <define/Tag|{ x }|>
     > 2 |   <div>${x++}</>
-        |          ^ Assignments to a tag parameter must be within a script or function.
+        |          ^ `x` is a tag parameter and can only be assigned within a script or function.
       3 | </define>
       4 |
       5 | <let/x=1>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-dom.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/template.marko:2:10
       1 | <define/Tag|{ x }|>
     > 2 |   <div>${x++}</>
-        |          ^ Assignments to a tag parameter must be within a script or function.
+        |          ^ `x` is a tag parameter and can only be assigned within a script or function.
       3 | </define>
       4 |
       5 | <let/x=1>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-html.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/template.marko:2:10
       1 | <define/Tag|{ x }|>
     > 2 |   <div>${x++}</>
-        |          ^ Assignments to a tag parameter must be within a script or function.
+        |          ^ `x` is a tag parameter and can only be assigned within a script or function.
       3 | </define>
       4 |
       5 | <let/x=1>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/__snapshots__/error-compile-html.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-param-in-render/template.marko:2:10
       1 | <define/Tag|{ x }|>
     > 2 |   <div>${x++}</>
-        |          ^ Assignments to a tag parameter must be within a script or function.
+        |          ^ `x` is a tag parameter and can only be assigned within a script or function.
       3 | </define>
       4 |
       5 | <let/x=1>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-dom.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/template.marko:2:8
       1 | <let/x=1>
     > 2 | <div>${x++}</>
-        |        ^ Assignments to a tag variable must be within a script or function.
+        |        ^ `x` is a tag variable and can only be assigned within a script or function.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-dom.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/template.marko:2:8
       1 | <let/x=1>
     > 2 | <div>${x++}</>
-        |        ^ Assignments to a tag variable must be within a script or function.
+        |        ^ `x` is a tag variable and can only be assigned within a script or function.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-html.debug.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/template.marko:2:8
       1 | <let/x=1>
     > 2 | <div>${x++}</>
-        |        ^ Assignments to a tag variable must be within a script or function.
+        |        ^ `x` is a tag variable and can only be assigned within a script or function.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/__snapshots__/error-compile-html.txt
@@ -2,5 +2,5 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-assign-to-tag-var-in-render/template.marko:2:8
       1 | <let/x=1>
     > 2 | <div>${x++}</>
-        |        ^ Assignments to a tag variable must be within a script or function.
+        |        ^ `x` is a tag variable and can only be assigned within a script or function.
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-dom.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/template.marko:2:10
       1 | <define/Foo|bar|>
     > 2 |   <const/bar = 1>
-        |          ^^^ Duplicate declaration "bar"
+        |          ^^^ Duplicate declaration of `bar`.
       3 |   <script>
       4 |     console.log(bar)
       5 |   </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-dom.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/template.marko:2:10
       1 | <define/Foo|bar|>
     > 2 |   <const/bar = 1>
-        |          ^^^ Duplicate declaration "bar"
+        |          ^^^ Duplicate declaration of `bar`.
       3 |   <script>
       4 |     console.log(bar)
       5 |   </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-html.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/template.marko:2:10
       1 | <define/Foo|bar|>
     > 2 |   <const/bar = 1>
-        |          ^^^ Duplicate declaration "bar"
+        |          ^^^ Duplicate declaration of `bar`.
       3 |   <script>
       4 |     console.log(bar)
       5 |   </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/__snapshots__/error-compile-html.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-duplicate-declaration/template.marko:2:10
       1 | <define/Foo|bar|>
     > 2 |   <const/bar = 1>
-        |          ^^^ Duplicate declaration "bar"
+        |          ^^^ Duplicate declaration of `bar`.
       3 |   <script>
       4 |     console.log(bar)
       5 |   </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-dom.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/template.marko:1:8
     > 1 | <const/input=1>
-        |        ^^^^^ Duplicate declaration "input"
+        |        ^^^^^ Duplicate declaration of `input`.
       2 | <script>
       3 |   console.log(input)
       4 | </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-dom.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/template.marko:1:8
     > 1 | <const/input=1>
-        |        ^^^^^ Duplicate declaration "input"
+        |        ^^^^^ Duplicate declaration of `input`.
       2 | <script>
       3 |   console.log(input)
       4 | </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-html.debug.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/template.marko:1:8
     > 1 | <const/input=1>
-        |        ^^^^^ Duplicate declaration "input"
+        |        ^^^^^ Duplicate declaration of `input`.
       2 | <script>
       3 |   console.log(input)
       4 | </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/__snapshots__/error-compile-html.txt
@@ -1,7 +1,7 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/error-input-shadow/template.marko:1:8
     > 1 | <const/input=1>
-        |        ^^^^^ Duplicate declaration "input"
+        |        ^^^^^ Duplicate declaration of `input`.
       2 | <script>
       3 |   console.log(input)
       4 | </>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-dom.debug.txt
@@ -3,6 +3,6 @@
       1 | <div/el/>
       2 | <script>
     > 3 |   el = 1;
-        |   ^^^^^^ Tag variables on native elements cannot be assigned to.
+        |   ^^^^^^ `el` is a [tag variable](https://markojs.com/docs/reference/language#tag-variables) on a native element (an element reference) and cannot be assigned to.
       4 | </script>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-dom.txt
@@ -3,6 +3,6 @@
       1 | <div/el/>
       2 | <script>
     > 3 |   el = 1;
-        |   ^^^^^^ Tag variables on native elements cannot be assigned to.
+        |   ^^^^^^ `el` is a [tag variable](https://markojs.com/docs/reference/language#tag-variables) on a native element (an element reference) and cannot be assigned to.
       4 | </script>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-html.debug.txt
@@ -3,6 +3,6 @@
       1 | <div/el/>
       2 | <script>
     > 3 |   el = 1;
-        |   ^^^^^^ Tag variables on native elements cannot be assigned to.
+        |   ^^^^^^ `el` is a [tag variable](https://markojs.com/docs/reference/language#tag-variables) on a native element (an element reference) and cannot be assigned to.
       4 | </script>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-assign/__snapshots__/error-compile-html.txt
@@ -3,6 +3,6 @@
       1 | <div/el/>
       2 | <script>
     > 3 |   el = 1;
-        |   ^^^^^^ Tag variables on native elements cannot be assigned to.
+        |   ^^^^^^ `el` is a [tag variable](https://markojs.com/docs/reference/language#tag-variables) on a native element (an element reference) and cannot be assigned to.
       4 | </script>
       5 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-dom.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/template.marko:2:7
       1 | <div/el/>
     > 2 | <span/el/>
-        |       ^^ Duplicate declaration "el"
+        |       ^^ Duplicate declaration of `el`.
       3 | <script>
       4 |   console.log(el);
       5 | </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-dom.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/template.marko:2:7
       1 | <div/el/>
     > 2 | <span/el/>
-        |       ^^ Duplicate declaration "el"
+        |       ^^ Duplicate declaration of `el`.
       3 | <script>
       4 |   console.log(el);
       5 | </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-html.debug.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/template.marko:2:7
       1 | <div/el/>
     > 2 | <span/el/>
-        |       ^^ Duplicate declaration "el"
+        |       ^^ Duplicate declaration of `el`.
       3 | <script>
       4 |   console.log(el);
       5 | </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/__snapshots__/error-compile-html.txt
@@ -2,7 +2,7 @@
     at packages/runtime-tags/src/__tests__/fixtures/error-native-tag-var-duplicate/template.marko:2:7
       1 | <div/el/>
     > 2 | <span/el/>
-        |       ^^ Duplicate declaration "el"
+        |       ^^ Duplicate declaration of `el`.
       3 | <script>
       4 |   console.log(el);
       5 | </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-dom.debug.txt
@@ -3,5 +3,5 @@
       4 | </define>
       5 |
     > 6 | <Child/foo onClick() { foo().innerHTML = 'clicked' } />
-        |                        ^^^ Tag variable circular references are not supported.
+        |                        ^^^ `foo` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-dom.txt
@@ -3,5 +3,5 @@
       4 | </define>
       5 |
     > 6 | <Child/foo onClick() { foo().innerHTML = 'clicked' } />
-        |                        ^^^ Tag variable circular references are not supported.
+        |                        ^^^ `foo` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-html.debug.txt
@@ -3,5 +3,5 @@
       4 | </define>
       5 |
     > 6 | <Child/foo onClick() { foo().innerHTML = 'clicked' } />
-        |                        ^^^ Tag variable circular references are not supported.
+        |                        ^^^ `foo` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-custom-tag/__snapshots__/error-compile-html.txt
@@ -3,5 +3,5 @@
       4 | </define>
       5 |
     > 6 | <Child/foo onClick() { foo().innerHTML = 'clicked' } />
-        |                        ^^^ Tag variable circular references are not supported.
+        |                        ^^^ `foo` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       7 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-dom.debug.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/template.marko:1:10
     > 1 | <const/x=x/>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 | <${x}>hi</>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-dom.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/template.marko:1:10
     > 1 | <const/x=x/>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 | <${x}>hi</>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-html.debug.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/template.marko:1:10
     > 1 | <const/x=x/>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 | <${x}>hi</>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/__snapshots__/error-compile-html.txt
@@ -1,6 +1,6 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-dynamic-tag/template.marko:1:10
     > 1 | <const/x=x/>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 | <${x}>hi</>
       3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-dom.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-error/template.marko:1:10
     > 1 | <const/x=x + 1>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-dom.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-error/template.marko:1:10
     > 1 | <const/x=x + 1>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-html.debug.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-error/template.marko:1:10
     > 1 | <const/x=x + 1>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-error/__snapshots__/error-compile-html.txt
@@ -1,5 +1,5 @@
 
     at packages/runtime-tags/src/__tests__/fixtures/self-reference-error/template.marko:1:10
     > 1 | <const/x=x + 1>
-        |          ^ Tag variable circular references are not supported.
+        |          ^ `x` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       2 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-dom.debug.txt
@@ -3,6 +3,6 @@
       2 | <button onClick() { items = [...items, items.length] }/>
       3 |
     > 4 | <const/sum = (i = 0) => (i >= items.length ? 0 : items[i] + sum(i + 1))>
-        |                                                             ^^^ Tag variable circular references are not supported.
+        |                                                             ^^^ `sum` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       5 | <div>${sum()}</div>
       6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-dom.txt
@@ -3,6 +3,6 @@
       2 | <button onClick() { items = [...items, items.length] }/>
       3 |
     > 4 | <const/sum = (i = 0) => (i >= items.length ? 0 : items[i] + sum(i + 1))>
-        |                                                             ^^^ Tag variable circular references are not supported.
+        |                                                             ^^^ `sum` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       5 | <div>${sum()}</div>
       6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-html.debug.txt
@@ -3,6 +3,6 @@
       2 | <button onClick() { items = [...items, items.length] }/>
       3 |
     > 4 | <const/sum = (i = 0) => (i >= items.length ? 0 : items[i] + sum(i + 1))>
-        |                                                             ^^^ Tag variable circular references are not supported.
+        |                                                             ^^^ `sum` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       5 | <div>${sum()}</div>
       6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-error/__snapshots__/error-compile-html.txt
@@ -3,6 +3,6 @@
       2 | <button onClick() { items = [...items, items.length] }/>
       3 |
     > 4 | <const/sum = (i = 0) => (i >= items.length ? 0 : items[i] + sum(i + 1))>
-        |                                                             ^^^ Tag variable circular references are not supported.
+        |                                                             ^^^ `sum` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.
       5 | <div>${sum()}</div>
       6 |

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -309,10 +309,10 @@ export function trackDomVarReferences(
         ? ref
             .get("var")
             .buildCodeFrameError(
-              `Duplicate declaration ${JSON.stringify(binding.originalName)}`,
+              `Duplicate declaration of \`${binding.originalName}\`.`,
             )
         : ref.buildCodeFrameError(
-            "Tag variables on native elements cannot be assigned to.",
+            `\`${binding.originalName}\` is a [tag variable](https://markojs.com/docs/reference/language#tag-variables) on a native element (an element reference) and cannot be assigned to.`,
           );
     }
   }
@@ -498,7 +498,7 @@ function trackReferencesForBinding(babelBinding: t.Binding, binding: Binding) {
       markoRoot.parentPath === babelBinding.path
     ) {
       throw ref.buildCodeFrameError(
-        `Tag variable circular references are not supported.`,
+        `\`${ref.node.name}\` is the [tag variable](https://markojs.com/docs/reference/language#tag-variables) this tag declares, so its own attributes cannot read it.`,
       );
     } else if (isReferenceHoisted(babelBinding.path, ref)) {
       const invoked = isInvokedFunction(ref);
@@ -536,13 +536,13 @@ function trackReferencesForBinding(babelBinding: t.Binding, binding: Binding) {
     if (ref.type === "MarkoTag") {
       throw ref
         .get("var")
-        .buildCodeFrameError(
-          `Duplicate declaration ${JSON.stringify(binding.name)}`,
-        );
+        .buildCodeFrameError(`Duplicate declaration of \`${binding.name}\`.`);
     }
 
     if (isReferenceHoisted(babelBinding.path, ref)) {
-      throw ref.buildCodeFrameError("Cannot assign to hoisted tag variable.");
+      throw ref.buildCodeFrameError(
+        `\`${binding.name}\` is declared by a tag below this assignment; a [tag variable](https://markojs.com/docs/reference/language#tag-variables) can only be assigned below its declaration. Move the declaring tag above this code.`,
+      );
     }
 
     if (ref.isUpdateExpression()) {
@@ -573,7 +573,7 @@ function trackAssignment(
   const fnParent = getFnParent(assignment);
   if (!fnParent) {
     throw assignment.buildCodeFrameError(
-      `Assignments to a tag ${binding.type === BindingType.param ? "parameter" : "variable"} must be within a script or function.`,
+      `\`${binding.name}\` is a tag ${binding.type === BindingType.param ? "parameter" : "variable"} and can only be assigned within a script or function.`,
     );
   }
 


### PR DESCRIPTION
`Cannot assign to hoisted tag variable.` named neither the variable nor the fix (declare the `<let>` above the assignment), and the sibling user-facing errors in `util/references.ts` also skipped the repo's backticked-name-plus-docs-link convention (`Duplicate declaration \"x\"` even used JSON quotes). All are reworded to name the variable, state the rule, and link the tag-variables reference; error-fixture snapshots regenerated (message lines only). Resolves the corresponding `agent-feedback/dx.md` entry.