### PR TITLE
fix: emit page assets after the doctype instead of ahead of it

### DIFF
--- a/.changeset/assets-after-doctype.md
+++ b/.changeset/assets-after-doctype.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Page asset tags are now emitted after a leading `<!doctype>`; a page entry without a literal `<head>` previously wrote them ahead of the doctype, silently putting the document in quirks mode.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -158,12 +158,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `flushSerializer` sets `state.hasGlobals = true` before calling `getFilteredGlobals`, so a render whose allow-listed `$global` keys are all still `undefined` at the first serializer flush permanently latches "globals already sent" and never re-checks. A value assigned later — e.g. `<const/_=($global.late="LATE")/>` inside `<await>` content — is then dropped from the resume payload, so streaming and non-streaming disagree on identical input. Move the assignment inside an `if (globals)` guard, as the sibling `flushSerializerGlobals` already does; that covers every case where a later flush still has scopes, but a global first defined after the last scope-carrying flush needs an explicit final-flush re-check, since `flushSerializer` returns early when neither `flushScopes` nor `serializer.pending()` holds. Re-verify: render that template with `$global.serializedGlobals=["late"]` and a promise resolving on a later tick — the streamed chunks contain no `[0,{late:…}` entry, while awaiting the same render emits `_=>[0,{late:"LATE"},{n:0},{m:5}]`.
 
-## Splice page assets after the doctype; a page entry with no literal `<head>` writes assets ahead of `<!doctype html>` and the document parses in quirks mode
-
-`packages/runtime-tags/src/html/assets.ts` › `flush` | 2026-07-27 | impact:med | effort:low
-
-`flush` ends with `return result + html`, so as the `$global.__flush__` hook it prepends the page's asset markup to the first chunk; the translator emits `_flush_head()` only at the close of a literal native `<head>` (`translator/visitors/tag/native-tag.ts`), so an entry like `<!doctype html><html><body>…` renders `<link …><script …><!doctype html>…`. A parser ignores a DOCTYPE that follows content, so the document silently falls into quirks mode. Fix in the runtime: skip a leading `<!doctype …>` in `html` before splicing `result` in — assets between the doctype and `<html>` land in the implicit head. Re-verify: render that template compiled with `linkAssets` and wrapped in `withPageAssets(tmpl, runtime, "entry")`, then parse the output with jsdom — `document.compatMode` is `BackCompat` and `document.doctype` is null.
-
 ## Preserve an Error's own enumerable properties through resume — only `message` and `cause` survive
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeError` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+const $template = "<!><html><body><button> </button></body></html>";
+const $walks = "bE D n";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, $scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<!doctype html><html>${_flush_head()}<body><button>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`), _trailers("</body></html>");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "4:10" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/html.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<!doctype html><html>${_flush_head()}<body><button>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`), _trailers("</body></html>");
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/render.debug.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<button>
+  0
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/render.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<button>
+  0
+</button>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html>
+
+<body><button>0<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+  <script>
+    WALKER_RUNTIME("M")("_");
+    M._.r = [_ => [1, {
+        n: 0
+      }],
+      "packages/runtime-tags/src/__tests__/fixtures/page-doctype/template.marko_0 1"
+    ];
+    M._.w()
+  </script>
+</body>
+
+</html>

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html>
+
+<body><button>0<!--M_*1 b--></button><!--M_*1 a-->
+  <script>
+    WALKER_RUNTIME("M")("_");
+    M._.r = [_ => [1, {
+      c: 0
+    }], "a0 1"];
+    M._.w()
+  </script>
+</body>
+
+</html>

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2598,
+      "brotli": 1327
+    }
+  },
+  "html": {
+    "min": 393,
+    "brotli": 256
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/template.marko
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <let/n=0/>
+    <button onClick() { n++ }>${n}</button>
+  </body>
+</html>

--- a/packages/runtime-tags/src/__tests__/fixtures/page-doctype/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/page-doctype/test.ts
@@ -1,0 +1,6 @@
+import type { TestConfig } from "../../main.test";
+
+// A full-document template cannot client-mount into a body.
+export const config: TestConfig = {
+  skip_csr: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let toggle = false;
-	_html(`<html><body${_attr("data-toggle", toggle)}><button>Toggle</button>${_el_resume($scope0_id, "#button/1")}</body>${_el_resume($scope0_id, "#body/0")}`), _trailers("</html>");
+	_html(`<html>${_flush_head()}<body${_attr("data-toggle", toggle)}><button>Toggle</button>${_el_resume($scope0_id, "#button/1")}</body>${_el_resume($scope0_id, "#body/0")}`), _trailers("</html>");
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { toggle }, "__tests__/template.marko", 0, { toggle: "1:5" });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/trailing-tag-dynamic-attr/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let toggle = false;
-	_html(`<html><body${_attr("data-toggle", toggle)}><button>Toggle</button>${_el_resume($scope0_id, "b")}</body>${_el_resume($scope0_id, "a")}`), _trailers("</html>");
+	_html(`<html>${_flush_head()}<body${_attr("data-toggle", toggle)}><button>Toggle</button>${_el_resume($scope0_id, "b")}</body>${_el_resume($scope0_id, "a")}`), _trailers("</html>");
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { c: toggle });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/translator/visitors/document-type.ts
+++ b/packages/runtime-tags/src/translator/visitors/document-type.ts
@@ -1,6 +1,7 @@
 import type { types as t } from "@marko/compiler";
 
-import { isOutputHTML } from "../util/marko-config";
+import { getMarkoOpts, isOutputHTML } from "../util/marko-config";
+import { callRuntime } from "../util/runtime";
 import type { TemplateVisitor } from "../util/visitors";
 import * as writer from "../util/writer";
 
@@ -9,8 +10,29 @@ export default {
     exit(documentType) {
       if (isOutputHTML()) {
         writer.writeTo(documentType)`<!${documentType.node.value}>`;
+        if (getMarkoOpts().linkAssets && !isBeforeHtmlOrHead(documentType)) {
+          // Assets flushed ahead of the doctype would put the document in
+          // quirks mode; here they land in the implicit head.
+          writer.writeTo(documentType)`${callRuntime("_flush_head")}`;
+        }
       }
       documentType.remove();
     },
   },
 } satisfies TemplateVisitor<t.MarkoDocumentType>;
+
+// A following `<html>`/`<head>` writes its own asset flush.
+function isBeforeHtmlOrHead(documentType: t.NodePath<t.MarkoDocumentType>) {
+  let next = documentType.getNextSibling();
+  while (next.node) {
+    if (next.isMarkoTag()) {
+      const { name } = next.node;
+      return (
+        name.type === "StringLiteral" &&
+        (name.value === "html" || name.value === "head")
+      );
+    }
+    next = next.getNextSibling();
+  }
+  return false;
+}

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -502,6 +502,21 @@ export default {
 
         let writeAtStartOfBody: t.Expression | undefined;
 
+        if (
+          tagName === "html" &&
+          getMarkoOpts().linkAssets &&
+          !tag.node.body.body.some(
+            (child) =>
+              child.type === "MarkoTag" &&
+              child.name.type === "StringLiteral" &&
+              child.name.value === "head",
+          )
+        ) {
+          // With no `<head>` child (cross-template layouts are not detected),
+          // assets flush here to land in the implicit head.
+          writeAtStartOfBody = callRuntime("_flush_head");
+        }
+
         if (tagName === "select") {
           if (staticControllable) {
             htmlSelectArgs.set(tag.node, {


### PR DESCRIPTION
A page entry whose template starts with a doctype previously wrote its asset tags ahead of it, silently putting the document in quirks mode. Under `linkAssets`, the translator now statically checks the template for a `<head>` (cross-template layouts are not detected): when absent, `_flush_head()` is written just inside `<html>` so assets land in the implicit head, or after the doctype when there is no `<html>` tag either. The existing `</head>` flush is unchanged, and no runtime scanning is involved.