### PR TITLE
refactor: extract one helper for the attrTag/attrTags merge in known-tag

### DIFF
--- a/agent-feedback/cleanup.md
+++ b/agent-feedback/cleanup.md
@@ -2,12 +2,6 @@
 
 Duplication, dead code, inconsistencies, refactor opportunities. Format and rules: [README.md](README.md).
 
-## Extract one helper for the `attrTag`/`attrTags` merge duplicated in `known-tag.ts`
-
-`packages/runtime-tags/src/translator/util/known-tag.ts` › `translateAttrTag` | 2026-07-23 | impact:low | effort:low
-
-The rule "a repeated attribute tag folds into `attrTags(prev, next)`, a non-repeated one becomes `attrTag(props)`" is implemented four times. `translateAttrTag` and the `isAttributeTag(tag)` branch of `applyAttrObject` are near-verbatim ~35-line copies, including the `t.parenthesizedExpression` mutation trick, differing only in where `repeated` comes from and whether the result is returned or handed to `addStatement`. `translate-attrs.ts` › `translateAttrs` and `addDynamicAttrTagStatements` encode the same rule over `contentProperties` and over an attr-tag identifier assignment. One helper would collapse the two `known-tag.ts` copies and let the other two share the `repeated ? attrTags : attrTag` decision, so a future change cannot land on three of four sites. Re-verify: `rg -n '"attrTags"' packages/runtime-tags/src/translator` lists exactly those four sites.
-
 ## Make a params binding identifiable from `binding.type`
 
 `packages/runtime-tags/src/translator/util/references.ts` › `trackParamsReferences` | 2026-07-22 | impact:med | effort:high

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -919,42 +919,17 @@ function applyAttrObject(
   }
 
   if (isAttributeTag(tag)) {
-    translatedProps = t.objectExpression(translatedAttrs.properties);
-    const attrTagName = getTagName(tag);
-    const parentTag = tag.parentPath as t.NodePath<t.MarkoTag>;
-    const repeated = analyzeAttributeTags(parentTag)?.[attrTagName]?.repeated;
-
-    if (repeated) {
-      let attrTagCallsForTag = (info.attrTagCallsByTag ||= new Map()).get(
-        parentTag,
-      );
-      if (!attrTagCallsForTag) {
-        info.attrTagCallsByTag.set(parentTag, (attrTagCallsForTag = new Map()));
-      }
-
-      const attrTagCall = attrTagCallsForTag.get(attrTagName);
-      if (attrTagCall) {
-        attrTagCall.expression = callRuntime(
-          "attrTags",
-          attrTagCall.expression,
-          translatedProps,
-        );
-        return;
-      } else {
-        // Uses parenthesized expressions since they are simple to mutate after the fact
-        // and do not impact the output.
-        attrTagCallsForTag.set(
-          attrTagName,
-          (translatedProps = t.parenthesizedExpression(
-            callRuntime("attrTag", translatedProps),
-          ) as t.ParenthesizedExpression & {
-            expression: t.CallExpression;
-          }),
-        );
-      }
-    } else {
-      translatedProps = callRuntime("attrTag", translatedProps);
-    }
+    const repeated = analyzeAttributeTags(
+      tag.parentPath as t.NodePath<t.MarkoTag>,
+    )?.[getTagName(tag)]?.repeated;
+    const mergedProps = getAttrTagProps(
+      tag,
+      repeated,
+      t.objectExpression(translatedAttrs.properties),
+      info,
+    );
+    if (!mergedProps) return;
+    translatedProps = mergedProps;
   }
 
   addStatement(
@@ -978,45 +953,50 @@ function translateAttrTag(
   statements: t.Statement[],
 ) {
   const translatedAttrs = translateAttrs(tag, true, undefined, statements);
-  let translatedProps: t.Expression = t.objectExpression(
-    translatedAttrs.properties,
+  return getAttrTagProps(
+    tag,
+    attrTagMeta.repeated,
+    t.objectExpression(translatedAttrs.properties),
+    info,
   );
+}
+
+function getAttrTagProps(
+  tag: t.NodePath<t.MarkoTag>,
+  repeated: boolean | undefined,
+  translatedProps: t.ObjectExpression,
+  info: TranslateDOMInfo,
+) {
+  if (!repeated) return callRuntime("attrTag", translatedProps);
+
   const attrTagName = getTagName(tag);
   const parentTag = tag.parentPath as t.NodePath<t.MarkoTag>;
-
-  if (attrTagMeta.repeated) {
-    let attrTagCallsForTag = (info.attrTagCallsByTag ||= new Map()).get(
-      parentTag,
-    );
-    if (!attrTagCallsForTag) {
-      info.attrTagCallsByTag.set(parentTag, (attrTagCallsForTag = new Map()));
-    }
-
-    const attrTagCall = attrTagCallsForTag.get(attrTagName);
-    if (attrTagCall) {
-      attrTagCall.expression = callRuntime(
-        "attrTags",
-        attrTagCall.expression,
-        translatedProps,
-      );
-      return;
-    } else {
-      // Uses parenthesized expressions since they are simple to mutate after the fact
-      // and do not impact the output.
-      attrTagCallsForTag.set(
-        attrTagName,
-        (translatedProps = t.parenthesizedExpression(
-          callRuntime("attrTag", translatedProps),
-        ) as t.ParenthesizedExpression & {
-          expression: t.CallExpression;
-        }),
-      );
-    }
-  } else {
-    translatedProps = callRuntime("attrTag", translatedProps);
+  let attrTagCallsForTag = (info.attrTagCallsByTag ||= new Map()).get(
+    parentTag,
+  );
+  if (!attrTagCallsForTag) {
+    info.attrTagCallsByTag.set(parentTag, (attrTagCallsForTag = new Map()));
   }
 
-  return translatedProps;
+  const attrTagCall = attrTagCallsForTag.get(attrTagName);
+  if (attrTagCall) {
+    attrTagCall.expression = callRuntime(
+      "attrTags",
+      attrTagCall.expression,
+      translatedProps,
+    );
+    return;
+  }
+
+  // Uses parenthesized expressions since they are simple to mutate after the fact
+  // and do not impact the output.
+  const wrappedProps = t.parenthesizedExpression(
+    callRuntime("attrTag", translatedProps),
+  ) as t.ParenthesizedExpression & {
+    expression: t.CallExpression;
+  };
+  attrTagCallsForTag.set(attrTagName, wrappedProps);
+  return wrappedProps;
 }
 
 function writeAttrsToSignals(


### PR DESCRIPTION
`known-tag.ts` implemented the "repeated attribute tags fold into `attrTags(prev, next)`, otherwise `attrTag(props)`" rule twice in near-verbatim ~30-line copies (`applyAttrObject`'s attribute-tag branch and `translateAttrTag`). Extracts a single `getAttrTagProps` helper both call. Compiled output is unchanged — no snapshot or size churn.