### PR TITLE
fix(runtime-tags): pure-rest child inputs map feeders and declare before their alias

### DIFF
--- a/.changeset/pure-rest-child-input.md
+++ b/.changeset/pure-rest-child-input.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix children consuming input only through a rest pattern or direct alias: their input groups now map their real feeders (restoring resume serialization for fed values), and the generated `$input` alias export no longer references its target before declaration.

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,25 @@
+// tags/echo/index.marko
+const $template$1 = "<em><!><!></em>";
+const $walks$1 = "D%b%l";
+const $setup$1 = () => {};
+const $skip = ($scope, skip) => _text($scope["#text/0"], skip);
+const $input_label = ($scope, input_label) => _text($scope["#text/1"], input_label);
+const $input = ($scope, input) => {
+	$skip($scope, input.skip);
+	$input_label($scope, input.label);
+};
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, $walks$1, $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<main>${_w0}<button>+</button></main>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}& l`)($walks$1);
+const $label = /*@__PURE__*/ _let("label/2", ($scope) => $input_label($scope["#childScope/0"], $scope.label));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$label($scope, $scope.label + "!");
+}));
+function $setup($scope) {
+	$skip($scope["#childScope/0"], "k");
+	$label($scope, "a");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// tags/echo/index.marko
+const $input_label = ($scope, input_label) => _text($scope.b, input_label);
+
+// template.marko
+const $label = /*@__PURE__*/ _let(2, ($scope) => $input_label($scope.a, $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$label($scope, $scope.c + "!");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// tags/echo/index.marko
+var echo_default = _template("__tests__/tags/echo/index.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_label = _serialize_guard($scope0_reason, 2);
+	const $scope0_id = _scope_id();
+	const { skip, ...r } = input;
+	const { ...s } = r;
+	_html(`<em>${_escape(skip)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 1))}${_sep($sg__input_label)}${_escape(s.label)}${_el_resume($scope0_id, "#text/1", $sg__input_label)}</em>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/echo/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "a";
+	_html("<main>");
+	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
+	echo_default({
+		skip: "k",
+		label
+	});
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/1")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		label,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { label: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// tags/echo/index.marko
+var echo_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_label = _serialize_guard($scope0_reason, 2);
+	const $scope0_id = _scope_id();
+	const { skip, ...r } = input;
+	const { ...s } = r;
+	_html(`<em>${_escape(skip)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 1))}${_sep($sg__input_label)}${_escape(s.label)}${_el_resume($scope0_id, "b", $sg__input_label)}</em>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "a";
+	_html("<main>");
+	_set_serialize_reason(10);
+	const $childScope = _peek_scope_id();
+	echo_default({
+		skip: "k",
+		label
+	});
+	_html(`<button>+</button>${_el_resume($scope0_id, "b")}</main>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: label,
+		a: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/render.debug.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<main>
+  <em>
+    ka
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    ka!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text@1 "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    ka!!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text@1 "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/render.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<main>
+  <em>
+    ka
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    ka!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text@1 "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    ka!!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text@1 "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<main><em>k<!>a<!--M_*2 #text/1--></em><button>+</button><!--M_*1 #button/1-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      label: "a",
+      "#childScope/0": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<main><em>k<!>a<!--M_*2 b--></em><button>+</button><!--M_*1 b--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: "a",
+    a: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2618,
+        "brotli": 1337
+      },
+      "files": {
+        "tags/echo/index.marko": 121,
+        "template.marko": 245
+      }
+    }
+  },
+  "html": {
+    "min": 388,
+    "brotli": 268
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/tags/echo/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/tags/echo/index.marko
@@ -1,0 +1,3 @@
+<const/{ skip, ...r }=input/>
+<const/{ ...s }=r/>
+<em>${skip}${s.label}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/template.marko
@@ -1,0 +1,5 @@
+<let/label="a"/>
+<main>
+  <echo skip="k" label=label/>
+  <button onClick() { label = label + "!" }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// Chained rest grains pass the walk through two property-less links:
+// updates reach the deep read client-side.
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,21 @@
+// tags/echo/index.marko
+const $template$1 = "<em> </em>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $input_label = ($scope, rest_label) => _text($scope["#text/0"], rest_label);
+const $input2 = ($scope, input) => $input_label($scope, input?.label);
+const $input = $input2;
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, "D l", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<main>${_w0}<button>+</button></main>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}& l`)("D l");
+const $label = /*@__PURE__*/ _let("label/2", ($scope) => $input($scope["#childScope/0"], { label: $scope.label }));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$label($scope, $scope.label + "!");
+}));
+function $setup($scope) {
+	$label($scope, "a");
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// tags/echo/index.marko
+const $input_label = ($scope, rest_label) => _text($scope.a, rest_label);
+const $input2 = ($scope, input) => $input_label($scope, input?.label);
+const $input = $input2;
+
+// template.marko
+const $label = /*@__PURE__*/ _let(2, ($scope) => $input($scope.a, { label: $scope.c }));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$label($scope, $scope.c + "!");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,26 @@
+// tags/echo/index.marko
+var echo_default = _template("__tests__/tags/echo/index.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const { ...rest } = input;
+	_html(`<em>${_escape(rest.label)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</em>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/echo/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "a";
+	_html("<main>");
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	echo_default({ label });
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/1")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		label,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { label: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.js
@@ -1,0 +1,26 @@
+// tags/echo/index.marko
+var echo_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const { ...rest } = input;
+	_html(`<em>${_escape(rest.label)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</em>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let label = "a";
+	_html("<main>");
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	echo_default({ label });
+	_html(`<button>+</button>${_el_resume($scope0_id, "b")}</main>`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {
+		c: label,
+		a: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/render.debug.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<main>
+  <em>
+    a
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    a!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    a!!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/render.md
@@ -1,0 +1,49 @@
+# Render
+```html
+<main>
+  <em>
+    a
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    a!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "a" => "a!"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <em>
+    a!!
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "a!" => "a!!"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<main><em>a<!--M_*2 #text/0--></em><button>+</button><!--M_*1 #button/1-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      label: "a",
+      "#childScope/0": _(2)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/rest-only-input/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<main><em>a<!--M_*2 a--></em><button>+</button><!--M_*1 b--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: "a",
+    a: _(2)
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 2649,
+        "brotli": 1352
+      },
+      "files": {
+        "tags/echo/index.marko": 214,
+        "template.marko": 250
+      }
+    }
+  },
+  "html": {
+    "min": 384,
+    "brotli": 266
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/tags/echo/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/tags/echo/index.marko
@@ -1,0 +1,2 @@
+<const/{ ...rest }=input/>
+<em>${rest.label}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/template.marko
@@ -1,0 +1,5 @@
+<let/label="a"/>
+<main>
+  <echo label=label/>
+  <button onClick() { label = label + "!" }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A pure-rest child's dom applier declares before its alias export: the
+// client bundle evaluates and re-applies on state changes.
+export const config: TestConfig = {
+  steps: [{}, click, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
@@ -25,6 +25,7 @@ var wrap_outer_default = _template("__tests__/tags/wrap-outer.marko", (input) =>
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		value: "abcd",

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
@@ -25,6 +25,7 @@ var wrap_outer_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason();
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		value: "abcd",

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -1474,14 +1474,21 @@ function mapParamBindingToExpr(
   exprs: KnownExprs,
   binding: InputBinding | ParamBinding,
 ): Opt<t.NodeExtra> {
-  const isRest =
-    binding.property === undefined && binding.excludeProperties !== undefined;
+  // Property-less with an upstream covers every whole-value link: pure
+  // rests (which carry no excludeProperties), rest grains, and aliases.
+  const isWholeAlias =
+    binding.property === undefined && binding.upstreamAlias !== undefined;
   const props: string[] = [];
-  let curBinding: Binding | undefined = isRest
+  let curBinding: Binding | undefined = isWholeAlias
     ? binding.upstreamAlias
     : binding;
-  while (curBinding && curBinding.property !== undefined) {
-    props.push(curBinding.property);
+  // Property-less links (rest grains, direct aliases) sit between real
+  // property hops: pass through them rather than stopping the walk.
+  while (
+    curBinding &&
+    (curBinding.property !== undefined || curBinding.upstreamAlias)
+  ) {
+    if (curBinding.property !== undefined) props.push(curBinding.property);
     curBinding = curBinding.upstreamAlias;
   }
 
@@ -1494,7 +1501,7 @@ function mapParamBindingToExpr(
     curExpr = nestedExpr;
   }
 
-  if (isRest) {
+  if (isWholeAlias) {
     let result: Opt<t.NodeExtra> = curExpr.value;
     if (curExpr.known) {
       for (const key in curExpr.known) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -79,6 +79,9 @@ export interface Signal {
     value: t.Expression;
   }>;
   intersection: Opt<Signal>;
+  /** Signals this one forwards into: they must declare first when the
+   * forward simplifies to a bare, eagerly evaluated reference. */
+  forwards: Opt<Signal>;
   render: t.Statement[];
   effect: t.Statement[];
   hasHTMLEffect: boolean;
@@ -258,6 +261,7 @@ export function getSignal(
         section,
         values: [],
         intersection: undefined,
+        forwards: undefined,
         render: [],
         effect: [],
         hasHTMLEffect: false,
@@ -467,7 +471,7 @@ function isPureMemberForwarder(binding: Binding): boolean {
 }
 
 function pushMemberForwards(
-  renderStatements: t.Statement[],
+  signal: Signal,
   value: t.Expression,
   alias: Binding,
 ) {
@@ -475,7 +479,7 @@ function pushMemberForwards(
     for (const [key, child] of alias.propertyAliases) {
       if (child.type !== BindingType.constant) {
         pushMemberForwards(
-          renderStatements,
+          signal,
           toMemberExpression(t.cloneNode(value, true), key, alias.nullable),
           child,
         );
@@ -483,7 +487,8 @@ function pushMemberForwards(
     }
   } else {
     const aliasSignal = getSignal(alias.section, alias);
-    renderStatements.push(
+    signal.forwards = push(signal.forwards, aliasSignal);
+    signal.render.push(
       t.expressionStatement(
         t.callExpression(aliasSignal.identifier, [
           scopeIdentifier,
@@ -507,6 +512,7 @@ export function getSignalFn(signal: Signal): t.Expression {
     for (const alias of binding.aliases) {
       const aliasSignal = getSignal(alias.section, alias);
       if (signalHasStatements(aliasSignal)) {
+        signal.forwards = push(signal.forwards, aliasSignal);
         if (alias.excludeProperties !== undefined) {
           const aliasId = t.identifier(alias.name);
           let pattern: t.ArrayPattern | t.ObjectPattern;
@@ -580,7 +586,7 @@ export function getSignalFn(signal: Signal): t.Expression {
     for (const [key, alias] of binding.propertyAliases) {
       if (alias.type !== BindingType.constant) {
         pushMemberForwards(
-          signal.render,
+          signal,
           toMemberExpression(
             createScopeReadExpression(binding),
             key,
@@ -958,6 +964,10 @@ export function writeSignals(section: Section) {
     let signalDeclaration: t.Statement | undefined;
     if (signal.build) {
       let value = signal.build();
+      // Eagerness is judged BEFORE wrappers (`_var_resume`/fill wraps keep
+      // their argument eager): a built bare identifier references its
+      // forward target at module evaluation.
+      const buildsEagerForward = t.isIdentifier(value);
 
       if (
         !value ||
@@ -983,6 +993,7 @@ export function writeSignals(section: Section) {
         );
       }
 
+      if (buildsEagerForward) forEach(signal.forwards, writeSignal);
       const signalDeclarator = t.variableDeclarator(signal.identifier, value);
       signalDeclaration =
         !section.parent &&


### PR DESCRIPTION
Children consuming input only through a rest pattern (`<const/{ ...rest }=input/>`) or a direct alias (`<const/x=input/>`) had two defects. The binding-to-expression walk stopped at property-less links and used `excludeProperties` to detect rest (which a pure rest doesn't carry), so such children's input groups mapped no feeders and their fed values could miss resume serialization. And the generated dom output declared the `$input` alias export above its target (`export const $input = $input2;` before `const $input2 = …`), a TDZ `ReferenceError` at module load. The walk now recognizes property-less-with-upstream links and passes through them to the real property hops, and alias-valued signal declarations order after their targets. A fixture pins client-bundle evaluation and re-application for a pure-rest child.