### PR TITLE
fix: give deferred call arguments an eager serializer id

### DIFF
--- a/.changeset/deferred-call-arg-eager-id.md
+++ b/.changeset/deferred-call-arg-eager-id.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Reusing a value that was serialized as a deferred `Map`/`Set` member (e.g. a member of a circular collection) in a later stream flush no longer crashes the serializer.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -170,12 +170,6 @@ One module-level `tickQueue` holds every in-flight render's `onNext`, and `flush
 
 `flush` ends with `return result + html`, so as the `$global.__flush__` hook it prepends the page's asset markup to the first chunk; the translator emits `_flush_head()` only at the close of a literal native `<head>` (`translator/visitors/tag/native-tag.ts`), so an entry like `<!doctype html><html><body>…` renders `<link …><script …><!doctype html>…`. A parser ignores a DOCTYPE that follows content, so the document silently falls into quirks mode. Fix in the runtime: skip a leading `<!doctype …>` in `html` before splicing `result` in — assets between the doctype and `<html>` land in the implicit head. Re-verify: render that template compiled with `linkAssets` and wrapped in `withPageAssets(tmpl, runtime, "entry")`, then parse the output with jsdom — `document.compatMode` is `BackCompat` and `document.doctype` is null.
 
-## Give deferred Map/Set call arguments an eager binding — reusing one in a later flush crashes `assignId` on a null parent
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeCallArg` | 2026-07-27 | impact:med | effort:low
-
-`deferCall` moves the remaining Map/Set members into post-construction `.set(...)`/`.add(...)` calls, and `writeCallArg` writes each argument as `writeProp(state, val, null, "")`, so the `Reference` left in `state.refs`/`state.strs` has neither an id nor an accessor path. Serializing that value again in a later flush skips the `pos` fast path and walks `cur.parent!`, which is null, throwing `TypeError: Cannot read properties of null (reading 'id')` out of `stringifyScopes`, which `Boundary.flush` calls unguarded, so the stream dies. `writeArrayArg` and the channel-mutation branch of `writeAssigned` already claim eager ids for this reason; do the same here. Re-verify: with `root.k0 = new Set([40, root, inner])`, `stringifyScopes([[1,{},{value:root}]])` then `stringifyScopes([[2,{},{value:inner}]])` throws; a Map key/value, a long string, or a nested value behave the same.
-
 ## Preserve an Error's own enumerable properties through resume — only `message` and `cause` survive
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeError` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -280,6 +280,18 @@ describe("serializer", () => {
 
       assertStringify(set, `_.b=new Set(_.a=[1,_.c={}]),_.c.nested=_.b`);
     });
+    it("reuses a deferred call argument in a later flush", () => {
+      const serializer = assertSerializer();
+      const inner = { name: "inner" };
+      const root = {} as Record<string, unknown>;
+      root.k0 = new Set([40, root, inner]);
+      serializer.assertStringify(
+        root,
+        `_.b={k0:_.a=new Set([40])},_.a.add(_.b),_.a.add(_.c={name:"inner"})`,
+      );
+      serializer.assertStringify({ again: inner }, `{again:_.c}`);
+    });
+
     it("dedupe values across flushes", () => {
       const serializer = assertSerializer();
       const objA = { a: 1 };

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -600,7 +600,11 @@ function writeCallArg(state: State, val: unknown) {
   if (val === undefined) {
     state.wroteUndefined = true;
     state.buf.push("$");
-  } else if (!writeProp(state, val, null, "")) {
+  } else if (writeProp(state, val, null, "")) {
+    // Args have no parent access path, so a later reuse needs an eager id.
+    const ref = state.refs.get(val as WeakKey) || state.strs.get(val as string);
+    if (ref && ref.id === null) assignId(state, ref);
+  } else {
     state.buf.push("void 0");
   }
 }


### PR DESCRIPTION
`deferCall` moves circular `Map`/`Set` members into post-construction `.set`/`.add` calls, but `writeCallArg` wrote each argument with a null parent and no id — so serializing the same value again in a later flush walked the null parent and killed the stream with `Cannot read properties of null (reading 'id')`. Call arguments now claim an eager id after a successful write (spliced in place via the reference's recorded buffer position), the same reason `writeArrayArg` already does. Verified for Set members, Map keys/values, and deduped long strings; adds a serializer unit test pinning the payload.