### PR TITLE
fix: escape carriage returns in server rendered attribute values

### DIFF
--- a/.changeset/attr-carriage-return-escape.md
+++ b/.changeset/attr-carriage-return-escape.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Carriage returns in server-rendered attribute values are now escaped as `&#13;`; the HTML parser previously normalized them to line feeds, diverging from client rendering.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -194,12 +194,6 @@ One module-level `tickQueue` holds every in-flight render's `onNext`, and `flush
 
 `writeError` emits exactly `new <Ctor>(message[, {cause}])`, so every own enumerable property an application hung on an error — `status`/`code`/`details`, an assigned `name` — is dropped on resume; `writeAggregateError` has the same gap. This is reachable from idiomatic source: `<try><@catch|err|><button onClick() { report(err) }>` compiles to `_scope($scope2_id, { err })`, so the server renders with `err.status === 404` while the resumed handler reads `undefined`, with no diagnostic. Plain objects round-trip all own props and the serializer already preserves `cause` and relinks `AggregateError.errors`, so extend both writers to append the remaining own props, deferring circular ones through `addAssignment` and emitting nothing extra when there are none. Re-verify: `stringifyScopes([[1,{},{value:Object.assign(new Error("boom"),{status:404})}]])` prints `_=>[1,{value:new Error("boom")}]`.
 
-## Escape a carriage return in an attribute value so SSR and CSR agree
-
-`packages/runtime-tags/src/html/attrs.ts` › `attrAssignment` | 2026-07-27 | impact:low | effort:low
-
-`attrAssignment` escapes only `"`, `'` and `&`, but the HTML input-stream preprocessor normalizes every CR and CRLF in an attribute value to a single LF, so `_attr("data-x", "a\rb")` parses back as `"a\nb"` while CSR (`dom/dom.ts` › `_attr` → `setAttribute`) writes the CR verbatim. `_attr`, `_attrs`, `_attr_class` and `_attr_style` all funnel through this escaper, so a controlled `<input value=…>` resumes with a `defaultValue` the server never rendered. Writing `\r` as `&#13;` survives, because character references are decoded after newline normalization. A U+0000 is separately replaced with U+FFFD and cannot be escaped away, leaving only a MARKO_DEBUG warning. This is a different defect from the entry "Escape a carriage return in a `<textarea>` body so SSR and CSR agree", which concerns textarea _text_ content and the `_escape` path rather than this attribute-value escaper — but a complete "CR survives SSR" story needs both landed. Re-verify: parse `"<div" + _attr("data-x", "a\rb") + "></div>"` with jsdom — `getAttribute("data-x")` is `"a\nb"`, while `el.setAttribute("data-x", "a\rb")` keeps `"a\rb"`.
-
 ## Reject a `<style>` interpolation inside an unquoted `url()` — the emitted `url(var(--…))` silently invalidates the declaration
 
 `packages/runtime-tags/src/translator/util/style-interpolation.ts` › `checkStyleInterpolations` | 2026-07-27 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,5 @@
+// template.marko
+const $template = "<div data-x=\"x&#13;y\"></div>";
+const $walks = "b";
+const $setup = () => {};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,6 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div data-x=\"x&#13;y\"></div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/html.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div data-x=\"x&#13;y\"></div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/render.debug.md
@@ -1,0 +1,23 @@
+# Render
+```html
+<div
+  data-x="xy"
+/>
+```
+
+# Update
+```js
+const div = document.querySelector("div");
+div.textContent = JSON.stringify(div.getAttribute("data-x"));
+```
+```html
+<div
+  data-x="xy"
+>
+  "x\ry"
+</div>
+```
+## Change
+```
+INSERT: div::text("\"x\\ry\"")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/render.md
@@ -1,0 +1,23 @@
+# Render
+```html
+<div
+  data-x="xy"
+/>
+```
+
+# Update
+```js
+const div = document.querySelector("div");
+div.textContent = JSON.stringify(div.getAttribute("data-x"));
+```
+```html
+<div
+  data-x="xy"
+>
+  "x\ry"
+</div>
+```
+## Change
+```
+INSERT: div::text("\"x\\ry\"")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+<div data-x="x&#13;y"></div>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+<div data-x="x&#13;y"></div>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 373,
+      "brotli": 250
+    }
+  },
+  "html": {
+    "min": 28,
+    "brotli": 32
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/template.marko
@@ -1,0 +1,1 @@
+<div data-x="x\ry"/>

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+function probe(document: Document) {
+  const div = document.querySelector("div")!;
+  div.textContent = JSON.stringify(div.getAttribute("data-x"));
+}
+
+export const config: TestConfig = {
+  steps: [{}, probe],
+};

--- a/packages/runtime-tags/src/__tests__/html-attrs.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-attrs.test.ts
@@ -40,7 +40,8 @@ describe("runtime-tags/html/attrs", () => {
       assert.equal(helpers._attr("foo", "bar baz"), ' foo="bar baz"');
       assert.equal(helpers._attr("foo", "bar\tbaz"), ' foo="bar\tbaz"');
       assert.equal(helpers._attr("foo", "bar\nbaz"), ' foo="bar\nbaz"');
-      assert.equal(helpers._attr("foo", "bar\rbaz"), ' foo="bar\rbaz"');
+      // A raw CR would parse back as LF; the reference survives normalization.
+      assert.equal(helpers._attr("foo", "bar\rbaz"), ' foo="bar&#13;baz"');
       assert.equal(helpers._attr("foo", "bar\fbaz"), ' foo="bar\fbaz"');
       assert.equal(
         helpers._attr("foo", "bar\"baz'qux"),
@@ -198,7 +199,7 @@ describe("runtime-tags/html/attrs", () => {
       assert.equal(helpers._attr_class("foo bar"), ' class="foo bar"');
       assert.equal(helpers._attr_class("foo\tbar"), ' class="foo\tbar"');
       assert.equal(helpers._attr_class("foo\nbar"), ' class="foo\nbar"');
-      assert.equal(helpers._attr_class("foo\rbar"), ' class="foo\rbar"');
+      assert.equal(helpers._attr_class("foo\rbar"), ' class="foo&#13;bar"');
       assert.equal(helpers._attr_class("foo\fbar"), ' class="foo\fbar"');
       assert.equal(
         helpers._attr_class("foo\"bar'baz"),
@@ -275,7 +276,10 @@ describe("runtime-tags/html/attrs", () => {
       assert.equal(helpers._attr_style("color: red"), ' style="color: red"');
       assert.equal(helpers._attr_style("color:\tred"), ' style="color:\tred"');
       assert.equal(helpers._attr_style("color:\nred"), ' style="color:\nred"');
-      assert.equal(helpers._attr_style("color:\rred"), ' style="color:\rred"');
+      assert.equal(
+        helpers._attr_style("color:\rred"),
+        ' style="color:&#13;red"',
+      );
       assert.equal(helpers._attr_style("color:\fred"), ' style="color:\fred"');
       assert.equal(
         helpers._attr_style('color:"red\'blue"'),

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -485,8 +485,9 @@ function nonVoidAttr(name: string, value: unknown) {
 
 // A `&` only decodes before `#` or an ASCII letter (parsers accept even
 // semicolon-less numeric and legacy named refs), so only those need escaping.
-const singleQuoteAttrReplacements = /'|&(?=[#a-zA-Z])/g;
-const doubleQuoteAttrReplacements = /"|&(?=[#a-zA-Z])/g;
+// `\r` must escape: the parser normalizes a raw CR/CRLF in a value to LF.
+const singleQuoteAttrReplacements = /['\r]|&(?=[#a-zA-Z])/g;
+const doubleQuoteAttrReplacements = /["\r]|&(?=[#a-zA-Z])/g;
 const needsQuotedAttr = /["'>\s]|&[#a-zA-Z]|\/$/g;
 export function attrAssignment(value: string) {
   return value
@@ -509,7 +510,7 @@ function escapeSingleQuotedAttrValue(value: string) {
 }
 
 function replaceUnsafeSingleQuoteAttrChar(match: string) {
-  return match === "'" ? "&#39;" : "&amp;";
+  return match === "'" ? "&#39;" : match === "\r" ? "&#13;" : "&amp;";
 }
 
 function escapeDoubleQuotedAttrValue(value: string) {
@@ -522,7 +523,7 @@ function escapeDoubleQuotedAttrValue(value: string) {
 }
 
 function replaceUnsafeDoubleQuoteAttrChar(match: string) {
-  return match === '"' ? "&#34;" : "&amp;";
+  return match === '"' ? "&#34;" : match === "\r" ? "&#13;" : "&amp;";
 }
 
 function normalizedValueMatches(a: unknown, b: unknown) {


### PR DESCRIPTION
The attribute escaper handled only quotes and ambiguous ampersands, but the HTML input-stream preprocessor normalizes a raw CR/CRLF in an attribute value to LF — so a server-rendered `\r` parsed back differently than client rendering writes it (`setAttribute` keeps the CR). Both quoted-value escapers now emit `&#13;`, which survives since character references decode after newline normalization. The separate `<textarea>` body entry remains open. Adds an `attr-carriage-return` fixture probing the parsed-back value.