### PR TITLE
Resolve the tag-name shorthand in export-from declarations

### DIFF
--- a/.changeset/export-tag-shorthand.md
+++ b/.changeset/export-tag-shorthand.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Resolve the `<tag-name>` import shorthand in `export ... from` declarations.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -176,12 +176,6 @@ For each non-repeated nested tag the `<`-branch unconditionally adds `loadAttrib
 
 For DOM, `translate.exit` folds the fallback into the derived signal itself (`value || _id($scope)`) and `_id` bumps a per-`$global` counter, so a nullish `value` mints a new id every time that signal recomputes — unlike valueless `<id/x/>`, which calls `_id` once from `$setup`. `<id/x=input.id>` is what `cheatsheet.md` recommends for reusable tags, so a caller omitting the id gets an identifier that changes on every update, never matches the resumed server id, and leaves outside references (CSS, `aria-*`, focus targets) stale. Mint it at setup and have the signal read that slot, leaving the HTML branch alone; keep `||`, since `tags/id.d.marko` types `value` as `string | null | false`. Fixture `id-tag` covers only the valueless form. Re-verify: mount compiled `<id/x=input.id>` + `<div id=x>` under jsdom and `update({ id: undefined, n })` twice — `id` goes `cM_0`, `cM_1`, `cM_2`.
 
-## Rewrite the `<tag-name>` shorthand in `export ... from` position, or reject it
-
-`packages/runtime-tags/src/translator/visitors/import-declaration.ts` › `default` | 2026-07-30 | impact:med | effort:low
-
-The `<tag-name>` shorthand is rewritten only by the `ImportDeclaration` visitor (`resolveTagImport`, then `node.source.value = tagImport`); the translator has no export-declaration visitor, so `export { byDueDate } from "<table-sorts>"` is emitted verbatim with its angle brackets in both `-o html` and `-o dom` and with no diagnostic, surfacing later as a module-resolution error against generated code. Analysis already follows the shorthand here: `resolveRegisteredExport` in `visitors/function.ts` walks `ExportNamedDeclaration`/`ExportAllDeclaration` sources via `loadFileForImport`, which resolves `<tag>`. Direction: run `resolveTagImport` over an export declaration's `source` too, or raise a `buildCodeFrameError` naming the relative form if shorthand re-export is not meant to be supported. Re-verify: `pnpm run compile -o html -d tags/sort-barrel.marko` whose only line is `export { byDueDate } from "<table-sorts>"` still emits that specifier unchanged, while the `import` form emits `./table-sorts.marko`.
-
 ## Queue pending `onNextSibling` callbacks in the inline reorder runtime
 
 `packages/runtime-tags/src/html/inlined-runtimes.debug.ts` › `REORDER_RUNTIME_CODE` | 2026-07-10 | impact:low | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/template.marko
@@ -1,3 +1,4 @@
 import BazComp from "<baz>";
+export { default as BazTemplate } from "<baz>";
 <${BazComp}/>
 <BazComp/>

--- a/packages/runtime-tags/src/translator/index.ts
+++ b/packages/runtime-tags/src/translator/index.ts
@@ -8,6 +8,7 @@ import MarkoCDATA from "./visitors/cdata";
 import MarkoComment from "./visitors/comment";
 import MarkoDeclaration from "./visitors/declaration";
 import MarkoDocumentType from "./visitors/document-type";
+import ExportDeclaration from "./visitors/export-declaration";
 import Function from "./visitors/function";
 import ImportDeclaration from "./visitors/import-declaration";
 import MarkoPlaceholder from "./visitors/placeholder";
@@ -28,6 +29,8 @@ const visitors = extractVisitors({
   Function,
   ReferencedIdentifier,
   ImportDeclaration,
+  ExportNamedDeclaration: ExportDeclaration,
+  ExportAllDeclaration: ExportDeclaration,
   MarkoDocumentType,
   MarkoDeclaration,
   MarkoCDATA,

--- a/packages/runtime-tags/src/translator/visitors/export-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/export-declaration.ts
@@ -1,0 +1,30 @@
+import { types as t } from "@marko/compiler";
+import { resolveTagImport } from "@marko/compiler/babel-utils";
+
+import type { TemplateVisitor } from "../util/visitors";
+
+export default {
+  analyze(exportDecl) {
+    const { node } = exportDecl;
+    const { source } = node;
+    if (source) {
+      const tagImport = resolveTagImport(exportDecl, source.value);
+      if (tagImport) {
+        (node.extra ??= {}).tagImport = tagImport;
+        const tags = exportDecl.hub.file.metadata.marko.tags!;
+        if (!tags.includes(tagImport)) {
+          tags.push(tagImport);
+        }
+      }
+    }
+  },
+  translate: {
+    exit(exportDecl) {
+      const { node } = exportDecl;
+      const tagImport = node.extra?.tagImport;
+      if (tagImport) {
+        node.source!.value = tagImport;
+      }
+    },
+  },
+} satisfies TemplateVisitor<t.ExportNamedDeclaration | t.ExportAllDeclaration>;


### PR DESCRIPTION
The `<tag-name>` specifier shorthand was only rewritten by the `ImportDeclaration` visitor, so `export { x } from "<tag>"` (and `export * from`) emitted the angle-bracket specifier verbatim, surfacing later as a module-resolution error against generated code. A new `ExportNamedDeclaration`/`ExportAllDeclaration` visitor resolves the source the same way imports do (and records the dependency in `metadata.marko.tags`). The `import-tag-shorthand` fixture now includes a re-export, which fails to bundle without the fix.