### PR TITLE
fix: drop placeholders that statically render empty text so they claim no walk step

### DIFF
--- a/.changeset/empty-placeholder-walk.md
+++ b/.changeset/empty-placeholder-walk.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a client-side crash or destroyed sibling elements when a template contains a placeholder that statically evaluates to an empty string (e.g. `${""}` or `${NaN}`): it rendered no text but still claimed a walk step, shifting every later step in the section by one.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -92,12 +92,6 @@ Two lookups drop translator-emitted debug info. (1) `writeObjectProps` passes th
 
 The `UpdateExpression` case lowers `x++` to `$x(scope, scope.x + 1)` (postfix subtracting 1 from the result), i.e. `x = x + 1` rather than JS's `x = ToNumeric(x) + 1`. With `<let/x="5"/>`, `x++` sets `x` to `"51"` and yields `50` instead of `6` and `5`; a `<let>` holding a bigint throws `Cannot mix BigInt and other types`. Wrapping the read in unary `+` fixes the string case but breaks bigint, so the lowering needs a real `ToNumeric` coercion — or `++`/`--` must be rejected on a tag variable whose type is not known numeric. Re-verify: compile `<let/x="5"/><button onClick(){ const v = x++ }>${x}</button>` with `-o dom`; the handler emits `const v = $x($scope, $scope.x + 1) - 1`.
 
-## Drop escaped placeholders that render an empty string so they stop claiming a walk step
-
-`packages/runtime-tags/src/translator/util/static-text.ts` › `isStaticText` | 2026-07-23 | impact:med | effort:low
-
-`isStaticText` accepts a confident escaped placeholder when `isNotVoid(computed)` — the attribute void rule — but the emitted text is `_escape(computed)`, which is `""` for `""`, `NaN` and `0n`; `placeholder.ts` (`analyze`, `translate.exit`) drops on the matching `isVoid`. Such a placeholder writes nothing yet still calls `walks.enterShallow`, so every later walk step in the section is off by one: `<div>${""}${input.x}<b/><i/></div>` compiles to `next(1), over(1), replace, out(1)` and the `replace` destroys `<b>`, while `<div>${""}<b/><i>${input.x}</i><u/></div>` walks off the end and throws `reading 'data'` from `_text`. SSR is marker-driven and unaffected. Switch `isStaticText`, `isEmptyPlaceholder` and both `placeholder.ts` checks to the text rule `computed || computed === 0`. Re-verify: `pnpm run compile -o dom -d` that template with and without the `${""}`; the walk comments differ for the same DOM shape.
-
 ## Error when one program lazily imports the same template with two different `load` triggers
 
 `packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `getOrCreateHtmlLoadWrapped` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,10 @@
+// template.marko
+const $template = "<div><!><b></b><i></i></div><div><b></b><i> </i><u></u></div>";
+const $walks = "D%lDbD m";
+const $setup = () => {};
+const $input_x = ($scope, input_x) => {
+	_text($scope["#text/0"], input_x);
+	_text($scope["#text/1"], input_x);
+};
+const $input = ($scope, input) => $input_x($scope, input.x);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html(`<div>${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "#text/0", $sg__input_x)}<b></b><i></i></div><div><b></b><i>${_escape(input.x)}${_el_resume($scope0_id, "#text/1", $sg__input_x)}</i><u></u></div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/html.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html(`<div>${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "a", $sg__input_x)}<b></b><i></i></div><div><b></b><i>${_escape(input.x)}${_el_resume($scope0_id, "b", $sg__input_x)}</i><u></u></div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-csr.debug.md
@@ -1,0 +1,36 @@
+# Render `{"x":"a"}`
+```html
+<div>
+  a
+  <b />
+  <i />
+</div>
+<div>
+  <b />
+  <i>
+    a
+  </i>
+  <u />
+</div>
+```
+
+# Update `{"x":"b"}`
+```html
+<div>
+  b
+  <b />
+  <i />
+</div>
+<div>
+  <b />
+  <i>
+    b
+  </i>
+  <u />
+</div>
+```
+## Change
+```
+UPDATE: div:nth-of-type(1)::text "a" => "b"
+UPDATE: div:nth-of-type(2) > i::text "a" => "b"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,15 @@
+# Render `{"x":"a"}`
+```html
+<div>
+  a
+  <b />
+  <i />
+</div>
+<div>
+  <b />
+  <i>
+    a
+  </i>
+  <u />
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/render-ssr.md
@@ -1,0 +1,15 @@
+# Render `{"x":"a"}`
+```html
+<div>
+  a
+  <b />
+  <i />
+</div>
+<div>
+  <b />
+  <i>
+    a
+  </i>
+  <u />
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/writes.debug.html
@@ -1,0 +1,2 @@
+<div>a<b></b><i></i></div>
+<div><b></b><i>a</i><u></u></div>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/writes.html
@@ -1,0 +1,2 @@
+<div>a<b></b><i></i></div>
+<div><b></b><i>a</i><u></u></div>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 373,
+      "brotli": 250
+    }
+  },
+  "html": {
+    "min": 59,
+    "brotli": 55
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/template.marko
@@ -1,0 +1,2 @@
+<div>${""}${input.x}<b/><i/></div>
+<div>${NaN}<b/><i>${input.x}</i><u/></div>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+// A confident empty placeholder (`${""}`, `${NaN}`) renders no text but once
+// claimed a walk step, shifting every later step in the section by one.
+export const config: TestConfig = {
+  // The SSR pass stops at the first new-input step.
+  equivalent: false,
+  steps: [{ x: "a" }, { x: "b" }],
+};

--- a/packages/runtime-tags/src/translator/util/static-text.ts
+++ b/packages/runtime-tags/src/translator/util/static-text.ts
@@ -1,7 +1,7 @@
 import { types as t } from "@marko/compiler";
 
-import { isNotVoid, isVoid } from "../../common/helpers";
 import evaluate from "./evaluate";
+import { getHTMLRuntime } from "./runtime";
 import { getNodeContentType } from "./sections";
 
 // A run of adjacent static text (literal `MarkoText` and confident non-void escaped
@@ -13,7 +13,7 @@ export function isStaticText(node?: t.Node) {
     case "MarkoPlaceholder": {
       if (node.escape) {
         const { confident, computed } = evaluate(node.value);
-        return confident && isNotVoid(computed);
+        return confident && getHTMLRuntime()._escape(computed) !== "";
       }
       return false;
     }
@@ -35,7 +35,14 @@ export function getPrevStaticSibling(path: t.NodePath) {
   return prev.node;
 }
 
+// Asking the runtime's own text writers keeps these checks in lockstep with
+// what would render (`""`, `NaN` and `0n` write nothing).
 function isEmptyPlaceholder(placeholder: t.MarkoPlaceholder) {
   const { confident, computed } = evaluate(placeholder.value);
-  return confident && isVoid(computed);
+  return (
+    confident &&
+    getHTMLRuntime()[placeholder.escape ? "_escape" : "_unescaped"](
+      computed,
+    ) === ""
+  );
 }

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -1,6 +1,5 @@
 import { types as t } from "@marko/compiler";
 
-import { isVoid } from "../../common/helpers";
 import { WalkCode } from "../../common/types";
 import { injectTextCoercion, kRawText } from "../util/body-to-text-literal";
 import evaluate from "../util/evaluate";
@@ -58,7 +57,12 @@ export default {
       const { node } = placeholder;
       const valueExtra = evaluate(node.value);
       const { confident, computed } = valueExtra;
-      if (confident && isVoid(computed)) return;
+      if (
+        confident &&
+        getHTMLRuntime()[node.escape ? "_escape" : "_unescaped"](computed) ===
+          ""
+      )
+        return;
 
       if (!isStaticText(node)) {
         const section = getOrCreateSection(placeholder);
@@ -77,11 +81,14 @@ export default {
 
       const { node } = placeholder;
       const { confident, computed } = evaluate(node.value);
-      if (confident && isVoid(computed)) return;
+      const staticText = confident
+        ? getHTMLRuntime()[node.escape ? "_escape" : "_unescaped"](computed)
+        : undefined;
+      if (staticText === "") return;
 
       const extra = node.extra || {};
       if (confident && node.escape) {
-        structure.writeTo(placeholder)`${getHTMLRuntime()._escape(computed)}`;
+        structure.writeTo(placeholder)`${staticText!}`;
       } else {
         const siblingText = extra[kSiblingText]!;
         if (
@@ -124,7 +131,10 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
   const valueExtra = evaluate(value);
   const { confident, computed } = valueExtra;
 
-  if (confident && isVoid(computed)) {
+  if (
+    confident &&
+    getHTMLRuntime()[node.escape ? "_escape" : "_unescaped"](computed) === ""
+  ) {
     placeholder.remove();
     return;
   }


### PR DESCRIPTION
A placeholder that statically evaluates to text the runtime renders as `""` (`${""}`, `${NaN}`, `${0n}`) was gated with the attribute void rule (`null`/`undefined`/`false`) instead of the text rule, so it contributed no text to the template yet still claimed a walk step — shifting every later step in the section by one. Depending on the shape this destroyed a following element (a `replace` landing on it) or threw `Cannot read properties of undefined` during client render. The compile-time checks in `static-text.ts` and `placeholder.ts` now share the text rule (falsy except numeric `0`), matching what `_escape`/`_to_text` would render, so such placeholders are dropped like `${null}`.