### PR TITLE
Keep preserving whitespace after a nested preserving tag closes

### DIFF
--- a/.changeset/preserve-whitespace-nesting.md
+++ b/.changeset/preserve-whitespace-nesting.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Keep preserving whitespace after a nested preserve-whitespace tag (eg a `<textarea>` inside `<pre>`) closes.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -152,12 +152,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `getTagsDir` scans the whole absolute filename right-to-left for a `tags` segment with no upper bound, while `packages/compiler/src/taglib/finder/index.js` › `find` stops its own walk at the nearest package root (`rootPkg.__dirname`, else `markoModules.cwd`). When they disagree, `isTagsAPI` records the synthetic `Template file within a tags directory` feature and any Class API construct then throws `Cannot mix Tags API and Class API features in the same file`, so a package named `tags` cannot compile one Marko 5 template and the only workaround is renaming the directory. Bound the scan at the same package-root boundary, and give the synthetic feature a real location — today it prints an empty code frame (`fixtures-interop/error-class-tags-dir/__snapshots__/error-compile-html.txt`). Re-verify: `class {}` + `<h1>hi</h1>` at `<tmp>/packages/tags/src/page.marko` beside a `package.json` fails `-t class -o html -d` with the mixing error, while renaming `tags` to `tag` compiles the identical file.
 
-## Restore the enclosing whitespace-preservation state when a preserve-whitespace tag closes
-
-`packages/compiler/src/babel-plugin/parser.js` › `parseMarko` (the `preservingWhitespaceUntil` slot) | 2026-07-27 | impact:low | effort:low
-
-`preservingWhitespaceUntil` is a single slot: `onOpenTagName` overwrites it with the current tag node whenever `parseOptions.preserveWhitespace` is set, and `onCloseTagEnd` clears it to `undefined` instead of restoring what it held before. `<textarea>`, `<script>` and `<style>` all nest legally inside `<pre>`, so `<pre>A   B` / an indented `<textarea>t</textarea>` / `C   D` / `</pre>` collapses everything after the nested tag down to a single space plus `C D` — silent corruption inside a `white-space: pre` element, on `-t class` too since the parser is shared. The slot is also seeded from the file-wide `htmlParseOptions.preserveWhitespace`, so under that option the first such tag disables preservation for the rest of the file. Save the previous value in `onOpenTagName` and restore it in `onCloseTagEnd`. Re-verify: `-o html -d` on that file emits `<textarea>…</textarea> C D</pre>`, while swapping the `<textarea>` for a `<span>` keeps `C   D` intact.
-
 ## Skip the source printer's reindent for whitespace-preserving tags
 
 `patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med

--- a/packages/compiler/src/babel-plugin/parser.js
+++ b/packages/compiler/src/babel-plugin/parser.js
@@ -343,7 +343,9 @@ export function parseMarko(file) {
 
         if (parseOptions) {
           if (parseOptions.preserveWhitespace) {
-            preservingWhitespaceUntil = node;
+            // Keep the outermost owner so a nested preserving tag (eg a
+            // `<textarea>` in `<pre>`) doesn't end preservation when it closes.
+            preservingWhitespaceUntil ||= node;
           }
 
           if (parseOptions.statement) {

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/cjs-expected.js
@@ -23,7 +23,11 @@ _marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, 
   out.w(" Hello");
   out.w("</div>");
   out.w("<pre>");
-  out.w("\n    This should  \n      be preserved\n  ");
+  out.w("\n    This should  \n      be preserved\n    ");
+  out.w("<textarea>");
+  out.w("nested");
+  out.w("</textarea>");
+  out.w("\n    still   preserved\n  ");
   out.w("</pre>");
   out.w("<div>");
   out.w("<div>");

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/generated-expected.marko
@@ -13,6 +13,12 @@
     
     This should  
       be preserved
+    
+    <textarea>
+      nested
+    </textarea>
+    
+    still   preserved
   
   </pre>
   <div>

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/html-expected.js
@@ -18,7 +18,11 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.w(" Hello");
   out.w("</div>");
   out.w("<pre>");
-  out.w("\n    This should  \n      be preserved\n  ");
+  out.w("\n    This should  \n      be preserved\n    ");
+  out.w("<textarea>");
+  out.w("nested");
+  out.w("</textarea>");
+  out.w("\n    still   preserved\n  ");
   out.w("</pre>");
   out.w("<div>");
   out.w("<div>");

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/htmlProduction-expected.js
@@ -6,7 +6,7 @@ import { x as _marko_escapeXml } from "marko/dist/runtime/html/helpers/escape-xm
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
-  out.w("<div><div>Hello <div> </div> World</div><div> Hello</div><pre>\n    This should  \n      be preserved\n  </pre><div><div>Hello </div></div></div><div>");
+  out.w("<div><div>Hello <div> </div> World</div><div> Hello</div><pre>\n    This should  \n      be preserved\n    <textarea>nested</textarea>\n    still   preserved\n  </pre><div><div>Hello </div></div></div><div>");
   scriptletA();
   scriptletB();
   out.w("Hello ");

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/vdom-expected.js
@@ -19,15 +19,19 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t(" Hello", _component);
   out.ee();
   out.be("pre", null, "4", _component, null, 0);
-  out.t("\n    This should  \n      be preserved\n  ", _component);
+  out.t("\n    This should  \n      be preserved\n    ", _component);
+  out.be("textarea", null, "5", _component, null, 0);
+  out.t("nested", _component);
   out.ee();
-  out.be("div", null, "5", _component, null, 0);
+  out.t("\n    still   preserved\n  ", _component);
+  out.ee();
   out.be("div", null, "6", _component, null, 0);
+  out.be("div", null, "7", _component, null, 0);
   out.t("Hello ", _component);
   out.ee();
   out.ee();
   out.ee();
-  out.be("div", null, "7", _component, null, 0);
+  out.be("div", null, "8", _component, null, 0);
   scriptletA();
   scriptletB();
   out.t("Hello ", _component);
@@ -38,7 +42,7 @@ _marko_template._ = _marko_renderer(function (input, out, _componentDef, _compon
   out.t(" Hello World! ", _component);
   out.t(a, _component);
   out.t(b, _component);
-  out.e("div", null, "8", _component, 0, 0);
+  out.e("div", null, "9", _component, 0, 0);
 }, {
   t: _marko_componentType,
   i: true,

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/vdomProduction-expected.js
@@ -3,7 +3,7 @@ const _marko_componentType = "QRka8CG",
   _marko_template = _t(_marko_componentType);
 export default _marko_template;
 import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";
-const _marko_node = _marko_constElement("div", null, 4).e("div", null, 3).t("Hello ").e("div", null, 1).t(" ").t(" World").e("div", null, 1).t(" Hello").e("pre", null, 1).t("\n    This should  \n      be preserved\n  ").e("div", null, 1).e("div", null, 1).t("Hello ");
+const _marko_node = _marko_constElement("div", null, 4).e("div", null, 3).t("Hello ").e("div", null, 1).t(" ").t(" World").e("div", null, 1).t(" Hello").e("pre", null, 3).t("\n    This should  \n      be preserved\n    ").e("textarea", null, 1).t("nested").t("\n    still   preserved\n  ").e("div", null, 1).e("div", null, 1).t("Hello ");
 const _marko_node2 = _marko_constElement("div", null, 0);
 import _marko_renderer from "marko/dist/runtime/components/renderer.js";
 import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
@@ -11,7 +11,7 @@ _marko_registerComponent(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
   out.n(_marko_node, _component);
-  out.be("div", null, "7", _component, null, 0);
+  out.be("div", null, "8", _component, null, 0);
   scriptletA();
   scriptletB();
   out.t("Hello ", _component);

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/template.marko
@@ -12,6 +12,8 @@
   <pre>
     This should  
       be preserved
+    <textarea>nested</textarea>
+    still   preserved
   </pre>
 
   <div>


### PR DESCRIPTION
`preservingWhitespaceUntil` was overwritten by every preserve-whitespace tag and reset to `undefined` on close, so a `<textarea>`/`<script>`/`<style>` nested inside `<pre>` silently re-enabled whitespace collapsing for the rest of the `<pre>` body (and the first such tag disabled a file-wide `preserveWhitespace` option for the rest of the file). The outermost owner now keeps the slot (`||=`), and the `white-space-test` fixture pins the nested case.