### PR TITLE
Fix trimmed text node end positions

### DIFF
--- a/.changeset/text-node-end-offset.md
+++ b/.changeset/text-node-end-offset.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Fix a trimmed text node's end position overshooting by the amount of trimmed leading whitespace.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -164,12 +164,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `onAttrValue` and `onAttrSpread` call `parseExpression(file, raw, part.value.start)` without the `sourceEnd` every sibling handler passes, so on failure `createParseError` (`babel-utils/parse.js`) sets `source` to the whole remainder of the file and leaves `node.end` undefined. `output:"source"`/`"migrate"` then print `MarkoParseError` as `this.token(node.source)`, re-emitting everything after the bad attribute twice — and `isSource` returns before the parse-error check in `babel-plugin/index.js`, so a formatter or codemod doubles the file even without `errorRecovery`. `getBoundedRange` also drops Babel's real location, so a multi-line attribute value reports "Unexpected token" at its opening paren while the same mistake inside `${…}` points at the offending token. Pass `part.value.end` at both call sites and in `withWrappedAttrValueHint`'s probe. Re-verify: `compileSync("<div foo=(1+)>hi</div>\n<span>tail</span>", "x.marko", { output: "source", translator: … })` prints the template twice; the `${1+}` control round-trips once.
 
-## Use the trimmed length, not `rawValue.length`, for a text node's end offset in `onText`
-
-`packages/compiler/src/babel-plugin/parser.js` › `onText` | 2026-07-27 | impact:med | effort:low
-
-The deferred `onNext` closure re-locates a trimmed text node with `end: trimmedStart + rawValue.length`, but `trimmedStart = part.start + rawValue.indexOf(value)` already skipped the removed leading whitespace, so the end overshoots by exactly the number of trimmed leading characters. Every text node preceded by a newline plus indentation — normal formatting — is affected, corrupting consumers of text-node ranges: editor tooling, codemods, and the source maps emitted for `output: "source"`/`"migrate"`, where a deeply indented trailing text node pushes the end past EOF. The fix is `end: trimmedStart + value.length`, symmetric with the start. Re-verify: compile `"<div>\n    hello\n</div>"` with `{ output: "source", ast: true }`; the `MarkoText` value is `"hello"` but its `loc` (2:4 → 3:5) spans `"hello\n</div"`.
-
 ## Skip the source printer's reindent for whitespace-preserving tags
 
 `patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -246,7 +246,7 @@ export function parseMarko(file) {
           const trimmedStart = part.start + rawValue.indexOf(value);
           withLoc(node, {
             start: trimmedStart,
-            end: trimmedStart + rawValue.length,
+            end: trimmedStart + value.length,
           });
         } else {
           body.splice(body.indexOf(node), 1);

--- a/packages/compiler/test/parser-locations.test.js
+++ b/packages/compiler/test/parser-locations.test.js
@@ -1,0 +1,44 @@
+import assert from "assert/strict";
+
+import { compileSync } from "@marko/compiler";
+
+describe("compiler/parser-locations", () => {
+  it("bounds a trimmed text node's range to the trimmed text", () => {
+    const text = firstText("<div>\n    hello\n</div>");
+    assert.equal(text.type, "MarkoText");
+    assert.equal(text.value, "hello");
+    assert.deepEqual(JSON.parse(JSON.stringify(text.loc)), {
+      start: { line: 2, column: 4 },
+      end: { line: 2, column: 9 },
+    });
+  });
+
+  it("spans the source text even when internal whitespace collapses", () => {
+    // The value collapses to "a b" but the range must cover the raw "a   b".
+    const text = firstText("<div>\n  a   b\n</div>");
+    assert.equal(text.value, "a b");
+    assert.deepEqual(JSON.parse(JSON.stringify(text.loc)), {
+      start: { line: 2, column: 2 },
+      end: { line: 2, column: 7 },
+    });
+  });
+
+  it("bounds a trailing-trimmed text node", () => {
+    // Only the newline run is trimmed; the spaces collapse into the value.
+    const text = firstText("<div>hi   \n</div>");
+    assert.equal(text.value, "hi ");
+    assert.deepEqual(JSON.parse(JSON.stringify(text.loc)), {
+      start: { line: 1, column: 5 },
+      end: { line: 1, column: 10 },
+    });
+  });
+});
+
+function firstText(src) {
+  const { ast } = compileSync(src, "text-loc.marko", {
+    ast: true,
+    code: false,
+    output: "source",
+  });
+  return ast.program.body[0].body.body[0];
+}

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/cjs-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/generated-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/generated-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/html-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/htmlProduction-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/hydrate-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/vdom-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |

--- a/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-at-tags-control-flow-mixed/snapshots/vdomProduction-error-expected.txt
@@ -3,7 +3,7 @@ CompileError:
        5 |         </@header>
        6 |
     >  7 |         Body content
-         |         ^ Cannot have attribute tags and body content under a control flow tag.
+         |         ^^^^^^^^^^^^ Cannot have attribute tags and body content under a control flow tag.
        8 |     </>
        9 | </>
       10 |


### PR DESCRIPTION
`onText`'s deferred relocation computed a trimmed text node's end as `trimmedStart + rawValue.length`, overshooting by the number of trimmed leading characters — so any indented text node reported a range spanning past its actual text (visible in error code frames, editor tooling, and `output: "source"` source maps). Use the trimmed value's length, symmetric with the start. New unit tests pin the trimmed, whitespace-collapse, and trailing-trim spans, and the `error-at-tags-control-flow-mixed` snapshots now underline the full offending text instead of collapsing to a single caret.