### PR TITLE
Drop the value attribute for a void controllable input value

### DIFF
--- a/.changeset/input-value-void-attr.md
+++ b/.changeset/input-value-void-attr.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Drop the `value` attribute for a void controllable input value on the client, matching server output.

--- a/.sizes.json
+++ b/.sizes.json
@@ -8,7 +8,7 @@
       "name": "*",
       "total": {
         "min": 26059,
-        "brotli": 9690
+        "brotli": 9697
       }
     },
     {

--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -1,4 +1,4 @@
-// size: 26059 (min) 9690 (brotli)
+// size: 26059 (min) 9697 (brotli)
 //#region packages/runtime-tags/dist/dom.mjs
 let unsafeStyleAttrReg = /[\\;]/g,
   replaceUnsafeStyleAttr = (c) => (c === ";" ? "\\3B " : "\\\\"),
@@ -1471,7 +1471,7 @@ function _attr_input_value(
     (scope["F" + nodeAccessor] = valueChange ? 2 : 5),
     valueChange && scope.H < runId
       ? setInputValue(el, normalizedValue)
-      : setDefault(scope, nodeAccessor, normalizedValue));
+      : setDefault(scope, nodeAccessor, value));
 }
 function _attr_input_value_attribute_default(scope, nodeAccessor, value) {
   _attr(scope[nodeAccessor], "value", value);

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -152,12 +152,6 @@ The patched `MarkoTag` printer wraps every non-void body in `newline(1)`/`indent
 
 `restOffset` is assigned only in the `Identifier` case, so every path that re-creates a rest's binding drops it — the `ObjectPattern`/`ArrayPattern` cases reuse `upstreamAlias` verbatim when `property === undefined`, and `trackVarReferences` forwards `excludeProperties` but not `restOffset`. `<const/[first, ...[second, third]] = arr/>` then compiles in DOM to `$second` reading `$scope.first` and `$third` reading `$scope.arr[1]` (`1|1|2` vs HTML's `1|2|3`); `<for|a, ...[b, c]|>` maps `c` to `#LoopKey`; `<const/copy = rest/>` takes `getSignalFn`'s object-rest branch, so `copy.length` reads `$scope.arr.length`. All are silent SSR/CSR divergence with no diagnostic. Set `restOffset` in the pattern cases and thread it through `trackVarReferences`. Re-verify: `pnpm run compile -o dom -d` on the nested-rest template emits `_text($scope["#text/1"], $scope.first)` for `$second`.
 
-## Hand the raw `value` to `_attr_input_value`'s default helper
-
-`packages/runtime-tags/src/dom/controllable.ts` › `_attr_input_value` | 2026-07-27 | impact:med | effort:low
-
-`_attr_input_value` passes `normalizeAttrValue(value) || ""` to `setDefault`, but the attribute-backed defaults (`_attr_input_value_attribute_default`, and the attribute arm of `_attr_input_value_dynamic_default`) write it through `_attr`, which removes the attribute only for `undefined`. A void `value` therefore renders `value=""` in CSR while `html/attrs.ts` emits no attribute, so a checkbox or radio submits `""` client-side and the spec default `"on"` server-side. The idiomatic `<input type="checkbox" value:=v/>` compiles straight to `_attr_input_value(…, _attr_input_value_attribute_default)`, and no test covers it. Pass `value` rather than `normalizedValue` to `setDefault`; `_attr_input_value_default` re-normalizes anyway. Re-verify: under jsdom call `_attr_input_value({"#i":el},"#i",undefined,()=>{},_attr_input_value_attribute_default)` — the element becomes `<input type="checkbox" value="">` against an empty SSR string.
-
 ## Mint `<id>`'s fallback once per scope
 
 `packages/runtime-tags/src/translator/core/id.ts` › `translate.exit` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-dynamic-tag/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 12771,
-      "brotli": 4960
+      "brotli": 4959
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4330,
-      "brotli": 2018
+      "brotli": 2019
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4211,
-      "brotli": 1959
+      "brotli": 1960
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 4330,
-      "brotli": 2005
+      "brotli": 2003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7295,
-        "brotli": 2991
+        "brotli": 2989
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7356,
-      "brotli": 3042
+      "brotli": 3039
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7552,
-        "brotli": 3070
+        "brotli": 3069
       },
       "files": {
         "tags/radio.marko": 280,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7555,
-        "brotli": 3072
+        "brotli": 3070
       },
       "files": {
         "tags/checkbox.marko": 286,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-details-textarea/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 14183,
-      "brotli": 5546
+      "brotli": 5545
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-tag-uncontrolled-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 13613,
-      "brotli": 5284
+      "brotli": 5279
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4129,
-        "brotli": 1918
+        "brotli": 1922
       },
       "files": {
         "tags/custom-input.marko": 496,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 4145,
-        "brotli": 1922
+        "brotli": 1925
       },
       "files": {
         "tags/my-input.marko": 507,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3859,
-      "brotli": 1822
+      "brotli": 1819
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7274,
-        "brotli": 2982
+        "brotli": 2979
       },
       "files": {
         "tags/my-input.marko": 256,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<input type=checkbox>";
+const $walks = " b";
+const $v = /*@__PURE__*/ _let("v/1", ($scope) => _attr_input_value($scope, "#input/0", $scope.v, $valueChange($scope), _attr_input_value_attribute_default));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#input/0"));
+function $setup($scope) {
+	$v($scope, undefined);
+	$setup__script($scope);
+}
+function $valueChange($scope) {
+	return (_new_v) => {
+		$v($scope, _new_v);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.js
@@ -1,0 +1,9 @@
+// template.marko
+const $v = /*@__PURE__*/ _let(1, ($scope) => _attr_input_value($scope, "a", $scope.b, $valueChange($scope), _attr_input_value_attribute_default));
+const $setup__script = _script("a1", ($scope) => _attr_input_value_script($scope, "a"));
+function $valueChange($scope) {
+	return (_new_v) => {
+		$v($scope, _new_v);
+	};
+}
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = undefined;
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", v, _resume((_new_v) => {
+		v = _new_v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))} type=checkbox>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = void 0;
+	_html(`<input${_attr_input_value($scope0_id, "a", v, _resume((_new_v) => {
+		v = _new_v;
+	}, "a0", $scope0_id))} type=checkbox>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.debug.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<input
+  type="checkbox"
+/>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.md
@@ -1,0 +1,6 @@
+# Render
+```html
+<input
+  type="checkbox"
+/>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.debug.html
@@ -1,0 +1,12 @@
+<input type=checkbox><!--M_*1 #input/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#input/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko_0/valueChange"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<input type=checkbox><!--M_*1 a-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    Ea: _(1, "a0")
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7261,
-      "brotli": 2996
+      "min": 3892,
+      "brotli": 1818
     }
   },
   "html": {
-    "min": 423,
-    "brotli": 276
+    "min": 351,
+    "brotli": 253
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko
@@ -1,0 +1,2 @@
+<let/v=undefined/>
+<input type="checkbox" value:=v/>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [{}],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3831,
-      "brotli": 1812
+      "brotli": 1810
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7312,
-      "brotli": 3024
+      "brotli": 3022
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 6293,
-      "brotli": 2738
+      "brotli": 2739
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7328,
-      "brotli": 3021
+      "brotli": 3020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 13899,
-      "brotli": 5394
+      "brotli": 5392
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 5606,
-        "brotli": 2477
+        "brotli": 2476
       },
       "files": {
         "tags/my-textarea.marko": 262,

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3831,
-      "brotli": 1812
+      "brotli": 1810
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 14514,
-        "brotli": 5629
+        "brotli": 5627
       },
       "files": {
         "tags/child1.marko": 364,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-handler-state/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 14022,
-      "brotli": 5442
+      "brotli": 5440
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-svg-camel/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-svg-camel/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 10244,
-      "brotli": 4075
+      "brotli": 4072
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7203,
-      "brotli": 2984
+      "brotli": 2981
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7284,
-        "brotli": 2984
+        "brotli": 2985
       },
       "files": {
         "tags/my-input.marko": 371,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7243,
-      "brotli": 2984
+      "brotli": 2982
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 14903,
-        "brotli": 5946
+        "brotli": 5964
       },
       "files": {
         "tags/child.marko": 758,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/sizes.json
@@ -3,7 +3,7 @@
     "template.marko.page.mjs": {
       "total": {
         "min": 7947,
-        "brotli": 3142
+        "brotli": 3139
       },
       "files": {
         "tags/child.marko": 134,

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 7501,
-      "brotli": 3323
+      "brotli": 3322
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-input-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3902,
-      "brotli": 1837
+      "brotli": 1836
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-default-update/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3944,
-      "brotli": 1852
+      "brotli": 1849
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -248,7 +248,9 @@ export function _attr_input_value(
   if (valueChange && scope[AccessorProp.Gen] < runId) {
     setInputValue(el, normalizedValue);
   } else {
-    setDefault(scope, nodeAccessor, normalizedValue);
+    // The raw value, so attribute-backed defaults drop the attribute for void
+    // values like the server does; `_attr_input_value_default` re-normalizes.
+    setDefault(scope, nodeAccessor, value);
   }
 }
 export function _attr_input_value_attribute_default(


### PR DESCRIPTION
`_attr_input_value` normalized a void `value` to `""` before handing it to the attribute-backed default helpers, which only remove the attribute for `undefined` — so `<input type="checkbox" value:=v/>` with a void `v` rendered `value=""` client-side while the server emitted no attribute (submitting `""` vs the spec default `"on"`). Pass the raw value through; `_attr_input_value_default` re-normalizes. New `controllable-input-value-void` fixture pins CSR/SSR agreement.