### PR TITLE
test: add a Destroy step to the CSR fixture harness

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -104,12 +104,6 @@ A `<script>` effect that writes a `<let>` it transitively reads re-renders forev
 
 All three fall past the constructor `switch` to `throwUnserializable`, so a resumed value holding one is dropped even though they reach templates through request handling. Each has a constructor form that round-trips its observable state (`new DOMException(message, name)`, `AbortSignal.abort(reason)`, `new Event(type, { bubbles, cancelable, composed })`), but a not-yet-aborted `AbortSignal` has no faithful representation — resume would have to wire it to a fresh controller, so settle that semantics before adding it. Worth the runtime bytes only if a real template needs them. These need `case globalThis.X:` guards in the `proto?.constructor` switch (boxed primitives were ruled wont-fix there; see the comment in `writeUnknownObject`). Verify: pass each through `Serializer#stringifyScopes` and watch it drop, against `new URL("https://a.b")` as a supported control.
 
-## Add a `Destroy` step to the CSR fixture harness
-
-`packages/runtime-tags/src/__tests__/main.test.ts` › `csr` | 2026-07-23 | impact:low | effort:low
-
-The CSR harness mounts a template and only ever calls `instance.update(input)`, so fixture snapshots never exercise teardown; `cleanup-*` fixtures only cover destroys driven from inside a render by `<if>`/`<for>`. `mounted-template.test.ts` now covers `destroy()`, `<lifecycle>` onDestroy, `$signal` abort, and the `value` getter/setter directly (4499fbaa3e), so what remains is snapshot breadth over nested-branch teardown. Add a `Destroy` step alongside `Wait`/`Flush`/`Throws` in `TestConfig.steps`, have `runSteps` call `instance.destroy()`, and let the mutation tracker snapshot the resulting removal. Verify: `rg -n "instance\." packages/runtime-tags/src/__tests__/main.test.ts` returns only `instance.update(input)`.
-
 ## Unify `packages/runtime-class/src` on ESM so its module type can be declared
 
 `packages/runtime-class/package.json` › `files` | 2026-07-24 | impact:low | effort:high

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,37 @@
+// tags/child.marko
+const $template$1 = "<p> </p>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $name__script = _script("__tests__/tags/child.marko_0_name", ($scope) => {
+	_lifecycle($scope, { onDestroy: function() {
+		console.log(`lifecycle ${$scope.name} destroyed`);
+	} });
+	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.name} destroyed`);
+});
+const $name = /*@__PURE__*/ _const("name", ($scope) => {
+	_text($scope["#text/0"], $scope.name);
+	$signalReset($scope, 0);
+	$name__script($scope);
+});
+const $input = ($scope, input) => $name($scope, input.name);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+
+// template.marko
+const $template = "<div></div>";
+const $walks = " b";
+const $for_content__item = ($scope, item) => $name($scope["#childScope/0"], item);
+const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $params2[0]);
+const $if_content__for = /*@__PURE__*/ _for_of("#text/1", $template$1, /*@__PURE__*/ ((_w0) => `/${_w0}&`)("D l"), 0, $for_content__$params);
+const $if_content__items = /*@__PURE__*/ _if_closure("#div/0", 0, ($scope) => $if_content__for($scope, [$scope._.items]));
+const $if_content__setup = ($scope) => {
+	$if_content__items._($scope);
+	$name($scope["#childScope/0"], "outer");
+};
+const $if = /*@__PURE__*/ _if("#div/0", /*@__PURE__*/ ((_w0) => `<section>${_w0}<!></section>`)($template$1), /*@__PURE__*/ ((_w0) => `D/${_w0}&%l`)("D l"), $if_content__setup);
+const $show = /*@__PURE__*/ _let("show/1", ($scope) => $if($scope, $scope.show ? 0 : 1));
+const $items = /*@__PURE__*/ _let("items/2");
+function $setup($scope) {
+	$show($scope, true);
+	$items($scope, ["a", "b"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// tags/child.marko
+const $name__script = _script("b0", ($scope) => {
+	_lifecycle($scope, { onDestroy: function() {
+		console.log(`lifecycle ${$scope.d} destroyed`);
+	} });
+	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.d} destroyed`);
+});

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,31 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const { name } = input;
+	_html(`<p>${_escape(name)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</p>`);
+	_script($scope0_id, "__tests__/tags/child.marko_0_name");
+	writeScope($scope0_id, { name }, "__tests__/tags/child.marko", 0, { name: "1:9" });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let show = true;
+	let items = ["a", "b"];
+	_html("<div>");
+	if (show) {
+		const $scope1_id = _scope_id();
+		_html("<section>");
+		child_default({ name: "outer" });
+		forOf(items, (item) => {
+			const $scope2_id = _scope_id();
+			child_default({ name: item });
+		});
+		_html("</section>");
+	}
+	_html("</div>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.js
@@ -1,0 +1,28 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const { name } = input;
+	_html(`<p>${_escape(name)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</p>`);
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, { d: name });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let items = ["a", "b"];
+	_html("<div>");
+	_scope_id();
+	_html("<section>");
+	child_default({ name: "outer" });
+	forOf(items, (item) => {
+		_scope_id();
+		child_default({ name: item });
+	});
+	_html("</section>");
+	_html("</div>");
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-csr.debug.md
@@ -1,0 +1,31 @@
+# Render
+```html
+<div>
+  <section>
+    <p>
+      outer
+    </p>
+    <p>
+      a
+    </p>
+    <p>
+      b
+    </p>
+  </section>
+</div>
+```
+
+# Update Destroy
+## Change
+```
+REMOVE: div
+```
+## Console
+```
+LOG "effect a destroyed"
+LOG "lifecycle a destroyed"
+LOG "effect b destroyed"
+LOG "lifecycle b destroyed"
+LOG "effect outer destroyed"
+LOG "lifecycle outer destroyed"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,16 @@
+# Render
+```html
+<div>
+  <section>
+    <p>
+      outer
+    </p>
+    <p>
+      a
+    </p>
+    <p>
+      b
+    </p>
+  </section>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/render-ssr.md
@@ -1,0 +1,16 @@
+# Render
+```html
+<div>
+  <section>
+    <p>
+      outer
+    </p>
+    <p>
+      a
+    </p>
+    <p>
+      b
+    </p>
+  </section>
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/writes.debug.html
@@ -1,0 +1,20 @@
+<div>
+  <section>
+    <p>outer</p>
+    <p>a</p>
+    <p>b</p>
+  </section>
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [3, {
+      name: "outer"
+    }, 1, {
+      name: "a"
+    }, 1, {
+      name: "b"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/tags/child.marko_0_name 3 5 7"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<div>
+  <section>
+    <p>outer</p>
+    <p>a</p>
+    <p>b</p>
+  </section>
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [3, {
+    d: "outer"
+  }, 1, {
+    d: "a"
+  }, 1, {
+    d: "b"
+  }], "b0 3 5 7"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2039,
+      "brotli": 1038
+    }
+  },
+  "html": {
+    "min": 396,
+    "brotli": 280
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/tags/child.marko
@@ -1,0 +1,6 @@
+<const/{name}=input/>
+<p>${name}</p>
+<lifecycle onDestroy() { console.log(`lifecycle ${name} destroyed`) }/>
+<script>
+  $signal.onabort = () => console.log(`effect ${name} destroyed`);
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/template.marko
@@ -1,0 +1,12 @@
+<let/show=true/>
+<let/items=["a", "b"]/>
+<div>
+  <if=show>
+    <section>
+      <child name="outer"/>
+      <for|item| of=items>
+        <child name=item/>
+      </for>
+    </section>
+  </if>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+import { destroy } from "../../utils/resolve";
+
+export const config: TestConfig = {
+  equivalent: false,
+  steps: [{}, destroy],
+};

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -19,8 +19,10 @@ import {
 import { captureConsole, type ConsoleRecord } from "./utils/capture-console";
 import createBrowser from "./utils/create-browser";
 import {
+  type Destroy,
   type Flush,
   type FlushType,
+  isDestroy,
   isFlush,
   isThrows,
   isWait,
@@ -38,7 +40,13 @@ import createMutationTracker from "./utils/track-mutations";
 
 const require = createRequire(import.meta.url);
 
-type Step = Input | Wait | Flush | Throws | ((document: Document) => unknown);
+type Step =
+  | Input
+  | Wait
+  | Flush
+  | Destroy
+  | Throws
+  | ((document: Document) => unknown);
 type Steps = [Input, ...Step[]];
 export type TestConfig = {
   steps?: Steps | (() => Steps | Promise<Steps>);
@@ -306,6 +314,9 @@ function testFixtures(interop?: true) {
                 instance.update(input);
                 tracker.logUpdate(input);
               },
+              onDestroy() {
+                instance.destroy();
+              },
             });
 
             tracker.cleanup();
@@ -498,10 +509,18 @@ async function runSteps(
   opts: {
     onInput?: (input: Input) => void;
     onFlush?: () => Promise<void>;
+    onDestroy?: () => void;
   },
 ) {
   for (const update of steps) {
-    if (isWait(update)) {
+    if (isDestroy(update)) {
+      // only the client tests have an instance to destroy
+      if (!opts.onDestroy) break;
+      tracker.beginUpdate();
+      opts.onDestroy();
+      run();
+      tracker.logUpdate("Destroy");
+    } else if (isWait(update)) {
       await update();
       await browser.runAsyncScripts();
       run();

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -70,6 +70,11 @@ export const flushMedia = Object.assign(() => {}, {
   flushType: "media" as const,
 });
 
+export type Destroy = typeof destroy;
+export const destroy = Object.assign(() => {}, {
+  destroy: true,
+});
+
 export type Throws = ReturnType<typeof throws>;
 export function throws(fn: (...args: any[]) => void) {
   return Object.assign(fn, { throws: true });
@@ -81,6 +86,10 @@ export function isWait(value: any): value is Wait {
 
 export function isFlush(value: any): value is Flush {
   return typeof value === "function" && value.flushType !== undefined;
+}
+
+export function isDestroy(value: any): value is Destroy {
+  return typeof value === "function" && value.destroy;
 }
 
 export function isThrows(value: any): value is Throws {


### PR DESCRIPTION
Adds a `destroy` step marker for fixture tests so CSR snapshots can exercise `instance.destroy()` teardown, plus a `destroy-nested-branches` fixture whose mutation log captures the removal and the ordered `<lifecycle onDestroy>`/`$signal` abort callbacks across nested `<if>`/`<for>` branches. Non-client test paths skip the step the same way input steps are skipped.