### PR TITLE
fix: error in debug builds when a for range from/step is a non-number

### DIFF
--- a/.changeset/for-range-from-debug-assert.md
+++ b/.changeset/for-range-from-debug-assert.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Debug builds now error when a `<for>` tag's `from` or `step` attribute is a non-number, instead of silently concatenating indices.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -32,12 +32,6 @@ The string-renderer branch never assigns `result` (its inline TODO says so) and 
 
 `/^on[-A-Z][a-zA-Z0-9_$]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$/` demands a character after `[-A-Z]` and leaves the second alternative unanchored, so it disagrees with the runtime's `isEventHandler` (`/^on[A-Z-]/`) at both ends. `<div onX() {}/>` fails `assertNativeAttrValueType` with "The `onX` attribute cannot be a function." though `<div on-x() {}/>` compiles. Conversely any name ending in `Change` counts as a change handler: `<div data-exChange="x"/>` errors, while `<div data-exChange=(() => {})/>` skips the function check and emits `_attr("data-exChange", _resume(() => {}, …))`, which an optimized build stringifies into the markup. Use `/^(?:on[-A-Z]|[a-zA-Z_$][a-zA-Z0-9_$]*Change$)/` and scope `assertNativeHandlerAttr` to the real controllables. Distinct from dx.md's "Surface a near-miss suggestion (or document the casing rule) for miscased event attributes", which is about type-check messaging for `onKeydown` vs `onKeyDown`, not this regex. Re-verify: `node -r ~ts scripts/inspect-compiled-output.mts -o dom -d` on those four templates — today only the hyphenated spellings behave.
 
-## Coerce (or validate) `forTo`/`forUntil`'s `from`; a string `from` concatenates the indices
-
-`packages/runtime-tags/src/common/for.ts` › `forTo` | 2026-07-23 | impact:med | effort:low
-
-Both helpers guard only the upper bound (`assertValidRangeBound`) and then compute `const start = from || 0; cb(start + i * delta)`, so a non-numeric `from` is never coerced: `forTo(5, "2", 1, cb)` yields `"20", "21", "22", "23"` instead of `2, 3, 4, 5` — wrong values and count, silently, even under MARKO_DEBUG. It is reachable from ordinary templates, since `getBaseArgsInForTag` (`translator/core/for.ts`) passes the attribute straight through and the core-tag metadata's `from: { type: "number" }` is LSP data, not a compile check. Either extend the debug guard to `from` (allowing nullish, since it defaults) or write `const start = +from || 0`. Re-verify: `node -r ~ts -e 'globalThis.MARKO_DEBUG=1;const{forTo}=require("./packages/runtime-tags/src/common/for.ts");const o=[];forTo(5,"2",1,v=>o.push(v));console.log(o)'` prints `[ '20', '21', '22', '23' ]`.
-
 ## Give the HTML spread-attrs path the same MARKO_DEBUG validation as the DOM path
 
 `packages/runtime-tags/src/html/attrs.ts` › `_attrs` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `from` attribute must be a finite number, but received type "string".

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+const $for_content__setup = ($scope) => _text($scope["#text/0"], $scope["#LoopKey"]);
+const $for = /*@__PURE__*/ _for_to("#text/0", "<li> </li>", "D ", $for_content__setup);
+const $input_from = ($scope, input_from) => $for($scope, [
+	5,
+	input_from,
+	1
+]);
+const $input = ($scope, input) => $input_from($scope, input.from);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_from = _serialize_guard($scope0_reason, 0), $si__input_from = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_for_to(5, input.from, 1, (i) => {
+		const $scope1_id = _scope_id();
+		_html(`<li>${_escape(i)}</li>`);
+		$si__input_from && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
+	}, 0, $scope0_id, "#text/0", $sg__input_from, $sg__input_from, $sg__input_from, 0, 1);
+	$si__input_from && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+A `<for>` tag's `from` attribute must be a finite number, but received type "string".

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/template.marko
@@ -1,0 +1,3 @@
+<for|i| from=input.from to=5>
+  <li>${i}</li>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ from: "2" }],
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -103,6 +103,16 @@ export function assertValidList(value: unknown) {
   }
 }
 
+export function assertValidRangeStart(name: string, value: unknown) {
+  // Unlike `to`, a truthy `from`/`step` reaches `start + i * delta` uncoerced,
+  // where a non-number `from` concatenates, so debug requires a real number.
+  if (value && (typeof value !== "number" || !isFinite(value))) {
+    throw new Error(
+      `A \`<for>\` tag's \`${name}\` attribute must be a finite number, but received ${describeForValue(value)}.`,
+    );
+  }
+}
+
 export function assertValidRangeBound(name: string, value: unknown) {
   // `isFinite` coerces like the range arithmetic, so a debug throw matches production.
   if (!isFinite(value as number)) {

--- a/packages/runtime-tags/src/common/for.ts
+++ b/packages/runtime-tags/src/common/for.ts
@@ -1,4 +1,8 @@
-import { assertValidList, assertValidRangeBound } from "./errors";
+import {
+  assertValidList,
+  assertValidRangeBound,
+  assertValidRangeStart,
+} from "./errors";
 import type { Falsy } from "./types";
 
 export function forIn(
@@ -29,7 +33,11 @@ export function forTo(
   step: number | Falsy,
   cb: (index: number) => void,
 ) {
-  if (MARKO_DEBUG) assertValidRangeBound("to", to);
+  if (MARKO_DEBUG) {
+    assertValidRangeBound("to", to);
+    assertValidRangeStart("from", from);
+    assertValidRangeStart("step", step);
+  }
   const start = from || 0;
   const delta = step || 1;
   for (let steps = (to - start) / delta, i = 0; i <= steps; i++) {
@@ -43,7 +51,11 @@ export function forUntil(
   step: number | Falsy,
   cb: (index: number) => void,
 ) {
-  if (MARKO_DEBUG) assertValidRangeBound("until", until);
+  if (MARKO_DEBUG) {
+    assertValidRangeBound("until", until);
+    assertValidRangeStart("from", from);
+    assertValidRangeStart("step", step);
+  }
   const start = from || 0;
   const delta = step || 1;
   for (let steps = (until - start) / delta, i = 0; i < steps; i++) {


### PR DESCRIPTION
A non-number `from` on `<for from to>`/`<for from until>` reaches `start + i * delta` uncoerced and concatenates the indices (`forTo(5, "2", 1)` yields `"20", "21", ...`) with no diagnostic. Debug builds now assert truthy `from`/`step` are finite numbers, matching the existing `to`/`until` guard; optimized output is unchanged. Adds an `error-for-from-non-number` fixture.