### PR TITLE
Error on value bindings for attribute-backed input types

### DIFF
--- a/.changeset/checkbox-value-binding-error.md
+++ b/.changeset/checkbox-value-binding-error.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Error when binding `value` on an input whose type is attribute-backed (checkbox, radio, hidden, button, submit, reset, image) — at compile time when the type is statically known, and as a dev-mode runtime error otherwise.

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,33 @@
+// template.marko
+const $template = "<input><input>";
+const $walks = " b b";
+const $v = /*@__PURE__*/ _let("v/6", ($scope) => _attr_input_value($scope, "#input/0", $scope.v, $valueChange($scope), _attr_input_value_dynamic_default));
+const $h = /*@__PURE__*/ _let("h/7", ($scope) => _attr_input_value($scope, "#input/1", $scope.h, $valueChange2($scope), _attr_input_value_dynamic_default));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
+	_attr_input_value_script($scope, "#input/0");
+	_attr_input_value_script($scope, "#input/1");
+});
+function $setup($scope) {
+	$v($scope, "a");
+	$h($scope, "b");
+	$setup__script($scope);
+}
+const $input_checkboxType = ($scope, input_checkboxType) => _attr($scope["#input/0"], "type", input_checkboxType);
+const $input_hiddenType = ($scope, input_hiddenType) => _attr($scope["#input/1"], "type", input_hiddenType);
+const $input = ($scope, input) => {
+	$input_checkboxType($scope, input.checkboxType);
+	$input_hiddenType($scope, input.hiddenType);
+};
+function $valueChange($scope) {
+	return (_new_v) => {
+		$v($scope, _new_v);
+	};
+}
+function $valueChange2($scope) {
+	return (_new_h) => {
+		$h($scope, _new_h);
+	};
+}
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+_resume("__tests__/template.marko_0/valueChange2", $valueChange2);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let v = "a";
+	let h = "b";
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", v, _resume((_new_v) => {
+		v = _new_v;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))}${_attr("type", input.checkboxType)}>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_value($scope0_id, "#input/1", h, _resume((_new_h) => {
+		h = _new_h;
+	}, "__tests__/template.marko_0/valueChange2", $scope0_id))}${_attr("type", input.hiddenType)}>${_el_resume($scope0_id, "#input/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/render-csr.debug.md
@@ -1,0 +1,16 @@
+# Render `{"checkboxType":"checkbox","hiddenType":"hidden"}`
+```html
+<input
+  type="checkbox"
+  value="a"
+/>
+<input
+  type="hidden"
+  value="b"
+/>
+```
+## Console
+```
+ERROR "`valueChange` cannot be used on a `type=\"checkbox\"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead."
+ERROR "`valueChange` cannot be used on a `type=\"hidden\"` `<input>` — user interaction can never change its `value`."
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,16 @@
+# Render `{"checkboxType":"checkbox","hiddenType":"hidden"}`
+```html
+<input
+  type="checkbox"
+  value="a"
+/>
+<input
+  type="hidden"
+  value="b"
+/>
+```
+## Console
+```
+ERROR "`valueChange` cannot be used on a `type=\"checkbox\"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead."
+ERROR "`valueChange` cannot be used on a `type=\"hidden\"` `<input>` — user interaction can never change its `value`."
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<input value=a type=checkbox><!--M_*1 #input/0--><input value=b
+  type=hidden><!--M_*1 #input/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      "ControlledHandler:#input/0": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/template.marko_0/valueChange"
+        ),
+      "ControlledHandler:#input/1": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/template.marko_0/valueChange2"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/template.marko
@@ -1,0 +1,4 @@
+<let/v="a"/>
+<let/h="b"/>
+<input type=input.checkboxType value:=v/>
+<input type=input.hiddenType value:=h/>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+// Binding `value` on an input whose type is attribute-backed (checkbox, radio,
+// hidden, …) is a mistake — user interaction can never change `value` — so
+// debug builds emit a `console.error` from both runtimes, captured under
+// `## Console`. The types here are dynamic; statically-known types are a
+// compile error instead (see `error-checkbox-value-binding`). Debug-only, so
+// optimize is skipped; the server's static-typed path has no type to check,
+// so the SSR and CSR consoles differ.
+export const config: TestConfig = {
+  skip_optimize: true,
+  equivalent: false,
+  steps: [{ checkboxType: "checkbox", hiddenType: "hidden" }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,10 @@
 // template.marko
-const $template = "<input type=checkbox>";
+const $template = "<input type=hidden>";
 const $walks = " b";
-const $v = /*@__PURE__*/ _let("v/1", ($scope) => _attr_input_value($scope, "#input/0", $scope.v, $valueChange($scope), _attr_input_value_attribute_default));
+const $v = /*@__PURE__*/ _let("v/1", ($scope) => _attr_input_value($scope, "#input/0", $scope.v, undefined, _attr_input_value_attribute_default));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#input/0"));
 function $setup($scope) {
 	$v($scope, undefined);
 	$setup__script($scope);
 }
-function $valueChange($scope) {
-	return (_new_v) => {
-		$v($scope, _new_v);
-	};
-}
-_resume("__tests__/template.marko_0/valueChange", $valueChange);
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/dom.bundle.js
@@ -1,9 +1,2 @@
 // template.marko
-const $v = /*@__PURE__*/ _let(1, ($scope) => _attr_input_value($scope, "a", $scope.b, $valueChange($scope), _attr_input_value_attribute_default));
-const $setup__script = _script("a1", ($scope) => _attr_input_value_script($scope, "a"));
-function $valueChange($scope) {
-	return (_new_v) => {
-		$v($scope, _new_v);
-	};
-}
-_resume("a0", $valueChange);
+const $setup__script = _script("a0", ($scope) => _attr_input_value_script($scope, "a"));

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.debug.js
@@ -3,9 +3,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let v = undefined;
-	_html(`<input${_attr_input_value($scope0_id, "#input/0", v, _resume((_new_v) => {
-		v = _new_v;
-	}, "__tests__/template.marko_0/valueChange", $scope0_id))} type=checkbox>${_el_resume($scope0_id, "#input/0")}`);
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", v, undefined)} type=hidden>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/html.bundle.js
@@ -2,11 +2,8 @@
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
-	let v = void 0;
-	_html(`<input${_attr_input_value($scope0_id, "a", v, _resume((_new_v) => {
-		v = _new_v;
-	}, "a0", $scope0_id))} type=checkbox>${_el_resume($scope0_id, "a")}`);
-	_script($scope0_id, "a1");
+	_html(`<input${_attr_input_value($scope0_id, "a", void 0, void 0)} type=hidden>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
 	writeScope($scope0_id, {});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.debug.md
@@ -1,6 +1,6 @@
 # Render
 ```html
 <input
-  type="checkbox"
+  type="hidden"
 />
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/render.md
@@ -1,6 +1,6 @@
 # Render
 ```html
 <input
-  type="checkbox"
+  type="hidden"
 />
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.debug.html
@@ -1,11 +1,7 @@
-<input type=checkbox><!--M_*1 #input/0-->
+<input type=hidden><!--M_*1 #input/0-->
 <script>
   WALKER_RUNTIME("M")("_");
-  M._.r = [_ => [1, {
-      "ControlledHandler:#input/0": _(1,
-        "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko_0/valueChange"
-        )
-    }],
+  M._.r = [
     "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko_0 1"
   ];
   M._.w()

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/__snapshots__/writes.html
@@ -1,8 +1,6 @@
-<input type=checkbox><!--M_*1 a-->
+<input type=hidden><!--M_*1 a-->
 <script>
   WALKER_RUNTIME("M")("_");
-  M._.r = [_ => [1, {
-    Ea: _(1, "a0")
-  }], "a1 1"];
+  M._.r = ["a0 1"];
   M._.w()
 </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 3892,
-      "brotli": 1818
+      "min": 2740,
+      "brotli": 1319
     }
   },
   "html": {
-    "min": 351,
-    "brotli": 253
+    "min": 327,
+    "brotli": 234
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-void/template.marko
@@ -1,2 +1,2 @@
 <let/v=undefined/>
-<input type="checkbox" value:=v/>
+<input type="hidden" value=v valueChange=undefined/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko:2:1
+      1 | <let/v="a"/>
+    > 2 | <input type="checkbox" value:=v/>
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `valueChange` cannot be used on a `type="checkbox"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko:2:1
+      1 | <let/v="a"/>
+    > 2 | <input type="checkbox" value:=v/>
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `valueChange` cannot be used on a `type="checkbox"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko:2:1
+      1 | <let/v="a"/>
+    > 2 | <input type="checkbox" value:=v/>
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `valueChange` cannot be used on a `type="checkbox"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/__snapshots__/error-compile-html.txt
@@ -1,0 +1,6 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko:2:1
+      1 | <let/v="a"/>
+    > 2 | <input type="checkbox" value:=v/>
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `valueChange` cannot be used on a `type="checkbox"` `<input>` — user interaction can never change its `value`. Bind `checked` or `checkedValue` instead.
+      3 |

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/template.marko
@@ -1,0 +1,2 @@
+<let/v="a"/>
+<input type="checkbox" value:=v/>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-checkbox-value-binding/test.ts
@@ -1,0 +1,5 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_compiler: true,
+};

--- a/packages/runtime-tags/src/common/errors.ts
+++ b/packages/runtime-tags/src/common/errors.ts
@@ -201,6 +201,25 @@ export function assertExclusiveAttrs(
   }
 }
 
+export function assertNoValueBindingOnCheckable(
+  type: unknown,
+  valueChange: unknown,
+) {
+  if (
+    valueChange &&
+    /^(?:button|checkbox|hidden|image|radio|reset|submit)$/i.test(
+      type as string,
+    )
+  ) {
+    console.error(
+      `\`valueChange\` cannot be used on a \`type="${type}"\` \`<input>\` — user interaction can never change its \`value\`.` +
+        (/^[cr]/i.test(type as string)
+          ? " Bind `checked` or `checkedValue` instead."
+          : ""),
+    );
+  }
+}
+
 export function assertHandlerIsFunction(name: string, value: unknown) {
   if (value && typeof value !== "function") {
     throw new Error(

--- a/packages/runtime-tags/src/dom/controllable.ts
+++ b/packages/runtime-tags/src/dom/controllable.ts
@@ -1,4 +1,7 @@
-import { assertHandlerIsFunction } from "../common/errors";
+import {
+  assertHandlerIsFunction,
+  assertNoValueBindingOnCheckable,
+} from "../common/errors";
 import { isNotVoid } from "../common/helpers";
 import {
   type Accessor,
@@ -238,6 +241,7 @@ export function _attr_input_value(
   const normalizedValue = normalizeAttrValue(value) || "";
   if (MARKO_DEBUG) {
     assertHandlerIsFunction("valueChange", valueChange);
+    assertNoValueBindingOnCheckable(el.type, valueChange);
   }
   scope[AccessorPrefix.ControlledHandler + nodeAccessor] = valueChange;
   scope[AccessorPrefix.ControlledValue + nodeAccessor] = normalizedValue;
@@ -262,6 +266,12 @@ export function _attr_input_value_attribute_default(
 }
 export function _attr_input_value_script(scope: Scope, nodeAccessor: Accessor) {
   const el = scope[nodeAccessor] as HTMLInputElement;
+  if (MARKO_DEBUG) {
+    assertNoValueBindingOnCheckable(
+      el.type,
+      scope[AccessorPrefix.ControlledHandler + nodeAccessor],
+    );
+  }
   if (isResuming) {
     scope[AccessorPrefix.ControlledValue + nodeAccessor] = el.defaultValue;
   }

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -1,6 +1,7 @@
 import {
   assertExclusiveAttrs,
   assertHandlerIsFunction,
+  assertNoValueBindingOnCheckable,
   assertValidAttrName,
   assertValidAttrValue,
 } from "../common/errors";
@@ -301,6 +302,9 @@ export function _attrs(
         );
         skip = /^(?:value|checked(?:Value)?)(?:Change)?$|[\s/>"'=]/;
       } else if (data.valueChange) {
+        if (MARKO_DEBUG) {
+          assertNoValueBindingOnCheckable(data.type, data.valueChange);
+        }
         result += _attr_input_value(
           scopeId,
           nodeAccessor,

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -243,6 +243,24 @@ export default {
       }
 
       relatedControllable ||= getRelatedControllable(tagName, seen);
+      const valueChangeEval =
+        tagName === "input" && seen.valueChange
+          ? evaluate(seen.valueChange.value)
+          : undefined;
+      if (
+        valueChangeEval &&
+        !(valueChangeEval.confident && valueChangeEval.computed == null) &&
+        getInputValueMode(seen.type) === "attribute"
+      ) {
+        const type = evaluate(seen.type!.value).computed as string;
+        throw tag.hub.buildError(
+          seen.valueChange,
+          `\`valueChange\` cannot be used on a \`type="${type}"\` \`<input>\` — user interaction can never change its \`value\`.` +
+            (/^[cr]/i.test(type)
+              ? " Bind `checked` or `checkedValue` instead."
+              : ""),
+        );
+      }
       if (relatedControllable && relatedControllable.attrs[1]) {
         hasEventHandlers = true;
       }


### PR DESCRIPTION
Two-way binding `value` on an input whose type is attribute-backed (checkbox, radio, hidden, button, submit, reset, image) makes no sense — user interaction can never change `value` — and hydration's edited-before-resume check misreads the checkbox/radio spec-default `value` IDL (`"on"`) as a user edit, firing `valueChange("on")` spuriously. When the `type` is statically known the translator now reports a compile error at the `valueChange`/bound attribute (skipped when the handler is confidently nullish, a legitimate "no handler" spelling); otherwise debug builds `console.error` from the DOM mount/update path, the resume script, and the HTML spread path. Checkbox/radio messages point at `checked`/`checkedValue`. Fixtures: `error-checkbox-value-binding` (compile error), `controllable-checkbox-value-binding` (runtime dev error via dynamic types), and `controllable-input-value-void` reworked to stay diagnostic-free while still pinning the void-value attribute parity fix.