### PR TITLE
fix: preserve computed and static flags when lowering registered methods for dom

### DIFF
--- a/.changeset/registered-method-computed-static.md
+++ b/.changeset/registered-method-computed-static.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Registered object/class methods with computed or static keys now keep those flags in browser output; a computed-key handler previously lowered to a literal key and silently wired nothing.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -116,12 +116,6 @@ The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix su
 
 `getChangeHandler` memoizes one change-handler node per binding in `BINDING_CHANGE_HANDLER`, keyed only on `binding.identifier`, while the refining-function shorthand (`value:parseInt:=value`) is read per attribute. For an identifier-valued `:=`, the first usage's refining function is baked into the shared handler and every later `:=` on that identifier reuses it verbatim, silently discarding its own modifier. `<let/value=0/><input value:parseInt:=value/><input value:=value/>` compiles both inputs to the same `$scope.$valueChange` = `_new_value => $value($scope, parseInt(_new_value))`; reversing the order drops `parseInt` entirely, and `parseInt` followed by `parseFloat` applies `parseInt` to both. Only the identifier branch is affected — the member-expression branch re-derives per attribute — so make the key `(binding.identifier, modifier-name-or-none)`. Re-verify: compile that pair with `-o dom -d` and confirm the second input's handler is unwrapped.
 
-## Preserve `computed`/`static` when lowering registered object and class methods in DOM output
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `replaceRegisteredFunctionNode` | 2026-07-23 | impact:med | effort:low
-
-The DOM copy rewrites a registered `ObjectMethod`/`ClassMethod`/`ClassPrivateMethod` with `t.objectProperty(node.key, replacement)` / `t.classProperty(...)` / `t.classPrivateProperty(...)`, dropping the node's `computed` and `static` flags; its twin in `visitors/program/html.ts` forwards both. A reactive computed key then crashes the compiler with a raw `TypeError: Property key of ObjectProperty expected node to be of a type [...] but instead got "MemberExpression"` and no Marko code frame; a static computed key miscompiles silently — `<const/handlers={ [key]() { n++ } }/>` emits `{ key: $handlers($scope) }` in DOM versus `{ [key]: _resume(...) }` in HTML, so `handlers[key]` is `undefined` on the client and `_on(el, "click", undefined)` wires nothing. Forward the flags exactly as html.ts does. Re-verify: compile `static const key = "bump";` plus that `<const>` and `<button onClick=handlers[key]>` with `-o dom -d` and `-o html -d`, then compare the object keys.
-
 ## Drop escaped placeholders that render an empty string so they stop claiming a walk step
 
 `packages/runtime-tags/src/translator/util/static-text.ts` › `isStaticText` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,20 @@
+// template.marko
+const $template = "<button>b</button><div> </div>";
+const $walks = " bD l";
+const key = "bump";
+const $handlers2__script = _script("__tests__/template.marko_0_handlers", ($scope) => _on($scope["#button/0"], "click", $scope.handlers[key]));
+const $handlers2 = /*@__PURE__*/ _const("handlers", $handlers2__script);
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => {
+	_text($scope["#text/1"], $scope.n);
+	$handlers2($scope, { [key]: $handlers($scope) });
+});
+function $setup($scope) {
+	$n($scope, 0);
+}
+function $handlers($scope) {
+	return function() {
+		$n($scope, $scope.n + 1);
+	};
+}
+_resume("__tests__/template.marko_0/handlers", $handlers);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/dom.bundle.js
@@ -1,0 +1,13 @@
+// template.marko
+const key = "bump";
+const $handlers2 = /*@__PURE__*/ _const(3, _script("a1", ($scope) => _on($scope.a, "click", $scope.d[key])));
+const $n = /*@__PURE__*/ _let(2, ($scope) => {
+	_text($scope.b, $scope.c);
+	$handlers2($scope, { [key]: $handlers($scope) });
+});
+function $handlers($scope) {
+	return function() {
+		$n($scope, $scope.c + 1);
+	};
+}
+_resume("a0", $handlers);

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,20 @@
+// template.marko
+const key = "bump";
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	const handlers = { [key]: _resume(function() {
+		n++;
+	}, "__tests__/template.marko_0/handlers", $scope0_id) };
+	_html(`<button>b</button>${_el_resume($scope0_id, "#button/0")}<div>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0_handlers");
+	writeScope($scope0_id, {
+		n,
+		handlers
+	}, "__tests__/template.marko", 0, {
+		n: "2:6",
+		handlers: "3:8"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/html.bundle.js
@@ -1,0 +1,17 @@
+// template.marko
+const key = "bump";
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	const handlers = { [key]: _resume(function() {
+		n++;
+	}, "a0", $scope0_id) };
+	_html(`<button>b</button>${_el_resume($scope0_id, "a")}<div>${_escape(n)}${_el_resume($scope0_id, "b")}</div>`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {
+		c: n,
+		d: handlers
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/render.debug.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  b
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  b
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/render.md
@@ -1,0 +1,26 @@
+# Render
+```html
+<button>
+  b
+</button>
+<div>
+  0
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  b
+</button>
+<div>
+  1
+</div>
+```
+## Change
+```
+UPDATE: div::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<button>b</button><!--M_*1 #button/0-->
+<div>0<!--M_*1 #text/1--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 0,
+      handlers: {
+        bump: _(1,
+          "packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/template.marko_0/handlers"
+          )
+      }
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/template.marko_0_handlers 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>b</button><!--M_*1 a-->
+<div>0<!--M_*1 b--></div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: 0,
+    d: {
+      bump: _(1, "a0")
+    }
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2750,
+      "brotli": 1399
+    }
+  },
+  "html": {
+    "min": 383,
+    "brotli": 267
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/template.marko
@@ -1,0 +1,5 @@
+static const key = "bump";
+<let/n=0/>
+<const/handlers={ [key]() { n++ } }/>
+<button onClick=handlers[key]>b</button>
+<div>${n}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/registered-computed-method/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -1694,15 +1694,30 @@ export function replaceRegisteredFunctionNode(node: t.Node) {
   switch (node.type) {
     case "ClassMethod": {
       const replacement = getRegisteredFnExpression(node);
-      return replacement && t.classProperty(node.key, replacement);
+      return (
+        replacement &&
+        t.classProperty(
+          node.key,
+          replacement,
+          undefined,
+          undefined,
+          node.computed,
+          node.static,
+        )
+      );
     }
     case "ClassPrivateMethod": {
       const replacement = getRegisteredFnExpression(node);
-      return replacement && t.classPrivateProperty(node.key, replacement);
+      return (
+        replacement &&
+        t.classPrivateProperty(node.key, replacement, undefined, node.static)
+      );
     }
     case "ObjectMethod": {
       const replacement = getRegisteredFnExpression(node);
-      return replacement && t.objectProperty(node.key, replacement);
+      return (
+        replacement && t.objectProperty(node.key, replacement, node.computed)
+      );
     }
     case "ArrowFunctionExpression":
     case "FunctionExpression": {


### PR DESCRIPTION
The DOM copy of `replaceRegisteredFunctionNode` rebuilt registered `ObjectMethod`/`ClassMethod`/`ClassPrivateMethod` nodes without forwarding `computed`/`static`, while its HTML twin forwards both — so `<const/handlers={ [key]() {...} }/>` emitted `{ key: ... }` in browser output versus `{ [key]: ... }` on the server, and `handlers[key]` wired `undefined` silently (a non-identifier computed key crashed the compiler instead). The flags are now forwarded exactly as in `html.ts`. Adds a `registered-computed-method` fixture.