### PR TITLE
Error on assignment to an attribute tag for parameter

### DIFF
--- a/.changeset/attr-tag-for-param-assign.md
+++ b/.changeset/attr-tag-for-param-assign.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Error at compile time when assigning to an attribute tag `<for>` parameter instead of emitting a handler that throws at runtime.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -104,12 +104,6 @@ HTML `_attrs` picks an `<input>`'s controllable from the change handler (`data.c
 
 For a custom tag with both a tag variable and attribute tags under control flow, `translateVar`'s `tag.insertBefore` puts `let menuEl = _myMenu({ item: $item })` ahead of the `let $item; _forOf(…)` statements that `translateAttrs` built and `tag.replaceWithMultiple(statements)` emits, so the render call reads `$item` in its temporal dead zone and SSR throws a ReferenceError. Sequence the call after the attr-tag statements, as the non-tag-variable path already does by pushing it onto `statements`. Only the HTML output is affected — the DOM output calls `_myMenu_input_item` after the loop. Re-verify: compile `<my-menu/menuEl><for|x| of=list><@item label=x/></for></my-menu>` with `pnpm run compile -o html -d`; the `let menuEl = _myMenu(…)` precedes `let $item`.
 
-## Reject assignments to an attribute tag `<for>` param inside an event handler
-
-`packages/runtime-tags/src/translator/util/references.ts` › `trackAssignment` | 2026-07-24 | impact:low | effort:low
-
-`<@item onClick() { x = "y" }>` where `x` is an attribute-tag `<for>` param (`BindingType.local`, from `core/for.ts`) reaches the change-handler branch of `trackAssignment` and compiles to `$scope.$Change("y")`, which nothing ever assigns, so the click throws a TypeError and nothing warns at compile time. Reads of such params work now (`referencedLocalBindingsInFunction`), which makes the silent write failure more confusing. These loops re-run wholesale on input change, so assignment has no reactive meaning; a compile error when `binding.type === BindingType.local` would be cheap and clear. Re-verify: compile that template with `pnpm run compile -o dom -d` and look for `$scope.$Change` in the handler.
-
 ## Match the internal `RenderedTemplate` to the published `Marko.RenderedTemplate`
 
 `packages/runtime-tags/src/common/types.ts` › `RenderedTemplate` | 2026-07-27 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko:4:27
+      2 |   <for|item| of=["a", "b"]>
+      3 |     <@row>
+    > 4 |       <button onClick() { item = "z" }>${item}</button>
+        |                           ^^^^ `item` is a tag parameter and cannot be assigned to.
+      5 |     </@row>
+      6 |   </for>
+      7 | </my-list>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko:4:27
+      2 |   <for|item| of=["a", "b"]>
+      3 |     <@row>
+    > 4 |       <button onClick() { item = "z" }>${item}</button>
+        |                           ^^^^ `item` is a tag parameter and cannot be assigned to.
+      5 |     </@row>
+      6 |   </for>
+      7 | </my-list>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko:4:27
+      2 |   <for|item| of=["a", "b"]>
+      3 |     <@row>
+    > 4 |       <button onClick() { item = "z" }>${item}</button>
+        |                           ^^^^ `item` is a tag parameter and cannot be assigned to.
+      5 |     </@row>
+      6 |   </for>
+      7 | </my-list>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko:4:27
+      2 |   <for|item| of=["a", "b"]>
+      3 |     <@row>
+    > 4 |       <button onClick() { item = "z" }>${item}</button>
+        |                           ^^^^ `item` is a tag parameter and cannot be assigned to.
+      5 |     </@row>
+      6 |   </for>
+      7 | </my-list>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/tags/my-list/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/tags/my-list/index.marko
@@ -1,0 +1,5 @@
+<ul>
+  <for|row| of=input.row || []>
+    <li><${row.renderBody}/></li>
+  </for>
+</ul>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/template.marko
@@ -1,0 +1,7 @@
+<my-list>
+  <for|item| of=["a", "b"]>
+    <@row>
+      <button onClick() { item = "z" }>${item}</button>
+    </@row>
+  </for>
+</my-list>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-assign-attr-tag-for-param/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -578,6 +578,14 @@ function trackAssignment(
     );
   }
 
+  // An attribute tag's loop params have no change handler an assignment
+  // could write through; the loop re-runs wholesale on input change.
+  if (binding.type === BindingType.local) {
+    throw assignment.buildCodeFrameError(
+      `\`${binding.name}\` is a tag parameter and cannot be assigned to.`,
+    );
+  }
+
   const fnRoot = getFnRoot(fnParent);
   const fnExtra =
     fnRoot && ((fnRoot.node.extra ??= {}) as ReferencedFunctionExtra);


### PR DESCRIPTION
Assigning to an attribute tag `<for>` param inside an event handler compiled to `$scope.$Change(...)`, which nothing assigns, so the handler threw a TypeError at runtime with no compile diagnostic. Those loops re-run wholesale on input change, so the assignment has no reactive meaning — `trackAssignment` now reports it as a compile error like the existing positional-parameter case. New `error-assign-attr-tag-for-param` fixture pins the diagnostic.