### PR TITLE
Detect tags-directory templates from discovered taglib dirs

### DIFF
--- a/.changeset/tags-dir-package-root.md
+++ b/.changeset/tags-dir-package-root.md
@@ -1,0 +1,7 @@
+---
+"@marko/compiler": patch
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Detect "template within a tags directory" from the taglib finder's discovered directories, so a package itself named `tags` can still contain Class API templates.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -146,12 +146,6 @@ The internal `RenderedTemplate` is `PromiseLike<string> & AsyncIterable<string> 
 
 `analyzeTagNameType` downgrades a custom tag whose child template is Class API to `TagNameType.DynamicTag` but leaves `extra.tagNameLoad` attached, so `translate.exit`'s DOM branch still sees `allKnownTagReferences` and deletes the whole `import Child … with { load: … }`, while the compat dynamic-tag path never reads `tagNameLoad` and emits a bare `$dynamicTag($scope, Child, …)`. `Child` is left undeclared, so `$setup` throws `ReferenceError` at first render with zero diagnostics, and every `fixtures-interop/lazy-class-child*` fixture uses a Class parent, so this direction is uncovered. Either wire `tagNameLoad` into the compat path or `buildCodeFrameError` in `analyze` when a `load` import resolves to a Class-API template. Re-verify: compile a `<!-- use tags -->` parent holding that import plus `<Child value=1/>` against a `class {}` child with `{ output: "dom", linkAssets, translator: "marko/translator" }`; Babel puts `Child` in the Program scope's `globals`, empty with a Tags-API child.
 
-## Bound `getTagsDir` at the package root — an ancestor directory named `tags` breaks every Class API template under it
-
-`packages/runtime-tags/src/translator/interop/feature-detection.ts` › `getTagsDir` | 2026-07-27 | impact:med | effort:low
-
-`getTagsDir` scans the whole absolute filename right-to-left for a `tags` segment with no upper bound, while `packages/compiler/src/taglib/finder/index.js` › `find` stops its own walk at the nearest package root (`rootPkg.__dirname`, else `markoModules.cwd`). When they disagree, `isTagsAPI` records the synthetic `Template file within a tags directory` feature and any Class API construct then throws `Cannot mix Tags API and Class API features in the same file`, so a package named `tags` cannot compile one Marko 5 template and the only workaround is renaming the directory. Bound the scan at the same package-root boundary, and give the synthetic feature a real location — today it prints an empty code frame (`fixtures-interop/error-class-tags-dir/__snapshots__/error-compile-html.txt`). Re-verify: `class {}` + `<h1>hi</h1>` at `<tmp>/packages/tags/src/page.marko` beside a `package.json` fails `-t class -o html -d` with the mixing error, while renaming `tags` to `tag` compiles the identical file.
-
 ## Skip the source printer's reindent for whitespace-preserving tags
 
 `patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med

--- a/packages/compiler/babel-utils.d.ts
+++ b/packages/compiler/babel-utils.d.ts
@@ -90,6 +90,7 @@ export interface TaglibLookup {
     callback: (attr: AttributeDefinition, tag: TagDefinition) => void,
   ): void;
   exclusiveTagDiscoveryDirs: undefined | false | string;
+  discoveryDirs: undefined | string[];
   manualTagsDirs: undefined | Set<string>;
 }
 

--- a/packages/compiler/src/taglib/finder/index.js
+++ b/packages/compiler/src/taglib/finder/index.js
@@ -82,6 +82,9 @@ function findWithMeta(dirname, registeredTaglibs, tagDiscoveryDirs) {
   let curDirname = dirname;
   // exclusiveTagDiscoveryDirs is used for the interop to detect if `tags` directories are used exclusively when finding tags
   let exclusiveTagDiscoveryDirs = undefined;
+  // Discovered discovery-dir paths in walk order (nearest first), for the
+  // interop's "is this file within a tags directory" check.
+  let discoveryDirs = undefined;
 
   while (true) {
     if (!excludedDirs[curDirname]) {
@@ -108,6 +111,7 @@ function findWithMeta(dirname, registeredTaglibs, tagDiscoveryDirs) {
               }
             }
 
+            (discoveryDirs ||= []).push(componentsPath);
             addTaglib(
               taglibLoader.loadTaglibFromDir(curDirname, tagDiscoveryDir),
             );
@@ -151,7 +155,7 @@ function findWithMeta(dirname, registeredTaglibs, tagDiscoveryDirs) {
     addTaglib(registeredTaglibs[i]);
   }
 
-  cached = { exclusiveTagDiscoveryDirs, taglibs };
+  cached = { discoveryDirs, exclusiveTagDiscoveryDirs, taglibs };
   cachedByDirname.set(dirname, cached);
   return cached;
 

--- a/packages/compiler/src/taglib/index.js
+++ b/packages/compiler/src/taglib/index.js
@@ -33,6 +33,7 @@ export function buildLookup(dirname, requestedTranslator, onError) {
 
   let taglibsForDir = loadedTranslatorsTaglibs.get(translator);
   let exclusiveTagDiscoveryDirs = undefined;
+  let discoveryDirs = undefined;
 
   if (!taglibsForDir) {
     loadedTranslatorsTaglibs.set(
@@ -55,6 +56,7 @@ export function buildLookup(dirname, requestedTranslator, onError) {
     );
     taglibsForDir = foundMeta.taglibs;
     exclusiveTagDiscoveryDirs = foundMeta.exclusiveTagDiscoveryDirs;
+    discoveryDirs = foundMeta.discoveryDirs;
   }, onError);
 
   const cacheKey = taglibsForDir
@@ -66,6 +68,7 @@ export function buildLookup(dirname, requestedTranslator, onError) {
   if (!lookup) {
     lookup = lookupCache[cacheKey] = new Lookup();
     lookup.exclusiveTagDiscoveryDirs = exclusiveTagDiscoveryDirs;
+    lookup.discoveryDirs = discoveryDirs;
     for (let i = taglibsForDir.length; i--;) {
       const taglib = taglibsForDir[i];
       lookup.addTaglib(taglib);

--- a/packages/compiler/src/taglib/lookup/index.js
+++ b/packages/compiler/src/taglib/lookup/index.js
@@ -53,6 +53,7 @@ class TaglibLookup {
 
     this._sortedTags = undefined;
     this.exclusiveTagDiscoveryDirs = undefined;
+    this.discoveryDirs = undefined;
     this.manualTagsDirs = undefined;
   }
 

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,40 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+function $setup($scope) {
+	$dynamicTag($scope, _marko_template);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => {};
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
+
+// tags/greeting.marko
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/tags/greeting.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	inc() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", null, "0", _component, null, 0, { "onclick": _componentDef.d("click", "inc", false) });
+	out.t(state.count, _component);
+	out.ee();
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/dom.bundle.js
@@ -1,0 +1,28 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => {};
+
+// tags/greeting.marko
+var import_components = require_components();
+var import_vdom = require_vdom();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	inc() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("button", null, "0", _component, null, 0, { "onclick": _componentDef.d("click", "inc", false) });
+	out.t(state.count, _component);
+	out.ee();
+}, { t: _marko_componentType }, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,29 @@
+// tags/greeting.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/tags/greeting.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	inc() {
+		this.state.count++;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<button>");
+	out.w((0, import_escape_xml.x)(state.count));
+	out.w("</button>");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+
+// template.marko
+s("__tests__/tags/greeting.marko", _marko_template);
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_dynamic_tag($scope0_id, "#text/0", _marko_template, {}, 0, 0, 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/html.bundle.js
@@ -1,0 +1,22 @@
+// tags/greeting.marko
+var import_html = require_html();
+var import_escape_xml = require_escape_xml();
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<button>${(0, import_escape_xml.x)(state.count)}</button>`);
+}, { t: _marko_componentType }, {
+	onCreate() {
+		this.state = { count: 0 };
+	},
+	inc() {
+		this.state.count++;
+	}
+});
+
+// template.marko
+s("b", _marko_template);
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_dynamic_tag(_scope_id(), "a", _marko_template, {}, 0, 0, 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/render.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/render.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  0
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1
+</button>
+```
+## Change
+```
+UPDATE: button::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/writes.debug.html
@@ -1,0 +1,22 @@
+<!--M#_0--><button>0</button><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    m5c: "_0",
+    m5i: {}
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/tags/greeting.marko"
+    ]
+  });
+  M._.r.push("$compat_setScope 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/__snapshots__/writes.html
@@ -1,0 +1,20 @@
+<!--M#_0--><button>0</button><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    m5c: "_0",
+    m5i: {}
+  }]];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2, {
+        "f": 1
+      }]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 49557,
+        "brotli": 14661
+      },
+      "files": {
+        "v:template.marko.hydrate-6.js": 104,
+        "tags/greeting.marko": 1005,
+        "v:template.marko.hydrate-5.js": 131
+      }
+    }
+  },
+  "html": {
+    "min": 454,
+    "brotli": 311
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/tags/greeting.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/tags/greeting.marko
@@ -1,0 +1,10 @@
+class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+  inc() {
+    this.state.count++;
+  }
+}
+
+<button on-click("inc")>${state.count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/tags/package.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/tags/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "tags-named-package-fixture",
+  "version": "0.0.0",
+  "private": true
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/template.marko
@@ -1,0 +1,1 @@
+<greeting/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/class-in-tags-named-package/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+// The `tags` directory here is its own package root, so templates inside it
+// are not "within a tags directory" and may stay Class API.
+export const config: TestConfig = {
+  steps: [{}, click],
+};
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}

--- a/packages/runtime-tags/src/translator/interop/feature-detection.ts
+++ b/packages/runtime-tags/src/translator/interop/feature-detection.ts
@@ -27,7 +27,7 @@ export function isTagsAPI(file = getFile()) {
 
   if (!featureType) {
     const lookup = getTaglibLookup(file);
-    const tagsDir = getTagsDir(file.opts.filename);
+    const tagsDir = getTagsDir(lookup, file.opts.filename);
     const state = {} as FeatureState;
     if (tagsDir && !lookup.manualTagsDirs?.has(tagsDir)) {
       addFeature(
@@ -51,30 +51,24 @@ export function isTagsAPI(file = getFile()) {
   return featureType === FeatureType.Tags;
 }
 
-function getTagsDir(filename: string) {
-  const pathSeparator = /\/|\\/.exec(filename)?.[0];
-  if (pathSeparator) {
-    let previousIndex = filename.length - 1;
-    while (previousIndex > 0) {
-      const index = filename.lastIndexOf(pathSeparator, previousIndex);
-      switch (previousIndex - index) {
-        case 4 /** "tags".length */: {
-          if (filename.startsWith("tags", index + 1)) {
-            return filename.slice(0, index + 5);
-          }
-          break;
-        }
-        case 10 /** "components".length */: {
-          if (filename.startsWith("components", index + 1)) {
-            return false;
-          }
-          break;
-        }
-      }
-      previousIndex = index - 1;
+// The nearest discovery dir containing the file, if it is a `tags` dir. The
+// finder already discovered these bounded at the package root, so a package
+// itself named `tags` doesn't flag every template under it — no fs work here.
+function getTagsDir(
+  lookup: ReturnType<typeof getTaglibLookup>,
+  filename: string,
+) {
+  let nearest: string | undefined;
+  for (const dir of lookup.discoveryDirs || []) {
+    if (
+      filename.startsWith(dir) &&
+      (filename[dir.length] === "/" || filename[dir.length] === "\\") &&
+      (!nearest || dir.length > nearest.length)
+    ) {
+      nearest = dir;
     }
   }
-  return false;
+  return !!nearest && /[/\\]tags$/.test(nearest) && nearest;
 }
 
 function scanBody(


### PR DESCRIPTION
`getTagsDir` scanned the whole filename for a `tags` segment with no upper bound, so a package itself named `tags` (e.g. `packages/tags/src/page.marko`) flagged every template under it as "within a tags directory" and any Class API construct then failed with the mixing error. The taglib finder already walks these directories bounded at the package root, so it now records the discovered discovery-dir paths on its meta, threaded onto the lookup alongside `exclusiveTagDiscoveryDirs` — and the interop feature detection just picks the nearest discovered dir containing the file, with no extra fs work. A genuine `tags/` dir inside the package still errors (existing `error-class-tags-dir` fixture); the new `class-in-tags-named-package` interop fixture pins the fixed case.