### PR TITLE
fix: reject loop-param reads anywhere in a for by expression

### DIFF
--- a/.changeset/for-by-param-member.md
+++ b/.changeset/for-by-param-member.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Reading a loop parameter anywhere in a `<for by=...>` expression (e.g. `by=item.id`) is now a compile error with a code frame, instead of compiling clean and throwing a `ReferenceError` at first render.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -320,12 +320,6 @@ For each non-repeated nested tag the `<`-branch unconditionally adds `loadAttrib
 
 For DOM, `translate.exit` folds the fallback into the derived signal itself (`value || _id($scope)`) and `_id` bumps a per-`$global` counter, so a nullish `value` mints a new id every time that signal recomputes — unlike valueless `<id/x/>`, which calls `_id` once from `$setup`. `<id/x=input.id>` is what `cheatsheet.md` recommends for reusable tags, so a caller omitting the id gets an identifier that changes on every update, never matches the resumed server id, and leaves outside references (CSS, `aria-*`, focus targets) stale. Mint it at setup and have the signal read that slot, leaving the HTML branch alone; keep `||`, since `tags/id.d.marko` types `value` as `string | null | false`. Fixture `id-tag` covers only the valueless form. Re-verify: mount compiled `<id/x=input.id>` + `<div id=x>` under jsdom and `update({ id: undefined, n })` twice — `id` goes `cM_0`, `cM_1`, `cM_2`.
 
-## Extend `<for>`'s `by=` loop-param check past bare identifiers
-
-`packages/runtime-tags/src/translator/core/for.ts` › `analyze` | 2026-07-27 | impact:med | effort:low
-
-The guard is `byAttr?.type === "Identifier" && !tag.scope.getBinding(...)`, so it fires only for a bare `by=item` (fixture `error-for-by-param`). The commoner React/Vue spelling `by=item.id` is a MemberExpression and slips through, as does a template literal, and since `by=` is emitted outside the iteration callback both targets reference an undeclared binding — HTML emits `_for_of(input.items, item => {…}, item.id, …)`, DOM emits `$for($scope, [input_items, item.id])`. Both compile clean and throw at first render, so the mistake surfaces as a 500 or a broken bundle instead of a code frame. Walk the whole `by=` expression for identifiers resolving only to `tag.node.body.params` (never `tag.scope`), reuse the existing message, and extend `error-for-by-param`. Re-verify: compile `<for|item| of=input.items by=item.id>` with `-o html` (succeeds) and render it — `ReferenceError: item is not defined`.
-
 ## Match `undefined`, not `null`, in `shallowClone`'s constructor switch
 
 `packages/compiler/src/babel-plugin/index.js` › `shallowClone` | 2026-07-27 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko:1:30
+    > 1 | <for|item| of=input.items by=item.id>
+        |                              ^^^^ The `by=` attribute is evaluated before the loop runs, so `item` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(item) => key`).
+      2 |   <div>${item.name}</div>
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko:1:30
+    > 1 | <for|item| of=input.items by=item.id>
+        |                              ^^^^ The `by=` attribute is evaluated before the loop runs, so `item` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(item) => key`).
+      2 |   <div>${item.name}</div>
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko:1:30
+    > 1 | <for|item| of=input.items by=item.id>
+        |                              ^^^^ The `by=` attribute is evaluated before the loop runs, so `item` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(item) => key`).
+      2 |   <div>${item.name}</div>
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/__snapshots__/error-compile-html.txt
@@ -1,0 +1,7 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko:1:30
+    > 1 | <for|item| of=input.items by=item.id>
+        |                              ^^^^ The `by=` attribute is evaluated before the loop runs, so `item` is not in scope. Key with a property name string (`by="id"`) or a function (`by=(item) => key`).
+      2 |   <div>${item.name}</div>
+      3 | </for>
+      4 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/template.marko
@@ -1,0 +1,3 @@
+<for|item| of=input.items by=item.id>
+  <div>${item.name}</div>
+</for>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-param-member/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -140,17 +140,22 @@ export default {
 
     // `by=` is evaluated once before the loop runs, so loop parameters are not in
     // scope; keying by one otherwise dies at render with an undefined-variable error.
-    if (
-      byAttr?.type === "Identifier" &&
-      !tag.scope.getBinding(byAttr.name) &&
-      tag.node.body.params.some((param) =>
-        Object.hasOwn(t.getBindingIdentifiers(param), byAttr.name),
-      )
-    ) {
-      throw tag.hub.buildError(
-        byAttr,
-        `The \`by=\` attribute is evaluated before the loop runs, so \`${byAttr.name}\` is not in scope. Key with a property name string (\`by="id"\`) or a function (\`by=(${byAttr.name}) => key\`).`,
-      );
+    if (byAttr) {
+      const paramNames = new Set<string>();
+      for (const param of tag.node.body.params) {
+        for (const name in t.getBindingIdentifiers(param)) {
+          paramNames.add(name);
+        }
+      }
+      const paramRead = paramNames.size
+        ? findLoopParamRead(byAttr, paramNames)
+        : undefined;
+      if (paramRead) {
+        throw tag.hub.buildError(
+          paramRead,
+          `The \`by=\` attribute is evaluated before the loop runs, so \`${paramRead.name}\` is not in scope. Key with a property name string (\`by="id"\`) or a function (\`by=(${paramRead.name}) => key\`).`,
+        );
+      }
     }
 
     const bodySection = startSection(tagBody);
@@ -478,6 +483,41 @@ export function getForType(tag: t.MarkoTag): ForType | undefined {
         case "until":
           return attr.name;
       }
+    }
+  }
+}
+
+// A plain node walk (no paths/scopes): functions and classes are skipped since
+// their params shadow, so an inner read falls back to the runtime error.
+function findLoopParamRead(
+  node: t.Node,
+  names: Set<string>,
+): t.Identifier | undefined {
+  switch (node.type) {
+    case "Identifier":
+      return names.has(node.name) ? node : undefined;
+    case "MemberExpression":
+    case "OptionalMemberExpression":
+      return (
+        findLoopParamRead(node.object, names) ||
+        (node.computed ? findLoopParamRead(node.property, names) : undefined)
+      );
+  }
+
+  if (t.isFunction(node) || t.isClass(node)) return;
+
+  for (const key of t.VISITOR_KEYS[node.type] || []) {
+    if (key === "typeAnnotation" || key === "typeParameters") continue;
+    if (key === "key" && !(node as t.ObjectProperty).computed) continue;
+    const value = (node as any)[key];
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        const found = child?.type && findLoopParamRead(child, names);
+        if (found) return found;
+      }
+    } else if (value?.type) {
+      const found = findLoopParamRead(value, names);
+      if (found) return found;
     }
   }
 }


### PR DESCRIPTION
The `by=` guard only caught a bare identifier (`by=item`), so the commoner `by=item.id` — and any other expression reading a loop parameter — compiled clean and threw `ReferenceError` at first render, since `by=` is evaluated before the loop runs. The guard now runs a plain node walk over the `by=` expression (no path/scope machinery): non-computed member properties and object keys are skipped, and function/class subtrees are skipped entirely since their params shadow — an inner read falls back to the runtime error as before. Adds an `error-for-by-param-member` fixture.