### PR TITLE
fix: key the bound attribute change handler cache per refining modifier

### DIFF
--- a/.changeset/change-handler-modifier-cache.md
+++ b/.changeset/change-handler-modifier-cache.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Mixing refined and plain bound attributes on the same variable (`value:parseInt:=x` and `value:=x`) now generates a change handler per refinement instead of reusing the first one for all.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -110,12 +110,6 @@ The key is `${section.id}` plus `_${name}` per referenced binding — no separat
 
 The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix subtracting 1 from the result), i.e. `x = x + 1` rather than JS's `x = ToNumeric(x) + 1`. With `<let/x="5"/>`, `x++` sets `x` to `"51"` and yields `50` instead of `6` and `5`; a `<let>` holding a bigint throws `Cannot mix BigInt and other types`. Wrapping the read in unary `+` fixes the string case but breaks bigint, so the lowering needs a real `ToNumeric` coercion — or `++`/`--` must be rejected on a tag variable whose type is not known numeric. Re-verify: compile `<let/x="5"/><button onClick(){ const v = x++ }>${x}</button>` with `-o dom`; the handler emits `const v = $x($scope, $scope.x + 1) - 1`.
 
-## Key the bound-attribute change-handler cache by refining function, not just the binding
-
-`packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandler` | 2026-07-23 | impact:med | effort:low
-
-`getChangeHandler` memoizes one change-handler node per binding in `BINDING_CHANGE_HANDLER`, keyed only on `binding.identifier`, while the refining-function shorthand (`value:parseInt:=value`) is read per attribute. For an identifier-valued `:=`, the first usage's refining function is baked into the shared handler and every later `:=` on that identifier reuses it verbatim, silently discarding its own modifier. `<let/value=0/><input value:parseInt:=value/><input value:=value/>` compiles both inputs to the same `$scope.$valueChange` = `_new_value => $value($scope, parseInt(_new_value))`; reversing the order drops `parseInt` entirely, and `parseInt` followed by `parseFloat` applies `parseInt` to both. Only the identifier branch is affected — the member-expression branch re-derives per attribute — so make the key `(binding.identifier, modifier-name-or-none)`. Re-verify: compile that pair with `-o dom -d` and confirm the second input's handler is unwrapped.
-
 ## Drop escaped placeholders that render an empty string so they stop claiming a walk step
 
 `packages/runtime-tags/src/translator/util/static-text.ts` › `isStaticText` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,44 @@
+// template.marko
+const $template = "<input id=refined><input id=refined2><input id=plain><input id=plain2><div><!> <!></div>";
+const $walks = " b b b bD%c%l";
+const $value__OR__$valueChange = /*@__PURE__*/ _or(10, ($scope) => {
+	_attr_input_value($scope, "#input/0", $scope.value, $scope.$valueChange);
+	_attr_input_value($scope, "#input/1", $scope.value, $scope.$valueChange);
+});
+const $value__OR__$valueChange2 = /*@__PURE__*/ _or(8, ($scope) => {
+	_attr_input_value($scope, "#input/2", $scope.value, $scope.$valueChange2);
+	_attr_input_value($scope, "#input/3", $scope.value, $scope.$valueChange2);
+});
+const $value = /*@__PURE__*/ _let("value/6", ($scope) => {
+	_text($scope["#text/4"], typeof $scope.value);
+	_text($scope["#text/5"], $scope.value);
+	$value__OR__$valueChange($scope);
+	$value__OR__$valueChange2($scope);
+});
+const $valueChange5 = /*@__PURE__*/ _const("$valueChange2", $value__OR__$valueChange2);
+const $valueChange6 = /*@__PURE__*/ _const("$valueChange", $value__OR__$valueChange);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_attr_input_value_script($scope, "#input/0");
+	_attr_input_value_script($scope, "#input/1");
+	_attr_input_value_script($scope, "#input/2");
+	_attr_input_value_script($scope, "#input/3");
+});
+function $setup($scope) {
+	$value($scope, 0);
+	$valueChange5($scope, $valueChange3($scope));
+	$valueChange6($scope, $valueChange4($scope));
+	$setup__script($scope);
+}
+function $valueChange3($scope) {
+	return (_new_value) => {
+		$value($scope, _new_value);
+	};
+}
+function $valueChange4($scope) {
+	return (_new_value) => {
+		$value($scope, parseInt(_new_value));
+	};
+}
+_resume("__tests__/template.marko_0/valueChange3", $valueChange3);
+_resume("__tests__/template.marko_0/valueChange4", $valueChange4);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/dom.bundle.js
@@ -1,0 +1,33 @@
+// template.marko
+const $value__OR__$valueChange = /*@__PURE__*/ _or(10, ($scope) => {
+	_attr_input_value($scope, "a", $scope.g, $scope.j);
+	_attr_input_value($scope, "b", $scope.g, $scope.j);
+});
+const $value__OR__$valueChange2 = /*@__PURE__*/ _or(8, ($scope) => {
+	_attr_input_value($scope, "c", $scope.g, $scope.h);
+	_attr_input_value($scope, "d", $scope.g, $scope.h);
+});
+const $value = /*@__PURE__*/ _let(6, ($scope) => {
+	_text($scope.e, typeof $scope.g);
+	_text($scope.f, $scope.g);
+	$value__OR__$valueChange($scope);
+	$value__OR__$valueChange2($scope);
+});
+const $setup__script = _script("a2", ($scope) => {
+	_attr_input_value_script($scope, "a");
+	_attr_input_value_script($scope, "b");
+	_attr_input_value_script($scope, "c");
+	_attr_input_value_script($scope, "d");
+});
+function $valueChange3($scope) {
+	return (_new_value) => {
+		$value($scope, _new_value);
+	};
+}
+function $valueChange4($scope) {
+	return (_new_value) => {
+		$value($scope, parseInt(_new_value));
+	};
+}
+_resume("a0", $valueChange3);
+_resume("a1", $valueChange4);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = 0;
+	const $valueChange2 = _resume((_new_value) => {
+		value = _new_value;
+	}, "__tests__/template.marko_0/valueChange3", $scope0_id);
+	const $valueChange = _resume((_new_value) => {
+		value = parseInt(_new_value);
+	}, "__tests__/template.marko_0/valueChange4", $scope0_id);
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", value, $valueChange)} id=refined>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_value($scope0_id, "#input/1", value, $valueChange)} id=refined2>${_el_resume($scope0_id, "#input/1")}<input${_attr_input_value($scope0_id, "#input/2", value, $valueChange2)} id=plain>${_el_resume($scope0_id, "#input/2")}<input${_attr_input_value($scope0_id, "#input/3", value, $valueChange2)} id=plain2>${_el_resume($scope0_id, "#input/3")}<div>${_escape(typeof value)}${_el_resume($scope0_id, "#text/4")} <!>${_escape(value)}${_el_resume($scope0_id, "#text/5")}</div>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		$valueChange2,
+		$valueChange
+	}, "__tests__/template.marko", 0, {
+		$valueChange2: 0,
+		$valueChange: 0
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.js
@@ -1,0 +1,19 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = 0;
+	const $valueChange2 = _resume((_new_value) => {
+		value = _new_value;
+	}, "a0", $scope0_id);
+	const $valueChange = _resume((_new_value) => {
+		value = parseInt(_new_value);
+	}, "a1", $scope0_id);
+	_html(`<input${_attr_input_value($scope0_id, "a", value, $valueChange)} id=refined>${_el_resume($scope0_id, "a")}<input${_attr_input_value($scope0_id, "b", value, $valueChange)} id=refined2>${_el_resume($scope0_id, "b")}<input${_attr_input_value($scope0_id, "c", value, $valueChange2)} id=plain>${_el_resume($scope0_id, "c")}<input${_attr_input_value($scope0_id, "d", value, $valueChange2)} id=plain2>${_el_resume($scope0_id, "d")}<div>${_escape(typeof value)}${_el_resume($scope0_id, "e")} <!>${_escape(value)}${_el_resume($scope0_id, "f")}</div>`);
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, {
+		h: $valueChange2,
+		j: $valueChange
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/render.debug.md
@@ -1,0 +1,99 @@
+# Render
+```html
+<input
+  id="refined"
+  value="0"
+/>
+<input
+  id="refined2"
+  value="0"
+/>
+<input
+  id="plain"
+  value="0"
+/>
+<input
+  id="plain2"
+  value="0"
+/>
+<div>
+  number 0
+</div>
+```
+
+# Update
+```js
+const el = document.getElementById(id);
+el.value = text;
+el.dispatchEvent(
+  new (document.defaultView).Event("input", { bubbles: true }),
+);
+```
+```html
+<input
+  default-value="0"
+  id="refined"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="refined2"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="plain"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="plain2"
+  value="42"
+/>
+<div>
+  number 42
+</div>
+```
+## Change
+```
+UPDATE: div::text@7 "0" => "42"
+```
+
+# Update
+```js
+const el = document.getElementById(id);
+el.value = text;
+el.dispatchEvent(
+  new (document.defaultView).Event("input", { bubbles: true }),
+);
+```
+```html
+<input
+  default-value="0"
+  id="refined"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="refined2"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="plain"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="plain2"
+  value="7em"
+/>
+<div>
+  string 7em
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "number" => "string"
+UPDATE: div::text@7 "42" => "7em"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/render.md
@@ -1,0 +1,99 @@
+# Render
+```html
+<input
+  id="refined"
+  value="0"
+/>
+<input
+  id="refined2"
+  value="0"
+/>
+<input
+  id="plain"
+  value="0"
+/>
+<input
+  id="plain2"
+  value="0"
+/>
+<div>
+  number 0
+</div>
+```
+
+# Update
+```js
+const el = document.getElementById(id);
+el.value = text;
+el.dispatchEvent(
+  new (document.defaultView).Event("input", { bubbles: true }),
+);
+```
+```html
+<input
+  default-value="0"
+  id="refined"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="refined2"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="plain"
+  value="42"
+/>
+<input
+  default-value="0"
+  id="plain2"
+  value="42"
+/>
+<div>
+  number 42
+</div>
+```
+## Change
+```
+UPDATE: div::text@7 "0" => "42"
+```
+
+# Update
+```js
+const el = document.getElementById(id);
+el.value = text;
+el.dispatchEvent(
+  new (document.defaultView).Event("input", { bubbles: true }),
+);
+```
+```html
+<input
+  default-value="0"
+  id="refined"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="refined2"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="plain"
+  value="7em"
+/>
+<input
+  default-value="0"
+  id="plain2"
+  value="7em"
+/>
+<div>
+  string 7em
+</div>
+```
+## Change
+```
+UPDATE: div::text@0 "number" => "string"
+UPDATE: div::text@7 "42" => "7em"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/writes.debug.html
@@ -1,0 +1,24 @@
+<input value=0 id=refined><!--M_*1 #input/0--><input value=0
+  id=refined2><!--M_*1 #input/1--><input value=0
+  id=plain><!--M_*1 #input/2--><input value=0 id=plain2><!--M_*1 #input/3-->
+<div>number<!--M_*1 #text/4-->
+  <!>0<!--M_*1 #text/5-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#input/0": _.a = _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/template.marko_0/valueChange4"
+        ),
+      "ControlledHandler:#input/1": _.a,
+      "ControlledHandler:#input/2": _.b = _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/template.marko_0/valueChange3"
+        ),
+      "ControlledHandler:#input/3": _.b,
+      $valueChange2: _.b,
+      $valueChange: _.a
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<input value=0 id=refined><!--M_*1 a--><input value=0
+  id=refined2><!--M_*1 b--><input value=0 id=plain><!--M_*1 c--><input value=0
+  id=plain2><!--M_*1 d-->
+<div>number<!--M_*1 e-->
+  <!>0<!--M_*1 f-->
+</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ea: _.a = _(1, "a1"),
+    Eb: _.a,
+    Ec: _.b = _(1, "a0"),
+    Ed: _.b,
+    h: _.b,
+    j: _.a
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 4131,
+      "brotli": 1917
+    }
+  },
+  "html": {
+    "min": 566,
+    "brotli": 323
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/template.marko
@@ -1,0 +1,6 @@
+<let/value=0/>
+<input#refined value:parseInt:=value/>
+<input#refined2 value:parseInt:=value/>
+<input#plain value:=value/>
+<input#plain2 value:=value/>
+<div>${typeof value} ${value}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/test.ts
@@ -1,0 +1,15 @@
+import type { TestConfig } from "../../main.test";
+
+function type(id: string, text: string) {
+  return (document: Document) => {
+    const el = document.getElementById(id) as HTMLInputElement;
+    el.value = text;
+    el.dispatchEvent(
+      new (document.defaultView as any).Event("input", { bubbles: true }),
+    );
+  };
+}
+
+export const config: TestConfig = {
+  steps: [{}, type("refined", "42px"), type("plain", "7em")],
+};

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -13,9 +13,11 @@ import withPreviousLocation from "../../util/with-previous-location";
 type StringOrIdPath = t.NodePath<t.StringLiteral> | t.NodePath<t.Identifier>;
 
 const TAG_NAME_IDENTIFIER_REG = /^[A-Z][a-zA-Z0-9_$]*$/;
+// Keyed per refining modifier (`value:parseInt:=x` vs `value:=x`), since the
+// modifier is baked into the built handler.
 const BINDING_CHANGE_HANDLER = new WeakMap<
   t.Identifier,
-  t.MarkoAttribute | t.Identifier
+  Map<string, t.MarkoAttribute | t.Identifier>
 >();
 
 export function preAnalyze(program: t.NodePath<t.Program>) {
@@ -205,7 +207,15 @@ function getChangeHandler(
         buildChangeHandlerFunction(attr.value, modifier),
       );
 
-    const existingChangedAttr = BINDING_CHANGE_HANDLER.get(binding.identifier);
+    const modifierKey = modifier?.name ?? "";
+    let handlerByModifier = BINDING_CHANGE_HANDLER.get(binding.identifier);
+    if (!handlerByModifier) {
+      BINDING_CHANGE_HANDLER.set(
+        binding.identifier,
+        (handlerByModifier = new Map()),
+      );
+    }
+    const existingChangedAttr = handlerByModifier.get(modifierKey);
     if (!existingChangedAttr) {
       const bindingIdentifierPath =
         binding.path.getOuterBindingIdentifierPaths()[binding.identifier.name];
@@ -240,7 +250,7 @@ function getChangeHandler(
         changeAttrName,
         changeAttrExpr,
       );
-      BINDING_CHANGE_HANDLER.set(binding.identifier, changeHandlerAttr);
+      handlerByModifier.set(modifierKey, changeHandlerAttr);
       return changeHandlerAttr;
     }
 
@@ -270,8 +280,8 @@ function getChangeHandler(
       null,
       t.identifier(changeHandlerId),
     );
-    BINDING_CHANGE_HANDLER.set(
-      binding.identifier,
+    handlerByModifier.set(
+      modifierKey,
       (existingChangedAttr.value = t.identifier(changeHandlerId)),
     );
 


### PR DESCRIPTION
The synthesized `*Change` handler for a bound attribute was cached per binding identifier only, so the first usage's refining modifier was baked into the handler every later `:=` on the same variable reused — `value:parseInt:=x` followed by `value:=x` applied `parseInt` to both (and reversed order dropped it). The cache is now keyed per `(binding, modifier)`, with the hoisted-const dedup operating per entry. Adds a `controllable-value-refinement-mixed` fixture covering repeated refined and plain bindings on one variable.