### PR TITLE
Forward rejectLoad into the CSR client runner

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -74,12 +74,6 @@ Neither type has a case in `writeUnknownObject`, and `writeFormData` aborts on a
 
 `mergeTagDef` special-cases only the hook keys and falls through to `value5 ?? value6`, so the Marko 5 `types` stub wins wherever both core taglibs declare one — today exactly `<await>` and `<script>`. Because `marko/translator` is the interop translator and `@marko/compiler`'s default, `@marko/language-tools` resolves those two to `marko/src/core-tags/core/await/index.d.marko` and `.../script.d.marko` even inside a Tags-API `tags/*.marko` file, so editors offer and silently accept `<@then>`/`<@catch>`/`client-reorder`/`timeout` and every html `<script>` attribute — all of which the Marko 6 translator rejects with a hard compile error — precisely in mid-migration projects. Direction: interop-specific stubs whose `Input` unions both APIs, selected when both sides declare `types`. Re-verify: `taglib.buildLookup(".../fixtures-interop/interop-basic-tags-to-class", "marko/translator").getTag("await").types` prints the Marko 5 path instead of `@marko/runtime-tags/tags/await.d.marko`.
 
-## Forward `rejectLoad` from `csr()` into `clientRunner` — `reject_load` is inert in CSR mode
-
-`packages/runtime-tags/src/__tests__/main.test.ts` › `csr` | 2026-07-27 | impact:med | effort:low
-
-`ssr()` builds its jsdom with `createBrowser(runner.assets, config.load_order, rejectLoad)`, but `csr()` calls the bare `createBrowser()` and reaches the client entry through `createServerRunner`'s `clientRunner` (`__tests__/utils/bundle.ts`), which calls `importWithContext(csrFile, { browser: true }, ctx)` with no `rejectLoad` — so `reject_load` never fails the `import("./v:child.marko.input_value.mjs")` the CSR bundle actually performs. A fixture with `reject_load` and no `skip_csr` therefore snapshots a successful lazy load and a `@catch` that never fires; only `fixtures/lazy-tag-input-chunk-load-error`'s easy-to-forget `skip_csr: true` hides that today, and the client-only chunk-failure path has no coverage at all. Thread `rejectLoad` through `clientRunner` into `importWithContext`, or throw at fixture setup when `reject_load` is set without `skip_csr`. Re-verify: drop `skip_csr` from that fixture and read the written CSR snapshot — it ends with `<span id="child">1</span>`, never the `#error` div its `render-ssr.debug.md` records for the same input.
-
 ## Default and validate `translator.tagDiscoveryDirs` in `buildLookup`
 
 `packages/compiler/src/taglib/index.js` › `buildLookup` | 2026-07-27 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/render-csr.debug.md
@@ -1,0 +1,32 @@
+# Render
+```html
+<button
+  id="toggle"
+>
+  toggle
+</button>
+```
+
+# Update
+```js
+document.querySelector("#toggle").click();
+```
+
+# Update
+```html
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div
+  id="error"
+>
+  simulated chunk load failure: ./v:child.marko.input_value.mjs
+</div>
+```
+## Change
+```
+INSERT: #toggle + #error
+UPDATE: #error::text " " => "simulated chunk load failure: ./v:child.marko.input_value.mjs"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/test.ts
@@ -7,7 +7,6 @@ export const config: TestConfig = {
   steps: [{}, wait, toggle, wait],
   reject_load: ["input_value"],
   equivalent: false,
-  skip_csr: true,
 };
 
 function toggle(document: Document) {

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -294,7 +294,10 @@ function testFixtures(interop?: true) {
             const { document } = browser.window;
             const { input, steps } = await getSteps(config);
             const tracker = createMutationTracker(browser);
-            const { template, run } = await runClient(browser.ctx);
+            const { template, run } = await runClient(
+              browser.ctx,
+              rejectLoad || undefined,
+            );
             const instance = template.mount(input, document.body, "afterbegin");
             tracker.logRender(input);
 

--- a/packages/runtime-tags/src/__tests__/utils/bundle.ts
+++ b/packages/runtime-tags/src/__tests__/utils/bundle.ts
@@ -42,7 +42,10 @@ export async function createServerRunner<T extends Record<string, string>>(
   assets: string;
   runServer(): Promise<Record<keyof T, Template>>;
   disposeServer(): void;
-  clientRunner?: (ctx: any) => Promise<{ template: Template; run: RunDOM }>;
+  clientRunner?: (
+    ctx: any,
+    rejectLoad?: (id: string) => boolean,
+  ) => Promise<{ template: Template; run: RunDOM }>;
   domBundle(): Promise<SnapshotResult>;
   htmlBundle(): Promise<SnapshotResult>;
   diagnostics: { id: string; items: Diagnostic[] }[];
@@ -75,11 +78,15 @@ export async function createServerRunner<T extends Record<string, string>>(
     domResult.output.find((c) => c.type === "chunk" && c.name === "csr")
       ?.fileName;
   const clientRunner = csrFileName
-    ? (ctx: any): Promise<{ template: Template; run: RunDOM }> =>
+    ? (
+        ctx: any,
+        rejectLoad?: (id: string) => boolean,
+      ): Promise<{ template: Template; run: RunDOM }> =>
         importWithContext(
           path.join(domOut, csrFileName),
           { browser: true },
           ctx,
+          rejectLoad,
         )
     : undefined;
 


### PR DESCRIPTION
`csr()` reached the client entry through `clientRunner`, which called `importWithContext` without the `rejectLoad` parameter — so a fixture's `reject_load` config never failed the lazy imports the CSR bundle performs, and the client-only chunk-failure path had no coverage. `clientRunner` now accepts and forwards `rejectLoad`, and `lazy-tag-input-chunk-load-error` drops its `skip_csr` — its new CSR snapshot records the `<@catch>` branch firing on the rejected chunk.