### PR TITLE
Bound failed attribute value parses to the value

### DIFF
--- a/.changeset/attr-value-source-end.md
+++ b/.changeset/attr-value-source-end.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Bound a failed attribute value parse to the attribute value instead of the rest of the file.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -158,12 +158,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `preservingWhitespaceUntil` is a single slot: `onOpenTagName` overwrites it with the current tag node whenever `parseOptions.preserveWhitespace` is set, and `onCloseTagEnd` clears it to `undefined` instead of restoring what it held before. `<textarea>`, `<script>` and `<style>` all nest legally inside `<pre>`, so `<pre>A   B` / an indented `<textarea>t</textarea>` / `C   D` / `</pre>` collapses everything after the nested tag down to a single space plus `C D` — silent corruption inside a `white-space: pre` element, on `-t class` too since the parser is shared. The slot is also seeded from the file-wide `htmlParseOptions.preserveWhitespace`, so under that option the first such tag disables preservation for the rest of the file. Save the previous value in `onOpenTagName` and restore it in `onCloseTagEnd`. Re-verify: `-o html -d` on that file emits `<textarea>…</textarea> C D</pre>`, while swapping the `<textarea>` for a `<span>` keeps `C   D` intact.
 
-## Pass the attribute value's end offset when parsing it — a bad attribute value swallows the rest of the file
-
-`packages/compiler/src/babel-plugin/parser.js` › `onAttrValue` | 2026-07-27 | impact:med | effort:low
-
-`onAttrValue` and `onAttrSpread` call `parseExpression(file, raw, part.value.start)` without the `sourceEnd` every sibling handler passes, so on failure `createParseError` (`babel-utils/parse.js`) sets `source` to the whole remainder of the file and leaves `node.end` undefined. `output:"source"`/`"migrate"` then print `MarkoParseError` as `this.token(node.source)`, re-emitting everything after the bad attribute twice — and `isSource` returns before the parse-error check in `babel-plugin/index.js`, so a formatter or codemod doubles the file even without `errorRecovery`. `getBoundedRange` also drops Babel's real location, so a multi-line attribute value reports "Unexpected token" at its opening paren while the same mistake inside `${…}` points at the offending token. Pass `part.value.end` at both call sites and in `withWrappedAttrValueHint`'s probe. Re-verify: `compileSync("<div foo=(1+)>hi</div>\n<span>tail</span>", "x.marko", { output: "source", translator: … })` prints the template twice; the `${1+}` control round-trips once.
-
 ## Skip the source printer's reindent for whitespace-preserving tags
 
 `patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -25,8 +25,12 @@ const withWrappedAttrValueHint = (file, part, rawValue, node) => {
   if (
     node.type === "MarkoParseError" &&
     jsxStyleAttrValueReg.test(trimmed) &&
-    parseExpression(file, trimmed.slice(1, -1), part.value.start).type !==
-      "MarkoParseError"
+    parseExpression(
+      file,
+      trimmed.slice(1, -1),
+      part.value.start,
+      part.value.end,
+    ).type !== "MarkoParseError"
   ) {
     node.label += `${node.label.endsWith(".") ? "" : "."} Attribute values in Marko are plain JavaScript expressions, not JSX; remove the wrapping \`{ }\`.`;
   }
@@ -447,7 +451,7 @@ export function parseMarko(file) {
         file,
         part,
         rawAttrValue,
-        parseExpression(file, rawAttrValue, part.value.start),
+        parseExpression(file, rawAttrValue, part.value.start, part.value.end),
       );
     },
 
@@ -480,7 +484,12 @@ export function parseMarko(file) {
       currentTag.node.attributes.push(
         withLoc(
           t.markoSpreadAttribute(
-            parseExpression(file, parser.read(part.value), part.value.start),
+            parseExpression(
+              file,
+              parser.read(part.value),
+              part.value.start,
+              part.value.end,
+            ),
           ),
           part,
         ),

--- a/packages/compiler/test/error-recovery.test.js
+++ b/packages/compiler/test/error-recovery.test.js
@@ -44,4 +44,14 @@ describe("compiler/error recovery", () => {
   it("throws on the first error without recovery", () => {
     assert.throws(() => compile("$ const x = ;", { errorRecovery: false }));
   });
+
+  it("bounds a bad attribute value to the value, not the rest of the file", () => {
+    for (const src of [
+      "<div foo=(1+)>hi</div>\n<span>tail</span>",
+      "<div ...(1+)>hi</div>\n<span>tail</span>",
+    ]) {
+      const { code } = compile(src, { output: "source" });
+      assert.equal(code.match(/tail/g).length, 1, code);
+    }
+  });
 });


### PR DESCRIPTION
`onAttrValue`, `onAttrSpread`, and `withWrappedAttrValueHint`'s probe called `parseExpression` without the `sourceEnd` every sibling handler passes, so a failed parse produced a `MarkoParseError` node whose `source` spanned the whole remainder of the file — `output: "source"`/`"migrate"` then re-emitted everything after the bad attribute twice. Pass `part.value.end` at all three sites; a new unit test pins the single round-trip for both the attribute-value and spread forms.