### PR TITLE
fix: isolate tick queue callbacks so one throwing sink cannot stall other renders

### DIFF
--- a/.changeset/isolate-tick-queue.md
+++ b/.changeset/isolate-tick-queue.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+A streaming sink that throws (e.g. a client disconnect mid-write) no longer degrades progressive streaming for other renders in flight on the same server.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -158,12 +158,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `flushSerializer` sets `state.hasGlobals = true` before calling `getFilteredGlobals`, so a render whose allow-listed `$global` keys are all still `undefined` at the first serializer flush permanently latches "globals already sent" and never re-checks. A value assigned later — e.g. `<const/_=($global.late="LATE")/>` inside `<await>` content — is then dropped from the resume payload, so streaming and non-streaming disagree on identical input. Move the assignment inside an `if (globals)` guard, as the sibling `flushSerializerGlobals` already does; that covers every case where a later flush still has scopes, but a global first defined after the last scope-carrying flush needs an explicit final-flush re-check, since `flushSerializer` returns early when neither `flushScopes` nor `serializer.pending()` holds. Re-verify: render that template with `$global.serializedGlobals=["late"]` and a promise resolving on a later tick — the streamed chunks contain no `[0,{late:…}` entry, while awaiting the same render emits `_=>[0,{late:"LATE"},{n:0},{m:5}]`.
 
-## Isolate `flushTickQueue` callbacks; one render whose sink throws stops progressive streaming for every other concurrent render
-
-`packages/runtime-tags/src/html/writer.ts` › `flushTickQueue` | 2026-07-27 | impact:med | effort:low
-
-One module-level `tickQueue` holds every in-flight render's `onNext`, and `flushTickQueue` runs `cb(true)` in a bare `for…of`, so one sink that throws (`stream.write` in `pipe`, `ctrl.enqueue` in `toReadable`) aborts the loop. The skipped victims stay parked — each set `tick = false` before queueing, `#read` (`html/template.ts`) re-arms only under `else if (tick)`, and `offTick` is a no-op once the queue is cleared — so they lose every later progressive flush and emit one combined chunk at completion, while the error escapes as an uncaught exception. Wrap `cb(true)` in try/catch and rethrow asynchronously, and/or re-arm `tick` from a `finally` in `#read`. Re-verify: `queueTick(() => { throw new Error("boom") })` then `queueTick(() => (ran = true))` leaves `ran` false.
-
 ## Splice page assets after the doctype; a page entry with no literal `<head>` writes assets ahead of `<!doctype html>` and the document parses in quirks mode
 
 `packages/runtime-tags/src/html/assets.ts` › `flush` | 2026-07-27 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/html-stream.test.ts
+++ b/packages/runtime-tags/src/__tests__/html-stream.test.ts
@@ -3,6 +3,7 @@ import path from "path";
 
 import type { Template } from "@marko/runtime-tags/common/types";
 
+import { queueTick } from "../html/writer";
 import * as tagsTranslator from "../translator";
 import { createServerRunner } from "./utils/bundle";
 
@@ -65,6 +66,33 @@ describe("runtime-tags/html async iterator", () => {
         slow.join("").includes(`${letter}:${letter}`),
         `slow consumer dropped ${letter}`,
       );
+    }
+  });
+  it("isolates tick callbacks so one throwing sink cannot stall other renders", async () => {
+    const errors: unknown[] = [];
+    const onError = (err: Error) => {
+      errors.push(err.message);
+    };
+    // Mocha's own uncaught handler would fail the test; the rethrow is the point.
+    const prevListeners = process.listeners("uncaughtException");
+    process.removeAllListeners("uncaughtException");
+    process.on("uncaughtException", onError);
+    try {
+      let ran = false;
+      queueTick(() => {
+        throw new Error("boom");
+      });
+      queueTick(() => {
+        ran = true;
+      });
+      await new Promise((resolve) => setTimeout(resolve, 30));
+      assert.equal(ran, true);
+      assert.deepEqual(errors, ["boom"]);
+    } finally {
+      process.off("uncaughtException", onError);
+      for (const listener of prevListeners) {
+        process.on("uncaughtException", listener);
+      }
     }
   });
 });

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1761,6 +1761,13 @@ function flushTickQueue() {
   tickQueue = undefined;
 
   for (const cb of queue) {
-    cb(true);
+    try {
+      cb(true);
+    } catch (err) {
+      // One render's throwing sink must not stall the queue's other renders.
+      tick(() => {
+        throw err;
+      });
+    }
   }
 }


### PR DESCRIPTION
One module-level tick queue drains every in-flight render's flush callback in a bare loop, so a single sink throwing (`stream.write` after a client disconnect, `ctrl.enqueue`) aborted the loop and permanently parked the remaining renders' progressive streaming — they silently fell back to one combined chunk at completion. Each callback now runs isolated, with the error rethrown on a fresh tick so it still surfaces as an uncaught exception. Server-only. Adds a unit test covering the victim callback and the surfaced error.