### PR TITLE
fix: register delegated events whose type collides with a Function property

### DIFF
--- a/.changeset/delegate-function-property-events.md
+++ b/.changeset/delegate-function-property-events.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Events whose type collides with a `Function` property (`on-name`, `on-length`, …) now register their delegated listener instead of silently never firing.

--- a/.sizes.json
+++ b/.sizes.json
@@ -7,8 +7,8 @@
     {
       "name": "*",
       "total": {
-        "min": 26014,
-        "brotli": 9653
+        "min": 26010,
+        "brotli": 9689
       }
     },
     {
@@ -18,12 +18,12 @@
         "brotli": 138
       },
       "runtime": {
-        "min": 4038,
-        "brotli": 1804
+        "min": 4034,
+        "brotli": 1792
       },
       "total": {
-        "min": 4199,
-        "brotli": 1942
+        "min": 4195,
+        "brotli": 1930
       }
     },
     {
@@ -33,12 +33,12 @@
         "brotli": 80
       },
       "runtime": {
-        "min": 2683,
-        "brotli": 1319
+        "min": 2679,
+        "brotli": 1318
       },
       "total": {
-        "min": 2763,
-        "brotli": 1399
+        "min": 2759,
+        "brotli": 1398
       }
     },
     {
@@ -48,12 +48,12 @@
         "brotli": 364
       },
       "runtime": {
-        "min": 6513,
-        "brotli": 2878
+        "min": 6509,
+        "brotli": 2875
       },
       "total": {
-        "min": 7158,
-        "brotli": 3242
+        "min": 7154,
+        "brotli": 3239
       }
     },
     {
@@ -63,12 +63,12 @@
         "brotli": 101
       },
       "runtime": {
-        "min": 2888,
-        "brotli": 1400
+        "min": 2884,
+        "brotli": 1393
       },
       "total": {
-        "min": 3003,
-        "brotli": 1501
+        "min": 2999,
+        "brotli": 1494
       }
     }
   ]

--- a/.sizes/comments.csr/runtime.js
+++ b/.sizes/comments.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 6513 (min) 2878 (brotli)
+// size: 6509 (min) 2875 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   branchesEnabled,
@@ -14,7 +14,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   },
   catchEnabled,
   delegate = (type, handler) =>
-    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
+    (handler[1 + type] ||= (document.addEventListener(type, handler, !0), 1)),
   parsers = {},
   nextScopeId = 1e6,
   destroyNestedScopes = function destroyNestedScopes(scope) {
@@ -287,13 +287,13 @@ function toArray(opt) {
   return opt ? (Array.isArray(opt) ? opt : [opt]) : [];
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 && delegate(type, handleDelegated),
-    (element["$" + type] = handler || null));
+  (element[1 + type] === void 0 && delegate(type, handleDelegated),
+    (element[1 + type] = handler || null));
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
   for (; target;)
-    (target["$" + ev.type]?.(ev, target),
+    (target[1 + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
 }
 function parseHTML(html, ns) {

--- a/.sizes/comments.ssr/runtime.js
+++ b/.sizes/comments.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2888 (min) 1400 (brotli)
+// size: 2884 (min) 1393 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
@@ -13,7 +13,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   },
   catchEnabled,
   delegate = (type, handler) =>
-    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
+    (handler[1 + type] ||= (document.addEventListener(type, handler, !0), 1)),
   isScheduled,
   channel,
   registeredValues = {},
@@ -86,13 +86,13 @@ function runRenders() {
   }
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 && delegate(type, handleDelegated),
-    (element["$" + type] = handler || null));
+  (element[1 + type] === void 0 && delegate(type, handleDelegated),
+    (element[1 + type] = handler || null));
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
   for (; target;)
-    (target["$" + ev.type]?.(ev, target),
+    (target[1 + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
 }
 function schedule() {

--- a/.sizes/counter.csr/runtime.js
+++ b/.sizes/counter.csr/runtime.js
@@ -1,4 +1,4 @@
-// size: 4038 (min) 1804 (brotli)
+// size: 4034 (min) 1792 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
@@ -13,7 +13,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   },
   catchEnabled,
   delegate = (type, handler) =>
-    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
+    (handler[1 + type] ||= (document.addEventListener(type, handler, !0), 1)),
   parsers = {},
   nextScopeId = 1e6,
   destroyNestedScopes = function destroyNestedScopes(scope) {
@@ -151,13 +151,13 @@ function abort(ctrl) {
   ctrl.abort();
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 && delegate(type, handleDelegated),
-    (element["$" + type] = handler || null));
+  (element[1 + type] === void 0 && delegate(type, handleDelegated),
+    (element[1 + type] = handler || null));
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
   for (; target;)
-    (target["$" + ev.type]?.(ev, target),
+    (target[1 + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
 }
 function parseHTML(html, ns) {

--- a/.sizes/counter.ssr/runtime.js
+++ b/.sizes/counter.ssr/runtime.js
@@ -1,4 +1,4 @@
-// size: 2683 (min) 1319 (brotli)
+// size: 2679 (min) 1318 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).toString(36),
   rendering,
@@ -13,7 +13,7 @@ let decodeAccessor = (num) => (num + (num < 26 ? 10 : num < 962 ? 334 : 11998)).
   },
   catchEnabled,
   delegate = (type, handler) =>
-    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
+    (handler[1 + type] ||= (document.addEventListener(type, handler, !0), 1)),
   isScheduled,
   channel,
   registeredValues = {},
@@ -83,13 +83,13 @@ function runRenders() {
   }
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 && delegate(type, handleDelegated),
-    (element["$" + type] = handler || null));
+  (element[1 + type] === void 0 && delegate(type, handleDelegated),
+    (element[1 + type] = handler || null));
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
   for (; target;)
-    (target["$" + ev.type]?.(ev, target),
+    (target[1 + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
 }
 function schedule() {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26014 (min) 9653 (brotli)
+// size: 26010 (min) 9689 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let unsafeStyleAttrReg = /[\\;]/g,
   replaceUnsafeStyleAttr = (c) => (c === ";" ? "\\3B " : "\\\\"),
@@ -33,7 +33,7 @@ let unsafeStyleAttrReg = /[\\;]/g,
   },
   catchEnabled,
   delegate = (type, handler) =>
-    (handler[type] ||= (document.addEventListener(type, handler, !0), 1)),
+    (handler[1 + type] ||= (document.addEventListener(type, handler, !0), 1)),
   parsers = {},
   nextScopeId = 1e6,
   collectingScopes,
@@ -517,13 +517,13 @@ function push(opt, item) {
   return opt ? (Array.isArray(opt) ? (opt.push(item), opt) : [opt, item]) : item;
 }
 function _on(element, type, handler) {
-  (element["$" + type] === void 0 && delegate(type, handleDelegated),
-    (element["$" + type] = handler || null));
+  (element[1 + type] === void 0 && delegate(type, handleDelegated),
+    (element[1 + type] = handler || null));
 }
 function handleDelegated(ev) {
   let target = !rendering && ev.target;
   for (; target;)
-    (target["$" + ev.type]?.(ev, target),
+    (target[1 + ev.type]?.(ev, target),
       (target = ev.bubbles && !ev.cancelBubble && target.parentNode));
 }
 function parseHTML(html, ns) {

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -44,12 +44,6 @@ The `renderer === "select" && ("value" in input || "valueChange" in input)` case
 
 `_attrs` guards its stale-attribute removal with `hasAttrAlias`, keeping `checked` on an `<input>` whose next attrs carry `checkedValue`; `_attrs_partial`'s loop tests only `!skip[name] && !(nextAttrs && name in nextAttrs)`, so it removes `checked`, clearing `defaultChecked` and — dirty flag unset — `el.checked`. `_attr_input_checked_default` then reads that cleared `el.checked` as `restoreValue` on the `scope[AccessorProp.Gen] < runId` branch and writes it back, unchecking a box whose bound value still selects it; the controlled variant keeps `checked` but is left `defaultChecked === false`, corrupting `hasCheckboxChanged`/`handleFormReset`. Reuse `hasAttrAlias` in `_attrs_partial`'s loop. Re-verify: `<let/sel=["a"]/><input ...{ checkedValue: sel, value: "a" } type="checkbox"><button onClick(){ sel = sel.slice() }>t</button>` compiles to `_attrs_partial(…, { type: 1 }, _controllable_input)`; one click unchecks the box.
 
-## Prefix `delegate`'s registration flag so event types named after `Function` properties register
-
-`packages/runtime-tags/src/dom/event.ts` › `delegate` | 2026-07-23 | impact:low | effort:low
-
-`delegate` memoizes its one-time `document.addEventListener` as `(handler as any)[type] ||= (…, 1)`, keyed on the raw event type. Any type colliding with a `Function` property — `name`, `length`, `constructor`, `toString`, `bind`, `call`, `apply`, `prototype` — already reads truthy, so the listener is never installed and the handler silently never fires; `caller`/`arguments` instead throw a `TypeError` out of `_on`, since the runtime is strict-mode ESM. The names come from user markup: `<div on-name(){}>` compiles to `_on($scope["#div/0"], "name", fn)`. `_on` already namespaces its own slot as `"$" + type`; use that key in `delegate` too. If "Delegate events from the element's root node again; nothing inside a ShadowRoot receives events or controlled-input updates" is taken, its per-root type-keyed map deletes this keyspace outright and supersedes the `"$" + type` patch, so the two must not land separately. Re-verify: `<div on-name(){ console.log("hi") }>x</div>`, then dispatch `new CustomEvent("name", { bubbles: true })` on it — nothing logs today while `on-click` works.
-
 ## Guard the tag-variable assignment in `_dynamic_tag` when the dynamic tag becomes falsy
 
 `packages/runtime-tags/src/dom/control-flow.ts` › `_dynamic_tag` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62292,
-        "brotli": 19189
+        "min": 62288,
+        "brotli": 19193
       },
       "files": {
         "components/tags-child.marko": 499,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64621,
-        "brotli": 20113
+        "min": 64617,
+        "brotli": 20147
       },
       "files": {
         "components/tags-child.marko": 624,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62522,
-        "brotli": 19301
+        "min": 62518,
+        "brotli": 19319
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63762,
-        "brotli": 19846
+        "min": 63758,
+        "brotli": 19848
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3158,
-        "brotli": 1542
+        "min": 3154,
+        "brotli": 1545
       },
       "files": {
         "template.marko": 236,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63644,
-        "brotli": 19807
+        "min": 63640,
+        "brotli": 19794
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62522,
-        "brotli": 19301
+        "min": 62518,
+        "brotli": 19319
       },
       "files": {
         "components/tags-counter.marko": 681,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-deprecated-core-tag-migrate/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3231,
-      "brotli": 1580
+      "min": 3227,
+      "brotli": 1575
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63801,
-        "brotli": 19862
+        "min": 63797,
+        "brotli": 19878
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62420,
-        "brotli": 19280
+        "min": 62416,
+        "brotli": 19247
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62461,
-        "brotli": 19283
+        "min": 62457,
+        "brotli": 19261
       },
       "files": {
         "components/tags-child.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63748,
-        "brotli": 19802
+        "min": 63744,
+        "brotli": 19860
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63867,
-        "brotli": 19832
+        "min": 63863,
+        "brotli": 19838
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62408,
-        "brotli": 19255
+        "min": 62404,
+        "brotli": 19231
       },
       "files": {
         "components/class-child.marko": 975,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62573,
-        "brotli": 19320
+        "min": 62569,
+        "brotli": 19352
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64057,
-        "brotli": 19985
+        "min": 64053,
+        "brotli": 19991
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62585,
-        "brotli": 19338
+        "min": 62581,
+        "brotli": 19343
       },
       "files": {
         "components/tags-pinger.marko": 658,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65330,
-        "brotli": 20299
+        "min": 65326,
+        "brotli": 20305
       },
       "files": {
         "components/tags-pinger.marko": 701,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63670,
-        "brotli": 19812
+        "min": 63666,
+        "brotli": 19797
       },
       "files": {
         "components/class-layout.marko": 1202,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63693,
-        "brotli": 19838
+        "min": 63689,
+        "brotli": 19825
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63975,
-        "brotli": 19924
+        "min": 63971,
+        "brotli": 19919
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63762,
-        "brotli": 19846
+        "min": 63758,
+        "brotli": 19870
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62824,
-        "brotli": 19459
+        "min": 62820,
+        "brotli": 19415
       },
       "files": {
         "components/tags-layout.marko": 838,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62496,
-        "brotli": 19313
+        "min": 62492,
+        "brotli": 19309
       },
       "files": {
         "components/tags-layout.marko": 696,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64198,
-        "brotli": 20042
+        "min": 64194,
+        "brotli": 20055
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63704,
-        "brotli": 19822
+        "min": 63700,
+        "brotli": 19830
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63374,
-        "brotli": 19697
+        "min": 63370,
+        "brotli": 19680
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63868,
-        "brotli": 19872
+        "min": 63864,
+        "brotli": 19892
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63474,
-        "brotli": 19724
+        "min": 63470,
+        "brotli": 19719
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 62881,
-        "brotli": 19484
+        "min": 62877,
+        "brotli": 19468
       },
       "files": {
         "components/tags-layout.marko": 912,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64562,
-        "brotli": 20182
+        "min": 64558,
+        "brotli": 20166
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63873,
-        "brotli": 19956
+        "min": 63869,
+        "brotli": 19897
       },
       "files": {
         "components/message.marko": 835,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3148,
-      "brotli": 1534
+      "min": 3144,
+      "brotli": 1538
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-derived-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2737,
-      "brotli": 1387
+      "min": 2733,
+      "brotli": 1385
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-increment/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2839,
+      "min": 2835,
       "brotli": 1432
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2653,
-      "brotli": 1347
+      "min": 2649,
+      "brotli": 1344
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-in-wrapped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2631,
-      "brotli": 1338
+      "min": 2627,
+      "brotli": 1340
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-let-to-undefined/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2634,
-      "brotli": 1344
+      "min": 2630,
+      "brotli": 1348
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2821,
-      "brotli": 1424
+      "min": 2817,
+      "brotli": 1419
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-multiple-derived-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2972,
-      "brotli": 1493
+      "min": 2968,
+      "brotli": 1495
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-owner-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5998,
-      "brotli": 2752
+      "min": 5994,
+      "brotli": 2749
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2817,
-      "brotli": 1416
+      "min": 2813,
+      "brotli": 1419
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1893,
-      "brotli": 979
+      "min": 1889,
+      "brotli": 981
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7464,
-      "brotli": 3273
+      "min": 7460,
+      "brotli": 3275
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-reject-then-resolve-before-and-after-isolated-boundaries/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6245,
+      "min": 6241,
       "brotli": 2831
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8855,
-      "brotli": 3857
+      "min": 8851,
+      "brotli": 3844
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8859,
-        "brotli": 3861
+        "min": 8855,
+        "brotli": 3855
       },
       "files": {
         "tags/hello/index.marko": 194,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3631,
-        "brotli": 1671
+        "min": 3627,
+        "brotli": 1667
       },
       "files": {
         "tags/hello/index.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3614,
-        "brotli": 1680
+        "min": 3610,
+        "brotli": 1676
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3614,
-        "brotli": 1686
+        "min": 3610,
+        "brotli": 1673
       },
       "files": {
         "tags/my-menu/index.marko": 138,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9903,
-        "brotli": 4332
+        "min": 9899,
+        "brotli": 4310
       },
       "files": {
         "tags/my-menu/index.marko": 540,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3157,
-      "brotli": 1601
+      "min": 3153,
+      "brotli": 1599
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7249,
-        "brotli": 3322
+        "min": 7245,
+        "brotli": 3321
       },
       "files": {
         "tags/child/index.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2849,
-      "brotli": 1421
+      "min": 2845,
+      "brotli": 1415
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-delimited-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3329,
-      "brotli": 1647
+      "min": 3325,
+      "brotli": 1645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-empty-string/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2734,
+      "min": 2730,
       "brotli": 1378
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3746,
-      "brotli": 1698
+      "min": 3742,
+      "brotli": 1692
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-value-with-dollar-brace/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10146,
-      "brotli": 4342
+      "min": 10142,
+      "brotli": 4339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-in-order/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6893,
+      "min": 6889,
       "brotli": 3137
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-within/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6971,
-      "brotli": 3161
+      "min": 6967,
+      "brotli": 3162
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7061,
-      "brotli": 3200
+      "min": 7057,
+      "brotli": 3196
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7106,
-      "brotli": 3201
+      "min": 7102,
+      "brotli": 3200
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-no-try-resume-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7538,
-      "brotli": 3355
+      "min": 7534,
+      "brotli": 3354
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-pending-interrupt-sync/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7135,
-      "brotli": 3179
+      "min": 7131,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-sync-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7085,
-      "brotli": 3148
+      "min": 7081,
+      "brotli": 3143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-tag/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5761,
+      "min": 5757,
       "brotli": 2666
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-toggle-sync-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7135,
-      "brotli": 3179
+      "min": 7131,
+      "brotli": 3183
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2655,
-        "brotli": 1362
+        "min": 2651,
+        "brotli": 1352
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2655,
-        "brotli": 1362
+        "min": 2651,
+        "brotli": 1353
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2777,
-        "brotli": 1395
+        "min": 2773,
+        "brotli": 1397
       },
       "files": {
         "tags/my-button.marko": 356,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2682,
-        "brotli": 1366
+        "min": 2678,
+        "brotli": 1360
       },
       "files": {
         "tags/my-button.marko": 280,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2655,
-        "brotli": 1362
+        "min": 2651,
+        "brotli": 1352
       },
       "files": {
         "tags/my-button.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3050,
-        "brotli": 1545
+        "min": 3046,
+        "brotli": 1542
       },
       "files": {
         "tags/my-button.marko": 130,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter-multiple-nodes/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6291,
+      "min": 6287,
       "brotli": 2866
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-conditional-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6289,
-      "brotli": 2863
+      "min": 6285,
+      "brotli": 2862
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-const-event-handler/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2736,
+      "min": 2732,
       "brotli": 1385
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2809,
-      "brotli": 1423
+      "min": 2805,
+      "brotli": 1424
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6358,
-      "brotli": 2891
+      "min": 6354,
+      "brotli": 2894
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-fn-with-block/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-multi-ref-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2621,
-      "brotli": 1335
+      "min": 2617,
+      "brotli": 1336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-handler-refless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2598,
-      "brotli": 1329
+      "min": 2594,
+      "brotli": 1325
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2842,
-      "brotli": 1425
+      "min": 2838,
+      "brotli": 1426
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-computed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2895,
-      "brotli": 1457
+      "min": 2891,
+      "brotli": 1459
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-member-expression-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2848,
-      "brotli": 1449
+      "min": 2844,
+      "brotli": 1450
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-merge-member-expression/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2924,
+      "min": 2920,
       "brotli": 1441
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7620,
-        "brotli": 3496
+        "min": 7616,
+        "brotli": 3497
       },
       "files": {
         "tags/child.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9432,
+        "min": 9428,
         "brotli": 4098
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3029,
+      "min": 3025,
       "brotli": 1536
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4607,
+      "min": 4603,
       "brotli": 2155
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3099,
+      "min": 3095,
       "brotli": 1535
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6373,
-      "brotli": 2915
+      "min": 6369,
+      "brotli": 2910
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7157,
-      "brotli": 3295
+      "min": 7153,
+      "brotli": 3297
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-shared-node-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7420,
-      "brotli": 3370
+      "min": 7416,
+      "brotli": 3375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-toggle-show/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2613,
-      "brotli": 1333
+      "min": 2609,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-unused-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6260,
-      "brotli": 2861
+      "min": 6256,
+      "brotli": 2857
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/batched-updates/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2745,
-      "brotli": 1396
+      "min": 2741,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3720,
-        "brotli": 1807
+        "min": 3716,
+        "brotli": 1794
       },
       "files": {
         "tags/counter.marko": 449,

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4602,
-        "brotli": 2154
+        "min": 4598,
+        "brotli": 2148
       },
       "files": {
         "tags/FancyButton.marko": 238,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4178,
-      "brotli": 1949
+      "min": 4180,
+      "brotli": 1953
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12778,
-      "brotli": 4968
+      "min": 12774,
+      "brotli": 4970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3678,
-      "brotli": 1756
+      "min": 3674,
+      "brotli": 1755
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
+      "min": 2598,
       "brotli": 1327
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4339,
-      "brotli": 2020
+      "min": 4335,
+      "brotli": 2021
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4220,
-      "brotli": 1963
+      "min": 4216,
+      "brotli": 1964
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4333,
-      "brotli": 2009
+      "min": 4335,
+      "brotli": 2007
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/branch-closure-if-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2645,
-      "brotli": 1335
+      "min": 2641,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-catch-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7187,
-      "brotli": 3265
+      "min": 7183,
+      "brotli": 3259
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await-same-tick/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7144,
-      "brotli": 3239
+      "min": 7140,
+      "brotli": 3231
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-nested-in-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7144,
-      "brotli": 3239
+      "min": 7140,
+      "brotli": 3231
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-reject-sibling-pending-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7164,
-      "brotli": 3249
+      "min": 7160,
+      "brotli": 3241
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-serialized-globals/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6927,
-      "brotli": 3148
+      "min": 6923,
+      "brotli": 3143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/change-handler-alias-assignment/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1947,
+      "min": 1943,
       "brotli": 1004
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7914,
-        "brotli": 3604
+        "min": 7910,
+        "brotli": 3606
       },
       "files": {
         "tags/child.marko": 714,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7683,
-        "brotli": 3405
+        "min": 7679,
+        "brotli": 3403
       },
       "files": {
         "tags/child.marko": 726,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6276,
-      "brotli": 2866
+      "min": 6272,
+      "brotli": 2862
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6457,
-        "brotli": 2938
+        "min": 6453,
+        "brotli": 2936
       },
       "files": {
         "tags/child.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8333,
-        "brotli": 3796
+        "min": 8329,
+        "brotli": 3789
       },
       "files": {
         "tags/child.marko": 566,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7864,
-        "brotli": 3590
+        "min": 7860,
+        "brotli": 3588
       },
       "files": {
         "tags/child.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7619,
+        "min": 7615,
         "brotli": 3380
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6258,
-      "brotli": 2852
+      "min": 6254,
+      "brotli": 2854
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6439,
-        "brotli": 2925
+        "min": 6435,
+        "brotli": 2926
       },
       "files": {
         "tags/child.marko": 342,

--- a/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/closure-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6288,
-      "brotli": 2865
+      "min": 6284,
+      "brotli": 2867
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2729,
-      "brotli": 1388
+      "min": 2725,
+      "brotli": 1386
     }
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2824,
-        "brotli": 1425
+        "min": 2820,
+        "brotli": 1426
       },
       "files": {
         "tags/display-intersection.marko": 225,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-code/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2823,
-        "brotli": 1422
+        "min": 2819,
+        "brotli": 1426
       },
       "files": {
         "tags/counter.marko": 324,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10984,
-        "brotli": 4786
+        "min": 10980,
+        "brotli": 4781
       },
       "files": {
         "tags/sections.marko": 734,

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2614,
-      "brotli": 1336
+      "min": 2610,
+      "brotli": 1335
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-table-row/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5996,
-      "brotli": 2751
+      "min": 5992,
+      "brotli": 2750
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-array-pattern/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2603,
-      "brotli": 1327
+      "min": 2599,
+      "brotli": 1330
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-async-method-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2666,
-      "brotli": 1361
+      "min": 2662,
+      "brotli": 1362
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-logical-nullable-member/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2907,
+      "min": 2903,
       "brotli": 1440
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-attr-meta/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2728,
-      "brotli": 1373
+      "min": 2724,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2725,
-      "brotli": 1380
+      "min": 2721,
+      "brotli": 1383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-with-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3068,
-        "brotli": 1555
+        "min": 3064,
+        "brotli": 1552
       },
       "files": {
         "tags/outer.marko": 162,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8539,
-      "brotli": 3823
+      "min": 8541,
+      "brotli": 3825
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7304,
-        "brotli": 2994
+        "min": 7300,
+        "brotli": 2998
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7365,
-      "brotli": 3040
+      "min": 7361,
+      "brotli": 3041
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4291,
-      "brotli": 1954
+      "min": 4293,
+      "brotli": 1957
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4666,
-      "brotli": 2061
+      "min": 4662,
+      "brotli": 2060
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4416,
-      "brotli": 1977
+      "min": 4418,
+      "brotli": 1982
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-rejected/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-rejected/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2847,
-      "brotli": 1348
+      "min": 2849,
+      "brotli": 1346
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7561,
-        "brotli": 3076
+        "min": 7557,
+        "brotli": 3078
       },
       "files": {
         "tags/radio.marko": 280,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4428,
+      "min": 4430,
       "brotli": 2013
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7564,
-        "brotli": 3077
+        "min": 7560,
+        "brotli": 3079
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4428,
+      "min": 4430,
       "brotli": 2013
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3334,
-      "brotli": 1584
+      "min": 3336,
+      "brotli": 1590
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4675,
-        "brotli": 2132
+        "min": 4671,
+        "brotli": 2131
       },
       "files": {
         "tags/my-details.marko": 257,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4910,
-      "brotli": 2247
+      "min": 4906,
+      "brotli": 2253
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6347,
-        "brotli": 2765
+        "min": 6343,
+        "brotli": 2764
       },
       "files": {
         "tags/my-dialog.marko": 264,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8399,
-      "brotli": 3663
+      "min": 8395,
+      "brotli": 3666
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14188,
-      "brotli": 5541
+      "min": 14184,
+      "brotli": 5538
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-only-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13746,
-      "brotli": 5340
+      "min": 13742,
+      "brotli": 5337
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13620,
-      "brotli": 5288
+      "min": 13616,
+      "brotli": 5286
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4132,
-        "brotli": 1921
+        "min": 4134,
+        "brotli": 1924
       },
       "files": {
         "tags/custom-input.marko": 496,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4148,
-        "brotli": 1924
+        "min": 4150,
+        "brotli": 1929
       },
       "files": {
         "tags/my-input.marko": 507,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3862,
+      "min": 3864,
       "brotli": 1819
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7283,
-        "brotli": 2985
+        "min": 7279,
+        "brotli": 2988
       },
       "files": {
         "tags/my-input.marko": 256,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3834,
-      "brotli": 1811
+      "min": 3836,
+      "brotli": 1815
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7321,
+      "min": 7317,
       "brotli": 3023
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6208,
-      "brotli": 2694
+      "min": 6204,
+      "brotli": 2695
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7337,
-      "brotli": 3020
+      "min": 7333,
+      "brotli": 3019
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4428,
+      "min": 4430,
       "brotli": 2013
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13904,
-      "brotli": 5392
+      "min": 13900,
+      "brotli": 5388
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4526,
-      "brotli": 2019
+      "min": 4522,
+      "brotli": 2010
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9140,
-      "brotli": 3984
+      "min": 9136,
+      "brotli": 3978
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4433,
-      "brotli": 1987
+      "min": 4429,
+      "brotli": 1985
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9363,
-      "brotli": 4052
+      "min": 9359,
+      "brotli": 4054
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8993,
-        "brotli": 3688
+        "min": 8989,
+        "brotli": 3689
       },
       "files": {
         "tags/my-select.marko": 266,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4110,
-      "brotli": 1847
+      "min": 4112,
+      "brotli": 1851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4110,
-      "brotli": 1847
+      "min": 4112,
+      "brotli": 1851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4414,
-      "brotli": 1973
+      "min": 4410,
+      "brotli": 1976
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4211,
-      "brotli": 1893
+      "min": 4213,
+      "brotli": 1895
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 5615,
-        "brotli": 2480
+        "min": 5611,
+        "brotli": 2479
       },
       "files": {
         "tags/my-textarea.marko": 262,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3834,
-      "brotli": 1811
+      "min": 3836,
+      "brotli": 1815
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/counter-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2805,
-      "brotli": 1418
+      "min": 2801,
+      "brotli": 1413
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3264,
-        "brotli": 1620
+        "min": 3260,
+        "brotli": 1625
       },
       "files": {
         "tags/my-let.marko": 241,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-runtime-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2610,
-      "brotli": 1333
+      "min": 2606,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2638,
-        "brotli": 1341
+        "min": 2634,
+        "brotli": 1342
       },
       "files": {
         "tags/cell/index.marko": 121,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2704,
-        "brotli": 1372
+        "min": 2700,
+        "brotli": 1381
       },
       "files": {
         "tags/press-button/index.marko": 145,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2651,
-        "brotli": 1342
+        "min": 2647,
+        "brotli": 1345
       },
       "files": {
         "tags/show-result/index.marko": 116,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-args/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8989,
+        "min": 8985,
         "brotli": 3904
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-attributes/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8975,
-        "brotli": 3903
+        "min": 8971,
+        "brotli": 3899
       },
       "files": {
         "tags/custom-tag.marko": 501,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-parameters-from-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8903,
-        "brotli": 3872
+        "min": 8899,
+        "brotli": 3863
       },
       "files": {
         "tags/custom-tag.marko": 446,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-assignment/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2937,
+        "min": 2933,
         "brotli": 1447
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3247,
-        "brotli": 1598
+        "min": 3243,
+        "brotli": 1605
       },
       "files": {
         "tags/child.marko": 454,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2959,
-        "brotli": 1484
+        "min": 2955,
+        "brotli": 1494
       },
       "files": {
         "tags/child.marko": 366,

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2704,
-        "brotli": 1367
+        "min": 2700,
+        "brotli": 1363
       },
       "files": {
         "tags/child.marko": 264,

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-content-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6400,
-      "brotli": 2918
+      "min": 6396,
+      "brotli": 2914
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8805,
-        "brotli": 3808
+        "min": 8801,
+        "brotli": 3810
       },
       "files": {
         "tags/child.marko": 409,

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-object/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2661,
+      "min": 2657,
       "brotli": 1362
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2727,
-      "brotli": 1391
+      "min": 2723,
+      "brotli": 1393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2633,
-      "brotli": 1339
+      "min": 2629,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2633,
-      "brotli": 1338
+      "min": 2629,
+      "brotli": 1340
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2633,
-      "brotli": 1338
+      "min": 2629,
+      "brotli": 1342
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6675,
-      "brotli": 3040
+      "min": 6671,
+      "brotli": 3043
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6341,
+      "min": 6337,
       "brotli": 2905
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2633,
-      "brotli": 1337
+      "min": 2629,
+      "brotli": 1342
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2615,
-      "brotli": 1335
+      "min": 2611,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4698,
-        "brotli": 2180
+        "min": 4694,
+        "brotli": 2183
       },
       "files": {
         "tags/child.marko": 187,

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2845,
-      "brotli": 1434
+      "min": 2841,
+      "brotli": 1433
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7449,
-        "brotli": 3400
+        "min": 7445,
+        "brotli": 3398
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/details-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dollar-global-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6183,
-      "brotli": 2813
+      "min": 6179,
+      "brotli": 2812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5772,
-      "brotli": 2667
+      "min": 5768,
+      "brotli": 2670
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3043,
-      "brotli": 1538
+      "min": 3039,
+      "brotli": 1533
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5953,
-      "brotli": 2696
+      "min": 5949,
+      "brotli": 2697
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-event-handlers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2615,
-      "brotli": 1338
+      "min": 2611,
+      "brotli": 1339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-dynamic-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8748,
-      "brotli": 3794
+      "min": 8744,
+      "brotli": 3791
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-native-tag-events/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8635,
-      "brotli": 3748
+      "min": 8631,
+      "brotli": 3740
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9542,
-        "brotli": 4091
+        "min": 9538,
+        "brotli": 4092
       },
       "files": {
         "tags/custom-tag.marko": 347,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9622,
-        "brotli": 4114
+        "min": 9618,
+        "brotli": 4111
       },
       "files": {
         "tags/custom-tag.marko": 339,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9435,
-        "brotli": 4052
+        "min": 9431,
+        "brotli": 4049
       },
       "files": {
         "tags/custom-tag.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-attr-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2891,
-      "brotli": 1431
+      "min": 2887,
+      "brotli": 1429
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6393,
-        "brotli": 2911
+        "min": 6389,
+        "brotli": 2908
       },
       "files": {
         "tags/inner.marko": 165,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9458,
-        "brotli": 4062
+        "min": 9454,
+        "brotli": 4063
       },
       "files": {
         "tags/child.marko": 321,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14521,
-        "brotli": 5632
+        "min": 14517,
+        "brotli": 5627
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-input-intersection/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13598,
-        "brotli": 5293
+        "min": 13594,
+        "brotli": 5291
       },
       "files": {
         "tags/my-tag.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3313
+      "min": 8496,
+      "brotli": 3312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8629,
-      "brotli": 3683
+      "min": 8625,
+      "brotli": 3680
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-null-after-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-null-after-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8995,
-      "brotli": 3917
+      "min": 8991,
+      "brotli": 3916
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9380,
-        "brotli": 4052
+        "min": 9376,
+        "brotli": 4045
       },
       "files": {
         "tags/child.marko": 393,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-single-arg/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9480,
-        "brotli": 4065
+        "min": 9476,
+        "brotli": 4069
       },
       "files": {
         "tags/custom-tag.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-sometimes-null/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8602,
-      "brotli": 3724
+      "min": 8598,
+      "brotli": 3723
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3313
+      "min": 8496,
+      "brotli": 3312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-assignment/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2807,
-        "brotli": 1405
+        "min": 2803,
+        "brotli": 1407
       },
       "files": {
         "tags/counter.marko": 379,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-var-destructured/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2898,
-        "brotli": 1448
+        "min": 2894,
+        "brotli": 1449
       },
       "files": {
         "tags/child/index.marko": 312,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-with-updating-body/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8864,
-        "brotli": 3828
+        "min": 8860,
+        "brotli": 3829
       },
       "files": {
         "tags/counter.marko": 389,

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-control-flow-boundary/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6791,
+      "min": 6787,
       "brotli": 3056
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3370,
-      "brotli": 1663
+      "min": 3366,
+      "brotli": 1658
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/embed-removal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2863,
-      "brotli": 1395
+      "min": 2859,
+      "brotli": 1407
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+const $template = "<div> </div>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#div/0"], "name", function() {
+	$n($scope, $scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "name", function() {
+	$n($scope, $scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<div>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</div>${_el_resume($scope0_id, "#div/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<div>${_escape(n)}${_el_resume($scope0_id, "b")}</div>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/render.debug.md
@@ -1,0 +1,24 @@
+# Render
+```html
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document
+.querySelector("div") 
+.dispatchEvent(
+  new (document.defaultView).CustomEvent("name", { bubbles: true }),
+);
+```
+```html
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/render.md
@@ -1,0 +1,24 @@
+# Render
+```html
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document
+.querySelector("div") 
+.dispatchEvent(
+  new (document.defaultView).CustomEvent("name", { bubbles: true }),
+);
+```
+```html
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<div>0<!--M_*1 #text/1--></div><!--M_*1 #div/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<div>0<!--M_*1 b--></div><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2597,
+      "brotli": 1327
+    }
+  },
+  "html": {
+    "min": 346,
+    "brotli": 244
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/template.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<div on-name() { n++ }>${n}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-function-property-name/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function fireName(document: Document) {
+  document
+    .querySelector("div")!
+    .dispatchEvent(
+      new (document.defaultView as any).CustomEvent("name", { bubbles: true }),
+    );
+}
+
+export const config: TestConfig = {
+  steps: [{}, fireName],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-handler-class-methods/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2729,
-      "brotli": 1390
+      "min": 2725,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/event-single-letter-camel/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/event-single-letter-camel/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2598,
-      "brotli": 1326
+      "min": 2594,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/export-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2730,
-      "brotli": 1368
+      "min": 2726,
+      "brotli": 1370
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/expression-statement-tag-var-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2723,
-      "brotli": 1372
+      "min": 2719,
+      "brotli": 1371
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-array-destructure-rest/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7319,
-      "brotli": 3357
+      "min": 7315,
+      "brotli": 3360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-nested-branch-divergence/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7949,
-      "brotli": 3608
+      "min": 7945,
+      "brotli": 3612
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-prefix-reorder-remove/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7415,
-      "brotli": 3380
+      "min": 7411,
+      "brotli": 3375
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-use-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8032,
-      "brotli": 3640
+      "min": 8028,
+      "brotli": 3638
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7522,
-      "brotli": 3376
+      "min": 7518,
+      "brotli": 3379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-conditional-only-child-range/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8003,
-      "brotli": 3627
+      "min": 7999,
+      "brotli": 3643
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-destructure/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7263,
+      "min": 7259,
       "brotli": 3331
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-empty-bodies/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-event-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7067,
-      "brotli": 3276
+      "min": 7063,
+      "brotli": 3273
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-in-by/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7074,
-      "brotli": 3276
+      "min": 7070,
+      "brotli": 3274
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-handler-live-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7333,
-      "brotli": 3365
+      "min": 7329,
+      "brotli": 3366
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-item-member-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7342,
-      "brotli": 3368
+      "min": 7338,
+      "brotli": 3369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-class/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8370,
-      "brotli": 3755
+      "min": 8366,
+      "brotli": 3754
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-handler-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3470,
-      "brotli": 1686
+      "min": 3466,
+      "brotli": 1687
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6569,
-      "brotli": 2970
+      "min": 6565,
+      "brotli": 2971
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3209,
-      "brotli": 1572
+      "min": 3205,
+      "brotli": 1576
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3212,
-      "brotli": 1573
+      "min": 3208,
+      "brotli": 1578
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-mixed-key-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8447,
-      "brotli": 3808
+      "min": 8443,
+      "brotli": 3804
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-multiple/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3638,
-      "brotli": 1767
+      "min": 3634,
+      "brotli": 1769
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-parent-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3783,
-      "brotli": 1799
+      "min": 3779,
+      "brotli": 1800
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-prepend/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8194,
-      "brotli": 3713
+      "min": 8190,
+      "brotli": 3731
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3451,
-      "brotli": 1683
+      "min": 3447,
+      "brotli": 1684
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-loop-closure-remove-all-items/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7001,
-      "brotli": 3230
+      "min": 6997,
+      "brotli": 3232
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7731,
-        "brotli": 3572
+        "min": 7727,
+        "brotli": 3561
       },
       "files": {
         "tags/list.marko": 295,

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8145,
+        "min": 8141,
         "brotli": 3707
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-row-with-not-taken-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-row-with-not-taken-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7532,
-      "brotli": 3444
+      "min": 7528,
+      "brotli": 3451
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3451,
+      "min": 3447,
       "brotli": 1683
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3453,
-      "brotli": 1684
+      "min": 3449,
+      "brotli": 1683
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-nested-branch-reject/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3446,
-      "brotli": 1697
+      "min": 3442,
+      "brotli": 1700
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3238,
+      "min": 3234,
       "brotli": 1593
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3453,
-      "brotli": 1684
+      "min": 3449,
+      "brotli": 1683
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-serialize-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2163,
-      "brotli": 1074
+      "min": 2159,
+      "brotli": 1076
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-tag-static-value-with-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2819,
-      "brotli": 1420
+      "min": 2815,
+      "brotli": 1422
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-to-range-resume-key/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7072,
-      "brotli": 3290
+      "min": 7068,
+      "brotli": 3284
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-unchanged-args-skip-params/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7313,
-      "brotli": 3362
+      "min": 7309,
+      "brotli": 3358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1905,
-      "brotli": 985
+      "min": 1901,
+      "brotli": 984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-default-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1917,
-      "brotli": 995
+      "min": 1913,
+      "brotli": 992
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/function-tag-var-registration/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1917,
-      "brotli": 996
+      "min": 1913,
+      "brotli": 995
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/getter-on-single-node-only-child/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7207,
+      "min": 7203,
       "brotli": 3326
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9245,
-        "brotli": 3955
+        "min": 9241,
+        "brotli": 3953
       },
       "files": {
         "tags/thing.marko": 360,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10005,
-        "brotli": 4232
+        "min": 10001,
+        "brotli": 4230
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9054,
+        "min": 9050,
         "brotli": 3872
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2651,
-      "brotli": 1349
+      "min": 2647,
+      "brotli": 1351
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-empty-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-empty-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2798,
-      "brotli": 1428
+      "min": 2794,
+      "brotli": 1421
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-marked-end-tag-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-marked-end-tag-order/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1332
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6386,
-      "brotli": 2900
+      "min": 6382,
+      "brotli": 2905
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2752,
+      "min": 2748,
       "brotli": 1394
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6375,
-      "brotli": 2890
+      "min": 6371,
+      "brotli": 2894
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2653,
-      "brotli": 1357
+      "min": 2649,
+      "brotli": 1360
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/id-tag-default/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2941,
+      "min": 2937,
       "brotli": 1463
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-default-false/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 5978,
-      "brotli": 2739
+      "min": 5974,
+      "brotli": 2736
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-else-chain-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6138,
-      "brotli": 2808
+      "min": 6134,
+      "brotli": 2812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-nested-not-taken/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-nested-not-taken/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6289,
-      "brotli": 2876
+      "min": 6285,
+      "brotli": 2879
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-no-content-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6119,
-      "brotli": 2793
+      "min": 6115,
+      "brotli": 2792
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-not-taken-after-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-not-taken-after-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9080,
-      "brotli": 3963
+      "min": 9076,
+      "brotli": 3965
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6499,
-        "brotli": 2956
+        "min": 6495,
+        "brotli": 2950
       },
       "files": {
         "tags/leaf.marko": 381,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6711,
-        "brotli": 3030
+        "min": 6707,
+        "brotli": 3028
       },
       "files": {
         "tags/leaf.marko": 274,

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6680,
-        "brotli": 3021
+        "min": 6676,
+        "brotli": 3018
       },
       "files": {
         "tags/child.marko": 332,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2760,
-        "brotli": 1395
+        "min": 2756,
+        "brotli": 1388
       },
       "files": {
         "tags/greeting.marko": 242,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2686,
-        "brotli": 1365
+        "min": 2682,
+        "brotli": 1360
       },
       "files": {
         "tags/extras.marko": 93,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2686,
-        "brotli": 1362
+        "min": 2682,
+        "brotli": 1357
       },
       "files": {
         "tags/chain-b.marko": 92,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9508,
+        "min": 9504,
         "brotli": 4074
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2666,
+        "min": 2662,
         "brotli": 1358
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2759,
-        "brotli": 1378
+        "min": 2755,
+        "brotli": 1377
       },
       "files": {
         "tags/greeting.marko": 190,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2663,
-        "brotli": 1354
+        "min": 2659,
+        "brotli": 1357
       },
       "files": {
         "tags/handlers.marko": 108,

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2680,
+        "min": 2676,
         "brotli": 1360
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2680,
+        "min": 2676,
         "brotli": 1360
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3289,
-      "brotli": 1616
+      "min": 3285,
+      "brotli": 1612
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-control-flow-only-child-select-event/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3295,
-      "brotli": 1624
+      "min": 3291,
+      "brotli": 1610
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2727,
-      "brotli": 1386
+      "min": 2723,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2727,
-      "brotli": 1386
+      "min": 2723,
+      "brotli": 1387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7212,
-      "brotli": 2986
+      "min": 7208,
+      "brotli": 2989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6466,
-      "brotli": 2951
+      "min": 6462,
+      "brotli": 2952
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7293,
-        "brotli": 2988
+        "min": 7289,
+        "brotli": 2989
       },
       "files": {
         "tags/my-input.marko": 371,

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-derived-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2612,
-      "brotli": 1334
+      "min": 2608,
+      "brotli": 1333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-chain/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2630,
+      "min": 2626,
       "brotli": 1340
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-dup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2620,
-      "brotli": 1338
+      "min": 2616,
+      "brotli": 1339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-effect/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2556,
+      "min": 2552,
       "brotli": 1312
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2734,
-      "brotli": 1381
+      "min": 2730,
+      "brotli": 1383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-inline-prop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2755,
-      "brotli": 1398
+      "min": 2751,
+      "brotli": 1397
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2713,
-        "brotli": 1375
+        "min": 2709,
+        "brotli": 1374
       },
       "files": {
         "tags/child.marko": 199,

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-nullable-prop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2774,
-      "brotli": 1410
+      "min": 2770,
+      "brotli": 1412
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-single-state-source/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2775,
-      "brotli": 1404
+      "min": 2771,
+      "brotli": 1402
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-formatters-resumed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-formatters-resumed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2791,
-      "brotli": 1411
+      "min": 2787,
+      "brotli": 1416
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-define-tag-empty-section-fn-closure-element-reference/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1911,
-      "brotli": 994
+      "min": 1907,
+      "brotli": 996
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 1973,
-        "brotli": 1013
+        "min": 1969,
+        "brotli": 1012
       },
       "files": {
         "tags/child.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2983,
-      "brotli": 1506
+      "min": 2979,
+      "brotli": 1508
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2633,
-        "brotli": 1341
+        "min": 2629,
+        "brotli": 1339
       },
       "files": {
         "tags/child/index.marko": 104,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7533,
+        "min": 7529,
         "brotli": 3452
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2633,
-        "brotli": 1341
+        "min": 2629,
+        "brotli": 1339
       },
       "files": {
         "tags/child/index.marko": 110,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2757,
-        "brotli": 1403
+        "min": 2753,
+        "brotli": 1402
       },
       "files": {
         "tags/leaf.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2633,
-        "brotli": 1341
+        "min": 2629,
+        "brotli": 1339
       },
       "files": {
         "tags/child-b/index.marko": 112,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2851,
+        "min": 2847,
         "brotli": 1434
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-chained/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-chained/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 107
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-async-in-child/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 152
     },
     "shared": {
-      "min": 5966,
-      "brotli": 2837
+      "min": 5962,
+      "brotli": 2832
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 103
     },
     "shared": {
-      "min": 5289,
-      "brotli": 2492
+      "min": 5285,
+      "brotli": 2489
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 80
     },
     "shared": {
-      "min": 7575,
-      "brotli": 3389
+      "min": 7571,
+      "brotli": 3383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-state/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 81
     },
     "shared": {
-      "min": 7597,
-      "brotli": 3392
+      "min": 7593,
+      "brotli": 3386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 150
     },
     "shared": {
-      "min": 11120,
-      "brotli": 4788
+      "min": 11116,
+      "brotli": 4790
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-unmount-before-load/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 164
     },
     "shared": {
-      "min": 11001,
-      "brotli": 4739
+      "min": 10997,
+      "brotli": 4738
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 150
     },
     "shared": {
-      "min": 10778,
-      "brotli": 4643
+      "min": 10774,
+      "brotli": 4645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7539,
-      "brotli": 3339
+      "min": 7535,
+      "brotli": 3333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7539,
-      "brotli": 3339
+      "min": 7535,
+      "brotli": 3333
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 69
     },
     "shared": {
-      "min": 7879,
-      "brotli": 3480
+      "min": 7875,
+      "brotli": 3481
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-event-handler/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 118
     },
     "shared": {
-      "min": 5174,
-      "brotli": 2415
+      "min": 5170,
+      "brotli": 2410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 7890,
-      "brotli": 3481
+      "min": 7886,
+      "brotli": 3482
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 134
     },
     "shared": {
-      "min": 10836,
-      "brotli": 4695
+      "min": 10832,
+      "brotli": 4697
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 101
     },
     "shared": {
-      "min": 5351,
-      "brotli": 2547
+      "min": 5347,
+      "brotli": 2544
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 160
     },
     "shared": {
-      "min": 6089,
-      "brotli": 2915
+      "min": 6085,
+      "brotli": 2912
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 5756,
-      "brotli": 2777
+      "min": 5752,
+      "brotli": 2773
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 5756,
-      "brotli": 2777
+      "min": 5752,
+      "brotli": 2773
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 158
     },
     "shared": {
-      "min": 5756,
-      "brotli": 2777
+      "min": 5752,
+      "brotli": 2773
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 136
     },
     "shared": {
-      "min": 5289,
-      "brotli": 2492
+      "min": 5285,
+      "brotli": 2489
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 6948,
-      "brotli": 3103
+      "min": 6944,
+      "brotli": 3095
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-reorder-stream-order/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 113
     },
     "shared": {
-      "min": 6454,
-      "brotli": 2909
+      "min": 6450,
+      "brotli": 2908
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 105
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 113
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/sizes.json
@@ -20,8 +20,8 @@
       "brotli": 103
     },
     "shared": {
-      "min": 5289,
-      "brotli": 2492
+      "min": 5285,
+      "brotli": 2489
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-sibling-binding/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-sibling-binding/sizes.json
@@ -21,8 +21,8 @@
       "brotli": 111
     },
     "shared": {
-      "min": 5174,
-      "brotli": 2415
+      "min": 5170,
+      "brotli": 2410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-twice/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-twice/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 107
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-unmount-before-load/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 75
     },
     "shared": {
-      "min": 9064,
-      "brotli": 3915
+      "min": 9060,
+      "brotli": 3909
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 71
     },
     "shared": {
-      "min": 5231,
-      "brotli": 2440
+      "min": 5227,
+      "brotli": 2437
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-parent-resume/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-parent-resume/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 105
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 106
     },
     "shared": {
-      "min": 5172,
-      "brotli": 2413
+      "min": 5168,
+      "brotli": 2409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-basic-member-expression-never-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2745,
-      "brotli": 1385
+      "min": 2741,
+      "brotli": 1388
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7779,
-        "brotli": 3541
+        "min": 7775,
+        "brotli": 3535
       },
       "files": {
         "tags/store.marko": 395,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3043,
-        "brotli": 1524
+        "min": 3039,
+        "brotli": 1523
       },
       "files": {
         "tags/child.marko": 349,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3006,
-        "brotli": 1512
+        "min": 3002,
+        "brotli": 1507
       },
       "files": {
         "tags/child.marko": 315,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3325,
-        "brotli": 1650
+        "min": 3321,
+        "brotli": 1664
       },
       "files": {
         "tags/let-global.marko": 572,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-intersection-child-var-define/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2994,
-      "brotli": 1500
+      "min": 2990,
+      "brotli": 1509
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3334,
-        "brotli": 1601
+        "min": 3330,
+        "brotli": 1620
       },
       "files": {
         "tags/child.marko": 1222,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3005,
-      "brotli": 1496
+      "min": 3001,
+      "brotli": 1499
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2957,
-      "brotli": 1487
+      "min": 2953,
+      "brotli": 1489
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2833,
-      "brotli": 1426
+      "min": 2829,
+      "brotli": 1427
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2596,
-      "brotli": 1328
+      "min": 2592,
+      "brotli": 1331
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2785,
-      "brotli": 1408
+      "min": 2781,
+      "brotli": 1409
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2763,
-      "brotli": 1388
+      "min": 2759,
+      "brotli": 1386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-assignment/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3030,
-      "brotli": 1507
+      "min": 3026,
+      "brotli": 1511
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional-child-cleanup/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6496,
-        "brotli": 2917
+        "min": 6492,
+        "brotli": 2919
       },
       "files": {
         "tags/child.marko": 357,

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-conditional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6725,
-      "brotli": 2983
+      "min": 6721,
+      "brotli": 2988
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-return-init/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-return-init/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2959,
+      "min": 2955,
       "brotli": 1478
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag-this/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2958,
-      "brotli": 1476
+      "min": 2954,
+      "brotli": 1475
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lifecycle-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2971,
-      "brotli": 1461
+      "min": 2967,
+      "brotli": 1457
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3062,
-      "brotli": 1517
+      "min": 3058,
+      "brotli": 1513
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multi-class-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3003,
-      "brotli": 1484
+      "min": 2999,
+      "brotli": 1479
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4081,
-      "brotli": 1916
+      "min": 4077,
+      "brotli": 1917
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3213,
-        "brotli": 1563
+        "min": 3209,
+        "brotli": 1566
       },
       "files": {
         "tags/2counters.marko": 836,

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9399,
+      "min": 9395,
       "brotli": 4042
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2974,
-      "brotli": 1498
+      "min": 2970,
+      "brotli": 1495
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-closure/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2696,
+      "min": 2692,
       "brotli": 1365
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4317,
-      "brotli": 2017
+      "min": 4313,
+      "brotli": 2011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2753,
-      "brotli": 1389
+      "min": 2749,
+      "brotli": 1391
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-iife/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-iife/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2839,
-      "brotli": 1431
+      "min": 2835,
+      "brotli": 1428
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2660,
-      "brotli": 1352
+      "min": 2656,
+      "brotli": 1354
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-param/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-param/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2617,
-      "brotli": 1337
+      "min": 2613,
+      "brotli": 1339
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2774,
-      "brotli": 1402
+      "min": 2770,
+      "brotli": 1404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2676,
-      "brotli": 1354
+      "min": 2672,
+      "brotli": 1355
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-content-attr-with-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-content-attr-with-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2502,
-      "brotli": 1289
+      "min": 2498,
+      "brotli": 1288
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-duplicate-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-duplicate-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1873,
-      "brotli": 970
+      "min": 1869,
+      "brotli": 973
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9914,
-      "brotli": 4313
+      "min": 9910,
+      "brotli": 4303
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3545,
-        "brotli": 1656
+        "min": 3541,
+        "brotli": 1658
       },
       "files": {
         "tags/my-box.marko": 124,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2737,
-        "brotli": 1375
+        "min": 2733,
+        "brotli": 1378
       },
       "files": {
         "tags/my-box.marko": 207,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3545,
-        "brotli": 1656
+        "min": 3541,
+        "brotli": 1658
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4278,
-        "brotli": 1987
+        "min": 4274,
+        "brotli": 1993
       },
       "files": {
         "tags/my-box.marko": 350,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9031,
-        "brotli": 3916
+        "min": 9027,
+        "brotli": 3920
       },
       "files": {
         "tags/render-input.marko": 289,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2717,
-        "brotli": 1370
+        "min": 2713,
+        "brotli": 1374
       },
       "files": {
         "tags/my-box.marko": 119,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3612,
-      "brotli": 1664
+      "min": 3608,
+      "brotli": 1662
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 4094,
+        "min": 4090,
         "brotli": 1934
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-assignment-expression/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2664,
-      "brotli": 1350
+      "min": 2660,
+      "brotli": 1352
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/nested-for-if-stateful/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8044,
+      "min": 8040,
       "brotli": 3636
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-destructure-dynamic-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3502,
-      "brotli": 1716
+      "min": 3498,
+      "brotli": 1709
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-adjacent-static-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-adjacent-static-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2632,
-      "brotli": 1346
+      "min": 2628,
+      "brotli": 1345
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2618,
-      "brotli": 1334
+      "min": 2614,
+      "brotli": 1336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 2009,
-        "brotli": 1027
+        "min": 2005,
+        "brotli": 1028
       },
       "files": {
         "tags/my-button.marko": 122,

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2620,
-      "brotli": 1333
+      "min": 2616,
+      "brotli": 1336
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/read-proposed-tag-variable-after-write/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2636,
-      "brotli": 1338
+      "min": 2632,
+      "brotli": 1342
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/reassignment-expression-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2705,
-      "brotli": 1344
+      "min": 2701,
+      "brotli": 1347
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/regexp-attr/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2758,
+      "min": 2754,
       "brotli": 1388
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-adoption/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7991,
-      "brotli": 3617
+      "min": 7987,
+      "brotli": 3615
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8719,
-        "brotli": 3935
+        "min": 8715,
+        "brotli": 3936
       },
       "files": {
         "tags/child.marko": 869,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-single-node/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7703,
-      "brotli": 3501
+      "min": 7699,
+      "brotli": 3506
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3264,
-        "brotli": 1620
+        "min": 3260,
+        "brotli": 1625
       },
       "files": {
         "tags/my-let.marko": 241,

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3265,
-      "brotli": 1575
+      "min": 3261,
+      "brotli": 1580
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-non-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2698,
-      "brotli": 1369
+      "min": 2694,
+      "brotli": 1366
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-value-arrow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2639,
-      "brotli": 1346
+      "min": 2635,
+      "brotli": 1351
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4203,
-      "brotli": 1889
+      "min": 4205,
+      "brotli": 1892
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4077,
-      "brotli": 1868
+      "min": 4073,
+      "brotli": 1863
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-function-named/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2686,
-      "brotli": 1362
+      "min": 2682,
+      "brotli": 1358
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/self-reference-native-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1896,
-      "brotli": 981
+      "min": 1892,
+      "brotli": 980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-cycle-repeat-reference/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2680,
+      "min": 2676,
       "brotli": 1368
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-promise-scoped-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2863,
-      "brotli": 1439
+      "min": 2859,
+      "brotli": 1435
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/serialize-set-ancestor-member/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/serialize-set-ancestor-member/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2655,
-      "brotli": 1354
+      "min": 2651,
+      "brotli": 1357
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/shadow-same-scope/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2783,
-      "brotli": 1372
+      "min": 2779,
+      "brotli": 1374
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4360,
+      "min": 4356,
       "brotli": 2081
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-for-body-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4356,
-      "brotli": 2076
+      "min": 4352,
+      "brotli": 2074
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-hidden/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4358,
-      "brotli": 2077
+      "min": 4354,
+      "brotli": 2076
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-empties/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6675,
-      "brotli": 2993
+      "min": 6671,
+      "brotli": 2994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-if-body-toggle/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4360,
-      "brotli": 2081
+      "min": 4356,
+      "brotli": 2077
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-in-for/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4553,
-      "brotli": 2161
+      "min": 4549,
+      "brotli": 2155
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-interactive-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4509,
-      "brotli": 2143
+      "min": 4505,
+      "brotli": 2141
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4431,
-      "brotli": 2106
+      "min": 4427,
+      "brotli": 2102
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child-interactive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4505,
-      "brotli": 2141
+      "min": 4501,
+      "brotli": 2138
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4379,
-      "brotli": 2087
+      "min": 4375,
+      "brotli": 2086
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4358,
-      "brotli": 2077
+      "min": 4354,
+      "brotli": 2076
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-text-prefix-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4519,
-      "brotli": 2155
+      "min": 4515,
+      "brotli": 2152
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2203,
-      "brotli": 1098
+      "min": 2199,
+      "brotli": 1101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7252,
-      "brotli": 2979
+      "min": 7248,
+      "brotli": 2981
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4474,
+      "min": 4470,
       "brotli": 2060
     }
   }

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3573,
-        "brotli": 1656
+        "min": 3569,
+        "brotli": 1657
       },
       "files": {
         "tags/child.marko": 132,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3573,
-      "brotli": 1655
+      "min": 3569,
+      "brotli": 1653
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 3573,
-        "brotli": 1653
+        "min": 3569,
+        "brotli": 1658
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1949,
-      "brotli": 1002
+      "min": 1945,
+      "brotli": 1003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14907,
+        "min": 14903,
         "brotli": 5928
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6967,
-        "brotli": 2713
+        "min": 6963,
+        "brotli": 2712
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1999,
-      "brotli": 1026
+      "min": 1995,
+      "brotli": 1028
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-alias-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2656,
-      "brotli": 1357
+      "min": 2652,
+      "brotli": 1356
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content-conditional-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8938,
-        "brotli": 3878
+        "min": 8934,
+        "brotli": 3874
       },
       "files": {
         "tags/consumer.marko": 509,

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1887,
+      "min": 1883,
       "brotli": 981
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-server-client-blocks/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-followed-by-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1327
+      "min": 2598,
+      "brotli": 1332
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-text-split-by-non-rendering-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2704,
-      "brotli": 1370
+      "min": 2700,
+      "brotli": 1365
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-attr-toggle-with-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2621,
-      "brotli": 1338
+      "min": 2617,
+      "brotli": 1341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-camelcase-accessors/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6262,
-      "brotli": 2859
+      "min": 6258,
+      "brotli": 2857
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/svg-math-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1326
+      "min": 2598,
+      "brotli": 1327
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9842,
+        "min": 9838,
         "brotli": 4183
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9294,
-      "brotli": 4025
+      "min": 9290,
+      "brotli": 4031
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-destructure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2893,
-      "brotli": 1456
+      "min": 2889,
+      "brotli": 1458
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-rest/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2911,
+      "min": 2907,
       "brotli": 1462
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6178,
-        "brotli": 2815
+        "min": 6174,
+        "brotli": 2812
       },
       "files": {
         "tags/child.marko": 171,

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6400,
-        "brotli": 2917
+        "min": 6396,
+        "brotli": 2913
       },
       "files": {
         "tags/tree/index.marko": 502,

--- a/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/template-literal-writes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3418,
-      "brotli": 1661
+      "min": 3414,
+      "brotli": 1657
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-content-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2561,
-      "brotli": 1308
+      "min": 2557,
+      "brotli": 1309
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2638,
-      "brotli": 1347
+      "min": 2634,
+      "brotli": 1349
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-dynamic-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3130,
-      "brotli": 1556
+      "min": 3126,
+      "brotli": 1553
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3733,
-      "brotli": 1762
+      "min": 3735,
+      "brotli": 1766
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3021,
-      "brotli": 1453
+      "min": 3017,
+      "brotli": 1450
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-template-literal-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3249,
-      "brotli": 1609
+      "min": 3245,
+      "brotli": 1608
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2690,
-      "brotli": 1364
+      "min": 2686,
+      "brotli": 1372
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-multiple-placeholders/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2824,
-      "brotli": 1438
+      "min": 2820,
+      "brotli": 1426
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-2/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6921,
-      "brotli": 3106
+      "min": 6917,
+      "brotli": 3101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6921,
-      "brotli": 3106
+      "min": 6917,
+      "brotli": 3101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child-with-marker/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1919,
+      "min": 1915,
       "brotli": 988
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7502,
-      "brotli": 3313
+      "min": 7504,
+      "brotli": 3312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-stateful-component/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6654,
-        "brotli": 3021
+        "min": 6650,
+        "brotli": 3027
       },
       "files": {
         "tags/counter.marko": 608,

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2732,
-      "brotli": 1372
+      "min": 2728,
+      "brotli": 1369
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8992,
-      "brotli": 3912
+      "min": 8988,
+      "brotli": 3909
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7134,
+      "min": 7130,
       "brotli": 3212
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-await-branch-removed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9365,
-      "brotli": 4078
+      "min": 9361,
+      "brotli": 4066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-details-open-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2951,
-      "brotli": 1479
+      "min": 2947,
+      "brotli": 1476
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-dialog-open-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2951,
-      "brotli": 1479
+      "min": 2947,
+      "brotli": 1476
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checkbox-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4327,
-      "brotli": 1974
+      "min": 4323,
+      "brotli": 1980
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-checked-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3402,
-      "brotli": 1622
+      "min": 3398,
+      "brotli": 1619
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-non-editable-value-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3510,
-      "brotli": 1666
+      "min": 3506,
+      "brotli": 1662
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-radio-checkedValue-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4321,
-      "brotli": 1967
+      "min": 4317,
+      "brotli": 1973
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3911,
+      "min": 3907,
       "brotli": 1842
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-default-update/sizes.json
@@ -1,7 +1,7 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4280,
+      "min": 4276,
       "brotli": 1925
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-select-value-multiple-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 4286,
-      "brotli": 1936
+      "min": 4282,
+      "brotli": 1935
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3953,
-      "brotli": 1852
+      "min": 3949,
+      "brotli": 1858
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9062,
-      "brotli": 3932
+      "min": 9058,
+      "brotli": 3924
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-pattern-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1967,
-      "brotli": 1010
+      "min": 1963,
+      "brotli": 1018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1893,
-      "brotli": 988
+      "min": 1889,
+      "brotli": 997
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1980,
-      "brotli": 1017
+      "min": 1976,
+      "brotli": 1018
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/used-var-mutation-registered-function/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2610,
-      "brotli": 1332
+      "min": 2606,
+      "brotli": 1334
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-next-wide-run/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-next-wide-run/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1327
+      "min": 2598,
+      "brotli": 1332
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/walks-multiplier/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2628,
-      "brotli": 1335
+      "min": 2624,
+      "brotli": 1337
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/warn-script-return-cleanup/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2713,
-      "brotli": 1361
+      "min": 2709,
+      "brotli": 1359
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/event.ts
+++ b/packages/runtime-tags/src/dom/event.ts
@@ -18,15 +18,17 @@ export function _on<
     );
   }
 
-  if ((element as any)["$" + type] === undefined) {
+  if ((element as any)[1 + type] === undefined) {
     delegate(type, handleDelegated);
   }
 
-  (element as any)["$" + type] = handler || null;
+  (element as any)[1 + type] = handler || null;
 }
 
 export const delegate = (type: string, handler: EventListener) =>
-  ((handler as any)[type] ||=
+  // The digit prefix keeps event types named after `Function` properties
+  // (`name`, `length`, …) from reading truthy and skipping registration.
+  ((handler as any)[1 + type] ||=
     (document.addEventListener(type, handler, true), 1));
 
 function handleDelegated(ev: GlobalEventHandlersEventMap[EventNames]) {
@@ -44,7 +46,7 @@ function handleDelegated(ev: GlobalEventHandlersEventMap[EventNames]) {
   }
 
   while (target) {
-    (target as any)["$" + ev.type]?.(ev, target);
+    (target as any)[1 + ev.type]?.(ev, target);
     target = ev.bubbles && !ev.cancelBubble && target.parentNode;
   }
 


### PR DESCRIPTION
`delegate` memoized its one-time `document.addEventListener` as `handler[type]`, so an event type matching a `Function` property (`name`, `length`, `constructor`, …) read truthy and the listener was never installed — `<div on-name(){}>` silently never fired (`caller`/`arguments` threw instead). The flag key now gets a digit prefix, which no `Function` property can collide with, keeping the single-property-read fast path. The per-element handler slots in `_on`/`handleDelegated` switch from `"$" + type` to the same digit prefix, making the change a net bundle-size reduction. Adds an `event-function-property-name` fixture.