### PR TITLE
fix: pass the branch scope, not the fragment marker, to setScopeNodes

### DIFF
--- a/.changeset/resumed-class-rerender-fast-path.md
+++ b/.changeset/resumed-class-rerender-fast-path.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix the tags-compat interop so re-renders of a server-rendered Marko 5 child reuse its fragment directly instead of falling back to a component lookup every time.

--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,12 +2,6 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
-## Pass the branch scope, not the fragment marker, to `setScopeNodes`
-
-`packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js` › `renderAndMorph` | 2026-07-13 | impact:low | effort:low
-
-After `host = rootNode.startNode`, `renderAndMorph` calls `domCompat.setScopeNodes(host, rootNode.startNode, rootNode.endNode)`, writing `#StartNode`/`#EndNode` onto the fragment's DOM marker (a self-assign plus an unused end ref) instead of onto the tags branch `scope`. Since `scope[#StartNode]` never becomes the fragment marker, the `rootNode = host.fragment` fast path can never fire for a resumed child and every re-render falls back to the `___componentLookup` / `___marko5Component.___rootNode` lookup. Correctness is unaffected, so this is a dead optimization plus a misleading invariant; passing `scope` restores it, but check destroy/move first, since the fragment markers sit inside the scope's original start/end range. Re-verify: on a second re-render of a server-rendered class child, `domCompat.getStartNode(scope).fragment` should be set.
-
 ## Extract one helper for the `attrTag`/`attrTags` merge duplicated in `known-tag.ts`
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `translateAttrTag` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js
+++ b/packages/runtime-class/src/runtime/helpers/tags-compat/runtime-dom.js
@@ -178,7 +178,7 @@ exports.p = function (domCompat) {
         );
       }
       host = rootNode.startNode;
-      domCompat.setScopeNodes(host, rootNode.startNode, rootNode.endNode);
+      domCompat.setScopeNodes(scope, rootNode.startNode, rootNode.endNode);
     }
     const existingComponent = scope.___marko5Component;
     const componentsContext = ___getComponentsContext(out);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62292,
-        "brotli": 19211
+        "brotli": 19189
       },
       "files": {
         "components/tags-child.marko": 499,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 64642,
-        "brotli": 20121
+        "brotli": 20140
       },
       "files": {
         "components/tags-child.marko": 624,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62522,
-        "brotli": 19347
+        "brotli": 19301
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63762,
-        "brotli": 19863
+        "brotli": 19846
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63644,
-        "brotli": 19813
+        "brotli": 19807
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62522,
-        "brotli": 19347
+        "brotli": 19301
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63801,
-        "brotli": 19904
+        "brotli": 19862
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62420,
-        "brotli": 19277
+        "brotli": 19280
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62461,
-        "brotli": 19258
+        "brotli": 19283
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63748,
-        "brotli": 19833
+        "brotli": 19802
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63867,
-        "brotli": 19882
+        "brotli": 19832
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62408,
-        "brotli": 19254
+        "brotli": 19255
       },
       "files": {
         "components/class-child.marko": 975,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62573,
-        "brotli": 19361
+        "brotli": 19320
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 64057,
-        "brotli": 19983
+        "brotli": 19985
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62585,
-        "brotli": 19350
+        "brotli": 19338
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 65330,
-        "brotli": 20283
+        "brotli": 20299
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63670,
-        "brotli": 19820
+        "brotli": 19812
       },
       "files": {
         "components/class-layout.marko": 1202,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63693,
-        "brotli": 19822
+        "brotli": 19838
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63975,
-        "brotli": 19948
+        "brotli": 19924
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63762,
-        "brotli": 19837
+        "brotli": 19846
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62824,
-        "brotli": 19456
+        "brotli": 19459
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62496,
-        "brotli": 19315
+        "brotli": 19313
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 64198,
-        "brotli": 19991
+        "brotli": 20042
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63704,
-        "brotli": 19808
+        "brotli": 19822
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 63474,
-        "brotli": 19735
+        "brotli": 19724
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 62881,
-        "brotli": 19485
+        "brotli": 19484
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 64562,
-        "brotli": 20201
+        "brotli": 20182
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,52 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// components/message.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/components/message.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	out.t(input.value, _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+const $template = "<button id=tags> </button><button id=toggle>toggle</button><!><!>";
+const $walks = " D l b%c";
+_resume("__tests__/components/message.marko", _marko_template);
+const $if_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $if_content__count = /*@__PURE__*/ _if_closure("#text/3", 0, ($scope) => $if_content__dynamicTag($scope, _marko_template, () => ({ value: $scope._.count })));
+const $if_content__setup = $if_content__count;
+const $count = /*@__PURE__*/ _let("count/4", ($scope) => {
+	_text($scope["#text/1"], $scope.count);
+	$if_content__count($scope);
+});
+const $if = /*@__PURE__*/ _if("#text/3", "<!><!><!>", "b%", $if_content__setup);
+const $show = /*@__PURE__*/ _let("show/5", ($scope) => $if($scope, $scope.show ? 0 : 1));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_on($scope["#button/0"], "click", function() {
+		$count($scope, $scope.count + 1);
+	});
+	_on($scope["#button/2"], "click", function() {
+		$show($scope, !$scope.show);
+	});
+});
+function $setup($scope) {
+	$count($scope, 0);
+	$show($scope, true);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/dom.bundle.js
@@ -1,0 +1,43 @@
+// components/message.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	out.t(input.value, _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+_resume("b", _marko_template);
+const $if_content__dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
+const $if_content__count = /*@__PURE__*/ _if_closure(3, 0, ($scope) => $if_content__dynamicTag($scope, _marko_template, () => ({ value: $scope._.e })));
+const $if_content__setup = $if_content__count;
+const $count = /*@__PURE__*/ _let(4, ($scope) => {
+	_text($scope.b, $scope.e);
+	$if_content__count($scope);
+});
+const $if = /*@__PURE__*/ _if(3, "<!><!><!>", "b%", $if_content__setup);
+const $show = /*@__PURE__*/ _let(5, ($scope) => $if($scope, $scope.f ? 0 : 1));
+const $setup__script = _script("a0", ($scope) => {
+	_on($scope.a, "click", function() {
+		$count($scope, $scope.e + 1);
+	});
+	_on($scope.c, "click", function() {
+		$show($scope, !$scope.f);
+	});
+});
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,42 @@
+// components/message.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/components/message.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	out.w((0, import_escape_xml.x)(input.value));
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+
+// template.marko
+s("__tests__/components/message.marko", _marko_template);
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	let show = true;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}<button id=toggle>toggle</button>${_el_resume($scope0_id, "#button/2")}`);
+	_if(() => {
+		if (show) {
+			const $scope1_id = _scope_id();
+			_dynamic_tag($scope1_id, "#text/0", _marko_template, { value: count });
+			writeScope($scope1_id, {}, "__tests__/template.marko", "9:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/3");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		count,
+		show
+	}, "__tests__/template.marko", 0, {
+		count: "1:6",
+		show: "2:6"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/html.bundle.js
@@ -1,0 +1,35 @@
+// components/message.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<div>${(0, import_escape_xml.x)(input.value)}</div>`);
+}, {
+	t: _marko_componentType,
+	i: true
+}, {});
+
+// template.marko
+s("b", _marko_template);
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	let show = true;
+	_html(`<button id=tags>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}<button id=toggle>toggle</button>${_el_resume($scope0_id, "c")}`);
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			_dynamic_tag($scope1_id, "a", _marko_template, { value: count });
+			writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "d");
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		e: count,
+		f: show
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-csr.debug.md
@@ -1,0 +1,87 @@
+# Render
+```html
+<button
+  id="tags"
+>
+  0
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  1
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+UPDATE: div::text "0" => "1"
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  2
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "1" => "2"
+UPDATE: div::text "1" => "2"
+```
+
+# Update
+```js
+(document.querySelector("#toggle")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+REMOVE: #toggle + div
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<button
+  id="tags"
+>
+  0
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  1
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+INSERT: #toggle + div
+INSERT: div::text("1")
+REMOVE: div + div
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  2
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "1" => "2"
+UPDATE: div::text "1" => "2"
+```
+
+# Update
+```js
+(document.querySelector("#toggle")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+REMOVE: #toggle + div
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/render-ssr.md
@@ -1,0 +1,89 @@
+# Render
+```html
+<button
+  id="tags"
+>
+  0
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  1
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "0" => "1"
+INSERT: #toggle + div
+INSERT: div::text("1")
+REMOVE: div + div
+```
+
+# Update
+```js
+(document.querySelector("#tags")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+<div>
+  2
+</div>
+```
+## Change
+```
+UPDATE: #tags::text "1" => "2"
+UPDATE: div::text "1" => "2"
+```
+
+# Update
+```js
+(document.querySelector("#toggle")).click();
+```
+```html
+<button
+  id="tags"
+>
+  2
+</button>
+<button
+  id="toggle"
+>
+  toggle
+</button>
+```
+## Change
+```
+REMOVE: #toggle + div
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/writes.debug.html
@@ -1,0 +1,35 @@
+<button id=tags>0<!--M_*1 #text/1--></button><!--M_*1 #button/0--><button
+  id=toggle>toggle</button><!--M_*1 #button/2--><!--M_[--><!--M_[--><!--M#_0-->
+<div>0</div><!--M/--><!--M_]2 #text/0 3--><!--M_]1 #text/3 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    count: 0,
+    show: !0
+  }, {
+    "ConditionalRenderer:#text/0": _._[
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/components/message.marko"
+      ]
+  }, {
+    m5c: "_0",
+    m5i: {
+      value: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/components/message.marko"
+    ]
+  });
+  M._.r.push(
+    "$compat_setScope 3 packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/template.marko_0 1"
+    );
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/__snapshots__/writes.html
@@ -1,0 +1,29 @@
+<button id=tags>0<!--M_*1 b--></button><!--M_*1 a--><button
+  id=toggle>toggle</button><!--M_*1 c--><!--M_[--><!--M_[--><!--M#_0-->
+<div>0</div><!--M/--><!--M_]2 a 3--><!--M_]1 d 2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: 0,
+    f: !0
+  }, {
+    Da: _._.b
+  }, {
+    m5c: "_0",
+    m5i: {
+      value: 0
+    }
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 3, {
+        "f": 1
+      }]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 3 a0 1");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/components/message.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/components/message.marko
@@ -1,0 +1,1 @@
+<div>${input.value}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63374,
-        "brotli": 19697
+        "min": 63873,
+        "brotli": 19956
       },
       "files": {
-        "components/class-display.marko": 856,
-        "template.marko": 356,
+        "components/message.marko": 835,
+        "template.marko": 796,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }
     }
   },
   "html": {
-    "min": 560,
-    "brotli": 367
+    "min": 630,
+    "brotli": 388
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/template.marko
@@ -1,0 +1,11 @@
+<let/count = 0/>
+<let/show = true/>
+<button id="tags" onClick() { count++ }>
+  ${count}
+</button>
+<button id="toggle" onClick() { show = !show }>
+  toggle
+</button>
+<if=show>
+  <message value=count/>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+function clickTags(document: Document) {
+  (document.querySelector("#tags") as HTMLButtonElement).click();
+}
+
+function clickToggle(document: Document) {
+  (document.querySelector("#toggle") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, clickTags, clickTags, clickToggle],
+};


### PR DESCRIPTION
In the tags-compat interop, `renderAndMorph` wrote the branch start/end nodes onto the fragment's own DOM marker instead of the tags branch scope — a self-assign plus an unused ref — so the `host.fragment` fast path never fired for a server-rendered Marko 5 child and every re-render fell back to the component lookup. Passing the scope restores the fast path. Adds an interop fixture covering re-render and unmount of a resumed class child, a path the suite did not previously exercise.