### PR TITLE
fix: register const-held functions that reach dynamic tag handler positions

### DIFF
--- a/.changeset/dynamic-tag-handler-serialize.md
+++ b/.changeset/dynamic-tag-handler-serialize.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+State read by event handlers spread onto a dynamic tag from a `<const>` now serializes for resume; previously the handlers were wired after resume but read their state as `undefined`.

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,53 @@
+// template.marko
+const $template = "<!><!><!><!><div> </div>";
+const $walks = "b%b%b%bD l";
+_resume_dynamic_tag();
+const $inputtag_content3 = _content_resume("__tests__/template.marko_3_content", "aliased");
+const $inputtag_content2 = _content_resume("__tests__/template.marko_2_content", "inline");
+const $inputtag_content = _content_resume("__tests__/template.marko_1_content", "spread");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputtag_content);
+const $input_tag__OR__attrs = /*@__PURE__*/ _or(10, ($scope) => $dynamicTag($scope, $scope.input_tag, () => ({
+	...$scope.attrs,
+	id: "spread"
+})));
+const $dynamicTag3 = /*@__PURE__*/ _dynamic_tag("#text/2", $inputtag_content3);
+const $input_tag__OR__aliased = /*@__PURE__*/ _or(11, ($scope) => $dynamicTag3($scope, $scope.input_tag, () => ({
+	...$scope.attrs,
+	id: "aliased"
+})));
+const $attrs2 = /*@__PURE__*/ _const("attrs", ($scope) => {
+	$input_tag__OR__attrs($scope);
+	$input_tag__OR__aliased($scope);
+});
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag("#text/1", $inputtag_content2);
+const $input_tag__OR__n = /*@__PURE__*/ _or(8, ($scope) => $dynamicTag2($scope, $scope.input_tag, () => ({
+	onClick: $onClick($scope),
+	id: "inline"
+})));
+const $n = /*@__PURE__*/ _let("n/7", ($scope) => {
+	_text($scope["#text/3"], $scope.n);
+	$attrs2($scope, { onClick: $attrs($scope) });
+	$input_tag__OR__n($scope);
+});
+function $setup($scope) {
+	$n($scope, 0);
+}
+const $input_tag = /*@__PURE__*/ _const("input_tag", ($scope) => {
+	$input_tag__OR__attrs($scope);
+	$input_tag__OR__n($scope);
+	$input_tag__OR__aliased($scope);
+});
+const $input = ($scope, input) => $input_tag($scope, input.tag);
+function $attrs($scope) {
+	return function() {
+		$n($scope, $scope.n + 1);
+	};
+}
+function $onClick($scope) {
+	return function() {
+		$n($scope, $scope.n + 10);
+	};
+}
+_resume("__tests__/template.marko_0/attrs", $attrs);
+_resume("__tests__/template.marko_0/onClick", $onClick);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/dom.bundle.js
@@ -1,0 +1,40 @@
+// template.marko
+_resume_dynamic_tag();
+const $inputtag_content3 = _content_resume("a4", "aliased");
+const $inputtag_content2 = _content_resume("a3", "inline");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0, _content_resume("a2", "spread"));
+const $input_tag__OR__attrs = /*@__PURE__*/ _or(10, ($scope) => $dynamicTag($scope, $scope.g, () => ({
+	...$scope.j,
+	id: "spread"
+})));
+const $dynamicTag3 = /*@__PURE__*/ _dynamic_tag(2, $inputtag_content3);
+const $input_tag__OR__aliased = /*@__PURE__*/ _or(11, ($scope) => $dynamicTag3($scope, $scope.g, () => ({
+	...$scope.j,
+	id: "aliased"
+})));
+const $attrs2 = /*@__PURE__*/ _const(9, ($scope) => {
+	$input_tag__OR__attrs($scope);
+	$input_tag__OR__aliased($scope);
+});
+const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(1, $inputtag_content2);
+const $input_tag__OR__n = /*@__PURE__*/ _or(8, ($scope) => $dynamicTag2($scope, $scope.g, () => ({
+	onClick: $onClick($scope),
+	id: "inline"
+})));
+const $n = /*@__PURE__*/ _let(7, ($scope) => {
+	_text($scope.d, $scope.h);
+	$attrs2($scope, { onClick: $attrs($scope) });
+	$input_tag__OR__n($scope);
+});
+function $attrs($scope) {
+	return function() {
+		$n($scope, $scope.h + 1);
+	};
+}
+function $onClick($scope) {
+	return function() {
+		$n($scope, $scope.h + 10);
+	};
+}
+_resume("a0", $attrs);
+_resume("a1", $onClick);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,47 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	const attrs = { onClick: _resume(function() {
+		n++;
+	}, "__tests__/template.marko_0/attrs", $scope0_id) };
+	const aliased = attrs;
+	_dynamic_tag($scope0_id, "#text/0", input.tag, {
+		...attrs,
+		id: "spread"
+	}, _content_resume("__tests__/template.marko_1_content", () => {
+		const $scope1_id = _scope_id();
+		_scope_reason();
+		_html("spread");
+	}, $scope0_id));
+	_dynamic_tag($scope0_id, "#text/1", input.tag, {
+		onClick: _resume(function() {
+			n += 10;
+		}, "__tests__/template.marko_0/onClick", $scope0_id),
+		id: "inline"
+	}, _content_resume("__tests__/template.marko_2_content", () => {
+		const $scope2_id = _scope_id();
+		_scope_reason();
+		_html("inline");
+	}, $scope0_id));
+	_dynamic_tag($scope0_id, "#text/2", input.tag, {
+		...aliased,
+		id: "aliased"
+	}, _content_resume("__tests__/template.marko_3_content", () => {
+		const $scope3_id = _scope_id();
+		_scope_reason();
+		_html("aliased");
+	}, $scope0_id));
+	_html(`<div>${_escape(n)}${_el_resume($scope0_id, "#text/3")}</div>`);
+	writeScope($scope0_id, {
+		input_tag: input.tag,
+		n,
+		attrs: _serialize_if($scope0_reason, 0) && attrs
+	}, "__tests__/template.marko", 0, {
+		input_tag: ["input.tag"],
+		n: "1:6",
+		attrs: "2:8"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/html.bundle.js
@@ -1,0 +1,43 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	const attrs = { onClick: _resume(function() {
+		n++;
+	}, "a0", $scope0_id) };
+	const aliased = attrs;
+	_dynamic_tag($scope0_id, "a", input.tag, {
+		...attrs,
+		id: "spread"
+	}, _content_resume("a2", () => {
+		_scope_id();
+		_scope_reason();
+		_html("spread");
+	}, $scope0_id));
+	_dynamic_tag($scope0_id, "b", input.tag, {
+		onClick: _resume(function() {
+			n += 10;
+		}, "a1", $scope0_id),
+		id: "inline"
+	}, _content_resume("a3", () => {
+		_scope_id();
+		_scope_reason();
+		_html("inline");
+	}, $scope0_id));
+	_dynamic_tag($scope0_id, "c", input.tag, {
+		...aliased,
+		id: "aliased"
+	}, _content_resume("a4", () => {
+		_scope_id();
+		_scope_reason();
+		_html("aliased");
+	}, $scope0_id));
+	_html(`<div>${_escape(n)}${_el_resume($scope0_id, "d")}</div>`);
+	writeScope($scope0_id, {
+		g: input.tag,
+		h: n,
+		j: _serialize_if($scope0_reason, 0) && attrs
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/render.debug.md
@@ -1,0 +1,108 @@
+# Render `{"tag":"button"}`
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document.getElementById("spread").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```
+
+# Update
+```js
+document.getElementById("inline").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  11
+</div>
+```
+## Change
+```
+UPDATE: div::text "1" => "11"
+```
+
+# Update
+```js
+document.getElementById("aliased").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  12
+</div>
+```
+## Change
+```
+UPDATE: div::text "11" => "12"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/render.md
@@ -1,0 +1,108 @@
+# Render `{"tag":"button"}`
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document.getElementById("spread").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```
+
+# Update
+```js
+document.getElementById("inline").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  11
+</div>
+```
+## Change
+```
+UPDATE: div::text "1" => "11"
+```
+
+# Update
+```js
+document.getElementById("aliased").click();
+```
+```html
+<button
+  id="spread"
+>
+  spread
+</button>
+<button
+  id="inline"
+>
+  inline
+</button>
+<button
+  id="aliased"
+>
+  aliased
+</button>
+<div>
+  12
+</div>
+```
+## Change
+```
+UPDATE: div::text "11" => "12"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/writes.debug.html
@@ -1,0 +1,38 @@
+<button
+  id=spread><!--M_[-->spread<!--M_]2 #button/0 3--></button><!--M_'1 #text/0 2--><button
+  id=inline><!--M_[-->inline<!--M_]4 #button/0 5--></button><!--M_'1 #text/1 4--><button
+  id=aliased><!--M_[-->aliased<!--M_]6 #button/0 7--></button><!--M_'1 #text/2 6-->
+<div>0<!--M_*1 #text/3--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    "ConditionalRenderer:#text/0": "button",
+    "ConditionalRenderer:#text/1": "button",
+    "ConditionalRenderer:#text/2": "button",
+    input_tag: "button",
+    n: 0
+  }, {
+    "EventAttributes:#button/0": {
+      click: _.a = _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko_0/attrs"
+        )
+    },
+    "ConditionalRenderer:#button/0": "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko_1_content",
+    "#Renderer": "button"
+  }, 1, {
+    "EventAttributes:#button/0": {
+      click: _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko_0/onClick"
+        )
+    },
+    "ConditionalRenderer:#button/0": "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko_2_content",
+    "#Renderer": "button"
+  }, 1, {
+    "EventAttributes:#button/0": {
+      click: _.a
+    },
+    "ConditionalRenderer:#button/0": "packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko_3_content",
+    "#Renderer": "button"
+  }], "_dynamicTagScript 2 4 6"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/__snapshots__/writes.html
@@ -1,0 +1,30 @@
+<button id=spread><!--M_[-->spread<!--M_]2 a 3--></button><!--M_'1 a 2--><button
+  id=inline><!--M_[-->inline<!--M_]4 a 5--></button><!--M_'1 b 4--><button
+  id=aliased><!--M_[-->aliased<!--M_]6 a 7--></button><!--M_'1 c 6-->
+<div>0<!--M_*1 d--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Da: "button",
+    Db: "button",
+    Dc: "button",
+    g: "button",
+    h: 0
+  }, {
+    Ia: {
+      click: _.a = _(1, "a0")
+    },
+    Da: "a2"
+  }, 1, {
+    Ia: {
+      click: _(1, "a1")
+    },
+    Da: "a3"
+  }, 1, {
+    Ia: {
+      click: _.a
+    },
+    Da: "a4"
+  }], "d 2 4 6"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 14025,
+      "brotli": 5440
+    }
+  },
+  "html": {
+    "min": 699,
+    "brotli": 372
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/template.marko
@@ -1,0 +1,7 @@
+<let/n=0/>
+<const/attrs={ onClick() { n++ } }/>
+<const/aliased=attrs/>
+<${input.tag} ...attrs id="spread">spread</>
+<${input.tag} onClick() { n += 10 } id="inline">inline</>
+<${input.tag} ...aliased id="aliased">aliased</>
+<div>${n}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/test.ts
@@ -1,0 +1,17 @@
+import type { TestConfig } from "../../main.test";
+
+function clickSpread(document: Document) {
+  document.getElementById("spread")!.click();
+}
+
+function clickInline(document: Document) {
+  document.getElementById("inline")!.click();
+}
+
+function clickAliased(document: Document) {
+  document.getElementById("aliased")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{ tag: "button" }, clickSpread, clickInline, clickAliased],
+};

--- a/packages/runtime-tags/src/translator/visitors/function.ts
+++ b/packages/runtime-tags/src/translator/visitors/function.ts
@@ -102,10 +102,39 @@ export default {
     } else if (shouldAlwaysRegister(markoRoot)) {
       registerFunction(fnExtra, true);
     } else {
-      getReferencesByFn().set(fnExtra, new Set([(exprRoot.node.extra ??= {})]));
+      const refs = new Set([(exprRoot.node.extra ??= {})]);
+      // A `<const>` can carry this function (eg an attrs object) into an
+      // always-register position such as a dynamic tag spread, so its tag
+      // variable's references decide registration like static declarations do.
+      if (getConstTagVarRefs(markoRoot, refs) === true) {
+        registerFunction(fnExtra, true);
+      } else {
+        getReferencesByFn().set(fnExtra, refs);
+      }
     }
   },
 } satisfies TemplateVisitor<t.Function>;
+
+function getConstTagVarRefs(
+  markoRoot: MarkoExprRootPath,
+  refs: Set<t.NodeExtra>,
+  seen = new Set<t.Node>(),
+): Set<t.NodeExtra> | true {
+  const tag = getTagFromMarkoRoot(markoRoot);
+  if (!tag?.node.var || !isCoreTagName(tag, "const") || seen.has(tag.node)) {
+    return refs;
+  }
+  seen.add(tag.node);
+  const ids = tag.get("var").getOuterBindingIdentifiers();
+  for (const name in ids) {
+    const binding = tag.scope.getBinding(name);
+    if (binding && addBindingRefs(binding, refs, seen) === true) {
+      return true;
+    }
+  }
+
+  return refs;
+}
 
 export function finalizeFunctionRegistry() {
   for (const [fnExtra, exprExtras] of getReferencesByFn()) {
@@ -379,6 +408,11 @@ function addBindingRefs(
       return true;
     } else {
       refs.add((exprRoot.node.extra ??= {}));
+      // Follow `<const>` aliases (eg `<const/b=a/>` spread onto a dynamic
+      // tag) the same way the walk entered through the declaring `<const>`.
+      if (getConstTagVarRefs(markoRoot, refs, seen) === true) {
+        return true;
+      }
     }
   }
 }


### PR DESCRIPTION
A function carried by a `<const>` (eg an attrs object) into a dynamic tag spread was registered with a serialize reason gated on the dynamic tag's own sources — but the runtime's native-tag branch serializes and wires such handlers unconditionally, so after resume the handler fired with its state resumed as `undefined` (`n++` → NaN). Function registration now walks a `<const>` tag variable's references the way static declarations already do (including through `<const>` aliases), so a function reaching an always-register position (dynamic tag spread/attr) registers with an unconditional reason, which the existing machinery uses to serialize what its body reads. Inline handlers, `<let>`/`static`-held functions, and handlers arriving through component input were already covered (verified). No other fixture's serialized output changes. Adds a `dynamic-tag-handler-state` fixture covering spread, inline, and aliased-spread handlers through CSR and resume.