### PR TITLE
fix: drop empty class object keys on the client like the server does

### DIFF
--- a/.changeset/class-object-empty-key.md
+++ b/.changeset/class-object-empty-key.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+An empty key in a class object (`class={ "": cond }`) no longer throws on client render; it is dropped, matching server rendering.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -200,12 +200,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `_style_shell` tags the generated stylesheet with `element.className = id`, but `SVGElement.className` is a readonly `SVGAnimatedString`, so in the runtime's strict-mode ESM that assignment throws `TypeError: Cannot set property className of #<SVGElement> which has only a getter`. `<let/c="red"/><svg><style>circle { fill: ${c}; }</style><circle cx=5 cy=5 r=4/></svg>` compiles to `_style_shell($scope, "#style/0")`, so every client-created render of such a template (a `mount`, or an `<if>`/`<for>` branch) dies before anything is inserted; SSR and resume survive because `html/attrs.ts` › `_style_html` emits `<style class=ID>` as markup and `_style_rule_item` only rewrites `textContent`. Write the marker with `element.setAttribute("class", id)` so both outputs set the same attribute regardless of namespace. Re-verify: mount that template in jsdom — it throws, while the identical `<style>` outside `<svg>` mounts as `<style class="cM_0">`.
 
-## Guard the empty class-object key: `class={ "": v }` renders nothing on the server and throws on the client
-
-`packages/runtime-tags/src/dom/dom.ts` › `_attr_class_item` | 2026-07-27 | impact:low | effort:low
-
-`_attr_class_item` lowers a class-object entry to `element.classList.toggle(name, !!value)`, which throws `SyntaxError: The token provided must not be empty` for an empty token. `trackDelimitedAttrObjectProperties` in `packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` only diverts whitespace-bearing keys (`!/\s/.test(keyEval.computed)`), so `<div class={ "": count % 2 }>` still lowers to `_attr_class_item($scope["#div/0"], "", …)` and the first CSR render takes the whole mount down, while SSR's `_attr_class` drops the key and renders cleanly. Widen the guard to `!/^$|\s/.test(...)` so the empty key falls to the whole-object `_attr_class`, which already ignores it (`_attr_class({ "": true, foo: true })` → `" class=foo"`); the style side needs nothing, since `style.setProperty("", v)` is a no-op. Re-verify: compile that template with `-o dom` and mount it in jsdom — it throws before any DOM is inserted.
-
 ## Re-check serialized `$global` values after the first flush; `flushSerializer` latches `hasGlobals` even when it emitted nothing
 
 `packages/runtime-tags/src/html/writer.ts` › `flushSerializer` | 2026-07-27 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+const $template = "<div>x</div><button>b</button>";
+const $walks = " b b";
+const $count = /*@__PURE__*/ _let("count/2", ($scope) => _attr_class($scope["#div/0"], {
+	"": $scope.count % 2,
+	odd: $scope.count % 2
+}));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$count($scope, $scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/dom.bundle.js
@@ -1,0 +1,8 @@
+// template.marko
+const $count = /*@__PURE__*/ _let(2, ($scope) => _attr_class($scope.a, {
+	"": $scope.c % 2,
+	odd: $scope.c % 2
+}));
+const $setup__script = _script("a0", ($scope) => _on($scope.b, "click", function() {
+	$count($scope, $scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<div${_attr_class({
+		"": count % 2,
+		odd: count % 2
+	})}>x</div>${_el_resume($scope0_id, "#div/0")}<button>b</button>${_el_resume($scope0_id, "#button/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/html.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<div${_attr_class({
+		"": count % 2,
+		odd: count % 2
+	})}>x</div>${_el_resume($scope0_id, "a")}<button>b</button>${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: count });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/render.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  x
+</div>
+<button>
+  b
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div
+  class="odd"
+>
+  x
+</div>
+<button>
+  b
+</button>
+```
+## Change
+```
+UPDATE: .odd[class] null => "odd"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/render.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  x
+</div>
+<button>
+  b
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<div
+  class="odd"
+>
+  x
+</div>
+<button>
+  b
+</button>
+```
+## Change
+```
+UPDATE: .odd[class] null => "odd"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<div>x</div><!--M_*1 #div/0--><button>b</button><!--M_*1 #button/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<div>x</div><!--M_*1 a--><button>b</button><!--M_*1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2892,
+      "brotli": 1433
+    }
+  },
+  "html": {
+    "min": 364,
+    "brotli": 256
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/template.marko
@@ -1,0 +1,3 @@
+<let/count=0/>
+<div class={ "": count % 2, odd: count % 2 }>x</div>
+<button onClick() { count++ }>b</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/class-object-empty-key/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -1875,7 +1875,9 @@ function trackDelimitedAttrObjectProperties(
       if (
         keyEval.confident &&
         typeof keyEval.computed === "string" &&
-        !/\s/.test(keyEval.computed)
+        // An empty key falls through to the whole-object helper, which drops
+        // it; `classList.toggle("")` would throw.
+        !/^$|\s/.test(keyEval.computed)
       ) {
         key = keyEval.computed + "";
       } else {


### PR DESCRIPTION
A statically-empty class object key lowered to `_attr_class_item(el, "", ...)`, and `classList.toggle("")` throws `SyntaxError` on the first client render while SSR silently drops the key. The static-key guard in `trackDelimitedAttrObjectProperties` now also diverts empty keys to the whole-object `_attr_class` path, which already ignores them. Translator-only. Adds a `class-object-empty-key` fixture.