### PR TITLE
Fix two-way binding destructured values with computed keys

### DIFF
--- a/.changeset/bound-computed-key.md
+++ b/.changeset/bound-computed-key.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Support two-way binding a destructured value with a computed string-literal key, and give a real diagnostic when the computed key is dynamic.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -236,12 +236,6 @@ The `<tag-name>` shorthand is rewritten only by the `ImportDeclaration` visitor 
 
 `replaceAssignedNode` rewrites only `AssignmentExpression` and `UpdateExpression`, so a `ForOfStatement`/`ForInStatement` whose `left` is a bare tag variable falls through to `getReadReplacement` (`util/references.ts`) and compiles to a plain scope read. `<let/x="a"/>` with `<button onClick(){ for (x of ["b","c"]) {} }>` emits `for ($scope.x of ["b", "c"]) {}`, mutating the scope slot without calling the `_let` signal, so nothing schedules a render and `${x}` keeps the stale value — no diagnostic in either output mode (`for (x in …)` is identical). Either mark for-of/for-in targets as assignments during reference analysis and route them through the binding's assignment builder, or raise a compile error naming the unsupported construct. Re-verify: `pnpm run compile -o dom -d f.marko` on that template emits `for ($scope.x of …)` with no `$x(` call in the handler.
 
-## Give a real diagnostic for two-way binding a computed-key destructured param
-
-`packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts` › `getChangeHandlerFromObjectPattern` | 2026-07-23 | impact:low | effort:low
-
-For a `computed === true` object-pattern property this appends a synthetic property keyed `t.binaryExpression("+", parent.get("key").node, t.stringLiteral("Change"))`, which `createBindingsAndTrackReferences` (`translator/util/references.ts`, ObjectPattern case) always rejects with "Only identifier and string literal keys are supported when destructuring." — so the branch can never produce a compilable template. It is reachable only for a computed string-literal key, and the error attaches to the loc-less synthetic node, so the caret covers the whole `<define>` tag and never mentions two-way binding; the key node is also reused without `t.cloneNode`. Fix: normalize a computed string-literal key to a plain key before synthesizing (and clone it), or throw a targeted diagnostic like the sibling array-pattern message. Re-verify: `<define/Wrap|{ ["a"]: val }|><input value:=val/></define>` fails today; deleting `value:=val` compiles.
-
 ## Carry the Class-API compat boundary mode per call site instead of downgrading the whole program
 
 `packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `pushCompatRegistration` | 2026-07-27 | impact:low | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,32 @@
+// tags/reveal/index.marko
+const $template$1 = "<div> </div>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $input = ($scope, input) => $input_value($scope, input.value);
+var reveal_default = /*@__PURE__*/ _template("__tests__/tags/reveal/index.marko", $template$1, "D l", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<button>inc <!></button>${_w0}${_w1}`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => ` Db%l/${_w0}&/${_w1}&`)("D l", "D l");
+const $pattern3 = ($scope, $pattern) => $a($scope, $pattern.a);
+const $a = ($scope, a) => $input_value($scope["#childScope/2"], a);
+const $pattern4 = ($scope, $pattern2) => $b($scope, $pattern2.b);
+const $n = /*@__PURE__*/ _let("n/8", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + 1);
+}));
+function $setup($scope) {
+	$pattern3($scope, {
+		a: "A",
+		aChange(v) {}
+	});
+	$pattern4($scope, {
+		b: "B",
+		bChange(v) {}
+	});
+	$n($scope, 1);
+	$setup__script($scope);
+}
+const $b = ($scope, b) => $input_value($scope["#childScope/3"], b);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $n = /*@__PURE__*/ _let(8, ($scope) => _text($scope.b, $scope.i));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, $scope.i + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,28 @@
+// tags/reveal/index.marko
+var reveal_default = _template("__tests__/tags/reveal/index.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.value)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/reveal/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const { ["a"]: a, ["aChange"]: aChange } = {
+		a: "A",
+		aChange(v) {}
+	};
+	const { "bChange": $bChange, ["b"]: b } = {
+		b: "B",
+		bChange(v) {}
+	};
+	let n = 1;
+	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	reveal_default({ value: a });
+	reveal_default({ value: b });
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "5:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/html.bundle.js
@@ -1,0 +1,28 @@
+// tags/reveal/index.marko
+var reveal_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<div>${_escape(input.value)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</div>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const { ["a"]: a, ["aChange"]: aChange } = {
+		a: "A",
+		aChange(v) {}
+	};
+	const { "bChange": $bChange, ["b"]: b } = {
+		b: "B",
+		bChange(v) {}
+	};
+	let n = 1;
+	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	reveal_default({ value: a });
+	reveal_default({ value: b });
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { i: n });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/render.debug.md
@@ -1,0 +1,32 @@
+# Render
+```html
+<button>
+  inc 1
+</button>
+<div>
+  A
+</div>
+<div>
+  B
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  inc 2
+</button>
+<div>
+  A
+</div>
+<div>
+  B
+</div>
+```
+## Change
+```
+UPDATE: button::text@4 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/render.md
@@ -1,0 +1,32 @@
+# Render
+```html
+<button>
+  inc 1
+</button>
+<div>
+  A
+</div>
+<div>
+  B
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  inc 2
+</button>
+<div>
+  A
+</div>
+<div>
+  B
+</div>
+```
+## Change
+```
+UPDATE: button::text@4 "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<button>inc <!>1<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+<div>A</div>
+<div>B</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/writes.html
@@ -1,0 +1,10 @@
+<button>inc <!>1<!--M_*1 b--></button><!--M_*1 a-->
+<div>A</div>
+<div>B</div>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    i: 1
+  }], "a0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2598,
+      "brotli": 1327
+    }
+  },
+  "html": {
+    "min": 383,
+    "brotli": 273
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/tags/reveal/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/tags/reveal/index.marko
@@ -1,0 +1,1 @@
+<div>${input.value}</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/template.marko
@@ -1,0 +1,8 @@
+// A computed string-literal key is statically known, so `value:=a` finds the
+// existing `["aChange"]` handler and `value:=b` synthesizes a `"bChange"` lookup.
+<const/{ ["a"]: a, ["aChange"]: aChange } = { a: "A", aChange(v) {} }/>
+<const/{ ["b"]: b } = { b: "B", bChange(v) {} }/>
+<let/n = 1/>
+<button onClick() { n++ }>inc ${n}</button>
+<reveal value:=a/>
+<reveal value:=b/>

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko:3:17
+      1 | static const key = "a";
+      2 | <define/Wrap|{ [key]: val }|>
+    > 3 |   <input value:=val/>
+        |                 ^^^ Cannot two-way bind to `val` because it is destructured with a dynamically computed key, so its change handler cannot be derived. Use a static key or pass an explicit `valueChange` attribute.
+      4 | </define>
+      5 | <Wrap a="x" aChange(v) {}/>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko:3:17
+      1 | static const key = "a";
+      2 | <define/Wrap|{ [key]: val }|>
+    > 3 |   <input value:=val/>
+        |                 ^^^ Cannot two-way bind to `val` because it is destructured with a dynamically computed key, so its change handler cannot be derived. Use a static key or pass an explicit `valueChange` attribute.
+      4 | </define>
+      5 | <Wrap a="x" aChange(v) {}/>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko:3:17
+      1 | static const key = "a";
+      2 | <define/Wrap|{ [key]: val }|>
+    > 3 |   <input value:=val/>
+        |                 ^^^ Cannot two-way bind to `val` because it is destructured with a dynamically computed key, so its change handler cannot be derived. Use a static key or pass an explicit `valueChange` attribute.
+      4 | </define>
+      5 | <Wrap a="x" aChange(v) {}/>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko:3:17
+      1 | static const key = "a";
+      2 | <define/Wrap|{ [key]: val }|>
+    > 3 |   <input value:=val/>
+        |                 ^^^ Cannot two-way bind to `val` because it is destructured with a dynamically computed key, so its change handler cannot be derived. Use a static key or pass an explicit `valueChange` attribute.
+      4 | </define>
+      5 | <Wrap a="x" aChange(v) {}/>
+      6 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/template.marko
@@ -1,0 +1,5 @@
+static const key = "a";
+<define/Wrap|{ [key]: val }|>
+  <input value:=val/>
+</define>
+<Wrap a="x" aChange(v) {}/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-bind-dynamic-key/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -10,8 +10,6 @@ import normalizeStringExpression from "../../util/normalize-string-expression";
 import { getHTMLRuntime } from "../../util/runtime";
 import withPreviousLocation from "../../util/with-previous-location";
 
-type StringOrIdPath = t.NodePath<t.StringLiteral> | t.NodePath<t.Identifier>;
-
 const TAG_NAME_IDENTIFIER_REG = /^[A-Z][a-zA-Z0-9_$]*$/;
 // Keyed per refining modifier (`value:parseInt:=x` vs `value:=x`), since the
 // modifier is baked into the built handler.
@@ -234,7 +232,11 @@ function getChangeHandler(
           attr.value,
           bindingIdentifierPath?.parentPath?.isArrayPattern()
             ? `Cannot two-way bind to \`${attr.value.name}\` because it comes from array destructuring, which has no change handler. Use object destructuring or pass an explicit \`${changeAttrName}\` attribute.`
-            : "Unable to bind to value.",
+            : bindingIdentifierPath?.parentPath?.isObjectProperty({
+                  computed: true,
+                })
+              ? `Cannot two-way bind to \`${attr.value.name}\` because it is destructured with a dynamically computed key, so its change handler cannot be derived. Use a static key or pass an explicit \`${changeAttrName}\` attribute.`
+              : "Unable to bind to value.",
         );
       }
 
@@ -378,56 +380,43 @@ function buildChangeHandlerFunction(
 function getChangeHandlerFromObjectPattern(
   parent: t.NodePath<t.ObjectProperty>,
 ) {
-  let changeKey: t.Identifier;
+  let changeKey: t.Identifier | undefined;
   const pattern = parent.parentPath as t.NodePath<t.ObjectPattern>;
-  if (parent.node.computed) {
-    changeKey = generateUidIdentifier("dynamicChange");
-    pattern.pushContainer(
-      "properties",
-      t.objectProperty(
-        t.binaryExpression(
-          "+",
-          parent.get("key").node,
-          t.stringLiteral("Change"),
-        ),
-        changeKey,
-        true,
-      ),
-    );
-  } else {
-    const key = parent.get("key") as StringOrIdPath;
-    const searchKey = `${getStringOrIdentifierValue(key)}Change`;
-    for (const prop of pattern.get("properties")) {
-      if (prop.isObjectProperty()) {
-        const propKey = prop.get("key");
-        const propValue = prop.get("value");
-        if (
-          !prop.node.computed &&
-          getStringOrIdentifierValue(propKey as StringOrIdPath) === searchKey &&
-          propValue.isIdentifier()
-        ) {
-          changeKey = propValue.node;
-          break;
-        }
+  const keyName = getStaticKeyName(parent.node);
+  // A dynamically computed key has no derivable change handler; caller reports.
+  if (keyName === undefined) return;
+
+  const searchKey = `${keyName}Change`;
+  for (const prop of pattern.get("properties")) {
+    if (prop.isObjectProperty()) {
+      const propValue = prop.get("value");
+      if (
+        getStaticKeyName(prop.node) === searchKey &&
+        propValue.isIdentifier()
+      ) {
+        changeKey = propValue.node;
+        break;
       }
     }
+  }
 
-    if (!changeKey!) {
-      pattern.unshiftContainer(
-        "properties",
-        t.objectProperty(
-          t.stringLiteral(searchKey),
-          (changeKey = generateUidIdentifier(searchKey)),
-        ),
-      );
-    }
+  if (!changeKey) {
+    pattern.unshiftContainer(
+      "properties",
+      t.objectProperty(
+        t.stringLiteral(searchKey),
+        (changeKey = generateUidIdentifier(searchKey)),
+      ),
+    );
   }
 
   return changeKey;
 }
 
-function getStringOrIdentifierValue(path: StringOrIdPath) {
-  return getLiteralName(path.node);
+function getStaticKeyName(prop: t.ObjectProperty) {
+  return prop.computed && !t.isStringLiteral(prop.key)
+    ? undefined
+    : getLiteralName(prop.key);
 }
 
 function getLiteralName(node: t.Node) {


### PR DESCRIPTION
Two-way binding a value destructured with a computed key (`{ ["a"]: val }` … `value:=val`) previously died with a misleading "Only identifier and string literal keys are supported when destructuring." error pointing at the whole tag, because `getChangeHandlerFromObjectPattern` synthesized an uncompilable `key + "Change"` pattern property. Computed string-literal keys are statically known, so they now resolve/synthesize the change handler like plain keys; a genuinely dynamic computed key now gets a targeted error at the bound attribute suggesting a static key or an explicit `*Change` attribute.