### PR TITLE
Name variables, attributes, and internal slots in unserializable errors

### DIFF
--- a/.changeset/unserializable-debug-info.md
+++ b/.changeset/unserializable-debug-info.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Improve debug "Unable to serialize" errors: restore variable names and locations for escaped keys and values inside Maps/Sets/generators, and name the offending controllable handler attribute or spread instead of printing internal accessors.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -68,12 +68,6 @@ A reorder flush appends `<t hidden {commentPrefix}={reorderId}>reorderHTML</t>`,
 
 The inline trigger script for `with { load: "visible…" | "on-…" }` resolves its target as `document.querySelector(sel) || l()`, and `writeScript` lands it at the end of the current flush chunk, not the document. A flush boundary (`<await>`, `<try>`, lazy content) between the tag and its target means `querySelector` returns null and `l()` fetches the module immediately — the code split degrades to eager loading. The CSR path warns on this miss (`dom/load.ts` › `getSelectorOrResolve`); the emitted SSR string has no `MARKO_DEBUG` branch, so on server-rendered pages it degrades silently. Re-check on `DOMContentLoaded` (or observe until the node appears) before falling back to `l()`, and emit a `MARKO_DEBUG`-gated warn. Re-verify: a `visible #footer` lazy tag placed before an `<await>` whose body holds `<footer id=footer>` — the first chunk already contains `document.querySelector("#footer")||l()`.
 
-## Restore the variable name and source location in `throwUnserializable`
-
-`packages/runtime-tags/src/html/serializer.ts` › `throwUnserializable` | 2026-07-23 | impact:low | effort:low
-
-Two lookups drop translator-emitted debug info. (1) `writeObjectProps` passes the escaped key (`toObjectKey(key)`) as the `Reference` accessor while `debug.vars` is keyed by the raw accessor from `writeHTMLResumeStatements` (`translator/util/signals.ts`), so `#LoopKey` never matches and prints double-quoted. (2) `while (ref?.accessor)` stops at the null-accessor `Reference` that `writeArrayArg`, `writeGenerator`, and `writeMaybeIterableProps` create for a collection's backing array, so anything inside a Map/Set/generator never reaches the scope `Reference` holding `debug`. Carry the raw key alongside the escaped one, and keep walking past null accessors. Re-verify with `node -r ~ts`: after `setDebugInfo(scope, "page.marko", "2:6", { selected: ["selected","2:6"] })`, serializing `{selected: new Set([new Thing()])}` aborts with `Unable to serialize (reading [0])` while the plain-array form reports `"selected" in page.marko:2:6`.
-
 ## Apply `ToNumeric` when lowering `++`/`--` on a tag variable
 
 `packages/runtime-tags/src/translator/util/signals.ts` › `replaceAssignedNode` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-to-pruned-let-with-change-handler/__snapshots__/html.bundle.debug.js
@@ -8,6 +8,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { "TagVariableChange:count": _resume(function(v) {
 		liveCount = v;
-	}, "__tests__/template.marko_0/valueChange", $scope0_id) || void 0 }, "__tests__/template.marko", 0);
+	}, "__tests__/template.marko_0/valueChange", $scope0_id) || void 0 }, "__tests__/template.marko", 0, { "TagVariableChange:count": ["countChange", "2:6"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var hello_default = _template("__tests__/tags/hello/index.marko", (input) => {
 		_dynamic_tag($scope1_id, "#text/1", content, {}, 0, 0, $sg__input_list_item);
 		_html(`</div>${_el_resume($scope1_id, "#div/0")}`);
 		_script($scope1_id, "__tests__/tags/hello/index.marko_1_attrs#5");
-		writeScope($scope1_id, {}, "__tests__/tags/hello/index.marko", "1:1");
+		writeScope($scope1_id, {}, "__tests__/tags/hello/index.marko", "1:1", { "EventAttributes:#div/0": ["...attrs", "2:15"] });
 	}, 0, $scope0_id, "#text/0", $sg__input_list_item, $sg__input_list_item, $sg__input_list_item__OR__input_col, 0, 1);
 	_for_of(input.col, ({ content, row, ...attrs }) => {
 		const $scope2_id = _scope_id();
@@ -21,10 +21,10 @@ var hello_default = _template("__tests__/tags/hello/index.marko", (input) => {
 			_dynamic_tag($scope3_id, "#text/1", content, {}, 0, 0, $sg__input_col);
 			_html(`</div>${_el_resume($scope3_id, "#div/0")}`);
 			_script($scope3_id, "__tests__/tags/hello/index.marko_3_attrs#5");
-			writeScope($scope3_id, {}, "__tests__/tags/hello/index.marko", "7:3");
+			writeScope($scope3_id, {}, "__tests__/tags/hello/index.marko", "7:3", { "EventAttributes:#div/0": ["...attrs", "8:16"] });
 		}, 0, $scope2_id, "#text/1", $sg__input_col, $sg__input_col, $sg__input_col, 0, 1);
 		_script($scope2_id, "__tests__/tags/hello/index.marko_2_attrs#5");
-		writeScope($scope2_id, {}, "__tests__/tags/hello/index.marko", "5:1");
+		writeScope($scope2_id, {}, "__tests__/tags/hello/index.marko", "5:1", { "EventAttributes:#div/0": ["...attrs", "6:14"] });
 	}, 0, $scope0_id, "#text/1", $sg__input_col, $sg__input_col, $sg__input_list_item__OR__input_col);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/hello/index.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) =>
 		_attrs_content(item, "#button/0", $scope1_id, "button");
 		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
 		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item#2");
-		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2", { "EventAttributes:#button/0": ["...item", "2:14"] });
 	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) =>
 		_attrs_content(item, "#button/0", $scope1_id, "button");
 		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
 		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item#2");
-		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2", { "EventAttributes:#button/0": ["...item", "2:14"] });
 	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var my_menu_default = _template("__tests__/tags/my-menu/index.marko", (input) =>
 		_attrs_content(item, "#button/0", $scope1_id, "button");
 		_html(`</button>${_el_resume($scope1_id, "#button/0")}`);
 		_script($scope1_id, "__tests__/tags/my-menu/index.marko_1_item#2");
-		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2");
+		writeScope($scope1_id, {}, "__tests__/tags/my-menu/index.marko", "1:2", { "EventAttributes:#button/0": ["...item", "2:14"] });
 	}, 0, $scope0_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/my-menu/index.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/__snapshots__/html.bundle.debug.js
@@ -5,5 +5,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const { attrs } = input;
 	_html(`<input${_attrs(attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_attrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...attrs", "2:11"],
+		"EventAttributes:#input/0": ["...attrs", "2:11"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,8 @@ var counter_default = _template("__tests__/tags/counter.marko", (input) => {
 	}, "__tests__/tags/counter.marko", 0, {
 		$countChange: 0,
 		count: "1:10",
-		x: "3:6"
+		x: "3:6",
+		"TagVariableChange:x": ["xChange", "3:6"]
 	});
 	_resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var FancyButton_default = _template("__tests__/tags/FancyButton.marko", (input) 
 	_dynamic_tag($scope0_id, "#text/1", content, {}, 0, 0, _serialize_guard($scope0_reason, 0));
 	_html(`</button>${_el_resume($scope0_id, "#button/0")}`);
 	_script($scope0_id, "__tests__/tags/FancyButton.marko_0_attrs#5");
-	writeScope($scope0_id, {}, "__tests__/tags/FancyButton.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/FancyButton.marko", 0, { "EventAttributes:#button/0": ["...attrs", "2:12"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-computed-key/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		state
 	}, "__tests__/template.marko", 0, {
 		key: "5:8",
-		state: "6:8"
+		state: "6:8",
+		"ControlledHandler:#input/2": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-missing-handler/__snapshots__/html.bundle.debug.js
@@ -6,6 +6,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const state = { x: "v" };
 	_html(`<button>inc <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}<input${_attr_input_value($scope0_id, "#input/2", state.x, state.xChange)}>${_el_resume($scope0_id, "#input/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, { n: "1:6" });
+	writeScope($scope0_id, { n }, "__tests__/template.marko", 0, {
+		n: "1:6",
+		"ControlledHandler:#input/2": ["valueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			a: _serialize_if($scope1_reason, 1) && a
 		}, "__tests__/template.marko", "1:2", {
 			$aChange: 0,
-			a: "1:16"
+			a: "1:16",
+			"ControlledHandler:#input/0": ["valueChange"],
+			"ControlledHandler:#input/1": ["valueChange"],
+			"ControlledHandler:#input/2": ["valueChange"]
 		});
 	}) };
 	let n = 1;

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-repeated-let/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$valueChange
 	}, "__tests__/template.marko", 0, {
 		x: "1:6",
-		$valueChange: 0
+		$valueChange: 0,
+		"ControlledHandler:#input/2": ["valueChange"],
+		"ControlledHandler:#input/3": ["valueChange"],
+		"ControlledHandler:#input/4": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-shapes/__snapshots__/html.bundle.debug.js
@@ -25,7 +25,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		a: "1:6",
 		b: "2:6",
 		state_aChange: ["state.aChange", "3:8"],
-		state_bChange: ["state.bChange", "3:8"]
+		state_bChange: ["state.bChange", "3:8"],
+		"ControlledHandler:#input/2": ["valueChange"],
+		"ControlledHandler:#input/3": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/checkbox-spread-checked-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/checkbox-spread-checked-value/__snapshots__/html.bundle.debug.js
@@ -9,6 +9,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, { type: 1 }, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}<button>t</button>${_el_resume($scope0_id, "#button/1")}<div>${_escape(sel.join(","))}${_el_resume($scope0_id, "#text/2")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	_script($scope0_id, "__tests__/template.marko_0_sel#3");
-	writeScope($scope0_id, { sel }, "__tests__/template.marko", 0, { sel: "1:6" });
+	writeScope($scope0_id, { sel }, "__tests__/template.marko", 0, {
+		sel: "1:6",
+		"ControlledHandler:#input/0": ["...{ checkedValue: sel, value: \"a\" }", "2:11"],
+		"EventAttributes:#input/0": ["...{ checkedValue: sel, value: \"a\" }", "2:11"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checkbox-value-binding/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		h = _new_h;
 	}, "__tests__/template.marko_0/valueChange2", $scope0_id))}${_attr("type", input.hiddenType)}>${_el_resume($scope0_id, "#input/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["valueChange"],
+		"ControlledHandler:#input/1": ["valueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-many/__snapshots__/html.bundle.debug.js
@@ -24,7 +24,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				newStates[i] = value;
 				states = newStates;
 			}, "__tests__/template.marko_1/valueChange", $scope1_id) || void 0
-		}, "__tests__/template.marko", "2:2", { "#LoopKey": "2:13" });
+		}, "__tests__/template.marko", "2:2", {
+			"#LoopKey": "2:13",
+			"TagVariableChange:checked": ["checkedChange", "3:8"],
+			"ControlledHandler:#input/0": ["checkedChange"]
+		});
 	}, 0, $scope0_id, "#text/0", 1, 1, 1, 0, 1);
 	_html(`<div>${_escape(states.join(","))}${_el_resume($scope0_id, "#text/1")}</div>`);
 	writeScope($scope0_id, { states }, "__tests__/template.marko", 0, { states: "1:6" });

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,10 @@ var checkbox_default = _template("__tests__/tags/checkbox.marko", (input) => {
 		...input
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/tags/checkbox.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/checkbox.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/checkbox.marko", 0, {
+		"ControlledHandler:#input/0": ["...input", "1:27"],
+		"EventAttributes:#input/0": ["...input", "1:27"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty-spread/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		rest
 	}, "__tests__/template.marko", 0, {
 		v: "1:6",
-		rest: "2:8"
+		rest: "2:8",
+		"ControlledHandler:#input/1": ["...rest", "4:51"],
+		"EventAttributes:#input/1": ["...rest", "4:51"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-empty/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		selected = _new_selected;
 	}, "__tests__/template.marko_0/checkedValueChange", $scope0_id), "")} type=checkbox>${_el_resume($scope0_id, "#input/0")}<output>${selected === undefined ? "undefined" : selected === null ? "null" : _escape("value=" + selected)}${_el_resume($scope0_id, "#text/1")}</output>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#input/0": ["checkedValueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-multiple-number/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		checked = v.map((it) => Number(it));
 	}, "__tests__/template.marko_0/checkedValueChange3", $scope0_id), 2)} type=checkbox>${_el_resume($scope0_id, "#input/2")}<span>${_escape(checked)}${_el_resume($scope0_id, "#text/3")}</span><button>Reset</button>${_el_resume($scope0_id, "#button/4")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["checkedValueChange", "3:53"],
+		"ControlledHandler:#input/1": ["checkedValueChange", "4:55"],
+		"ControlledHandler:#input/2": ["checkedValueChange", "5:53"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-number/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		checked = +v;
 	}, "__tests__/template.marko_0/checkedValueChange3", $scope0_id), 2)} type=radio>${_el_resume($scope0_id, "#input/2")}<span>${_escape(checked)}${_el_resume($scope0_id, "#text/3")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["checkedValueChange", "3:53"],
+		"ControlledHandler:#input/1": ["checkedValueChange", "4:52"],
+		"ControlledHandler:#input/2": ["checkedValueChange", "5:50"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-rejected/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-rejected/__snapshots__/html.bundle.debug.js
@@ -5,6 +5,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let picked = "a";
 	_html(`<input${_attr_input_checkedValue($scope0_id, "#input/0", picked, _resume(function() {}, "__tests__/template.marko_0/checkedValueChange"), "a")} type=radio name=pick>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_checkedValue($scope0_id, "#input/1", picked, _resume(function() {}, "__tests__/template.marko_0/checkedValueChange2"), "b")} type=radio name=pick>${_el_resume($scope0_id, "#input/1")}<span>${_escape(picked)}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["checkedValueChange", "2:63"],
+		"ControlledHandler:#input/1": ["checkedValueChange", "3:63"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,10 @@ var radio_default = _template("__tests__/tags/radio.marko", (input) => {
 		...input
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/tags/radio.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/radio.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/radio.marko", 0, {
+		"ControlledHandler:#input/0": ["...input", "1:24"],
+		"EventAttributes:#input/0": ["...input", "1:24"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value/__snapshots__/html.bundle.debug.js
@@ -8,6 +8,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko_0/checkedValueChange2", $scope0_id);
 	_html(`<input${_attr_input_checkedValue($scope0_id, "#input/0", checkedValue, $checkedValueChange, "a")} type=radio>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_checkedValue($scope0_id, "#input/1", checkedValue, $checkedValueChange, "b")} type=radio>${_el_resume($scope0_id, "#input/1")}<input${_attr_input_checkedValue($scope0_id, "#input/2", checkedValue, $checkedValueChange, "c")} type=radio>${_el_resume($scope0_id, "#input/2")}<span>${_escape(checkedValue)}${_el_resume($scope0_id, "#text/3")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, { $checkedValueChange: 0 });
+	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, {
+		$checkedValueChange: 0,
+		"ControlledHandler:#input/0": ["checkedValueChange"],
+		"ControlledHandler:#input/1": ["checkedValueChange"],
+		"ControlledHandler:#input/2": ["checkedValueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,10 @@ var checkbox_default = _template("__tests__/tags/checkbox.marko", (input) => {
 		...input
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/tags/checkbox.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/checkbox.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/checkbox.marko", 0, {
+		"ControlledHandler:#input/0": ["...input", "1:27"],
+		"EventAttributes:#input/0": ["...input", "1:27"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values/__snapshots__/html.bundle.debug.js
@@ -8,6 +8,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko_0/checkedValueChange2", $scope0_id);
 	_html(`<input${_attr_input_checkedValue($scope0_id, "#input/0", checkedValue, $checkedValueChange, "a")} type=checkbox>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_checkedValue($scope0_id, "#input/1", checkedValue, $checkedValueChange, "b")} type=checkbox>${_el_resume($scope0_id, "#input/1")}<input${_attr_input_checkedValue($scope0_id, "#input/2", checkedValue, $checkedValueChange, "c")} type=checkbox>${_el_resume($scope0_id, "#input/2")}<span>${_escape(checkedValue)}${_el_resume($scope0_id, "#text/3")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, { $checkedValueChange: 0 });
+	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, {
+		$checkedValueChange: 0,
+		"ControlledHandler:#input/0": ["checkedValueChange"],
+		"ControlledHandler:#input/1": ["checkedValueChange"],
+		"ControlledHandler:#input/2": ["checkedValueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		checked = _new_checked;
 	}, "__tests__/template.marko_0/checkedChange", $scope0_id))} type=checkbox>${_el_resume($scope0_id, "#input/0")}<span>${_escape(String(checked))}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#input/0": ["checkedChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,10 @@ var my_details_default = _template("__tests__/tags/my-details.marko", (input) =>
 	const $scope0_id = _scope_id();
 	_html(`<details${_attrs(input, "#details/0", $scope0_id, "details")}><summary>s</summary></details>${_el_resume($scope0_id, "#details/0")}`);
 	_script($scope0_id, "__tests__/tags/my-details.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-details.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-details.marko", 0, {
+		"ControlledHandler:#details/0": ["...input", "1:13"],
+		"EventAttributes:#details/0": ["...input", "1:13"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		open = _new_open;
 	}, "__tests__/template.marko_0/openChange", $scope0_id))}><summary></summary></details>${_el_resume($scope0_id, "#details/0")}<span>${_escape(String(open))}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#details/0": ["openChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-spread-rerender/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		n
 	}, "__tests__/template.marko", 0, {
 		open: "1:6",
-		n: "2:6"
+		n: "2:6",
+		"ControlledHandler:#details/1": ["...attrs", "5:13"],
+		"EventAttributes:#details/1": ["...attrs", "5:13"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,10 @@ var my_dialog_default = _template("__tests__/tags/my-dialog.marko", (input) => {
 	_attrs_content(input, "#dialog/0", $scope0_id, "dialog");
 	_html(`</dialog>${_el_resume($scope0_id, "#dialog/0")}`);
 	_script($scope0_id, "__tests__/tags/my-dialog.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-dialog.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-dialog.marko", 0, {
+		"ControlledHandler:#dialog/0": ["...input", "1:12"],
+		"EventAttributes:#dialog/0": ["...input", "1:12"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		open = _new_open;
 	}, "__tests__/template.marko_0/openChange", $scope0_id))}></dialog>${_el_resume($scope0_id, "#dialog/0")}<span>${_escape(String(open))}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#dialog/0": ["openChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dynamic-checkbox-checked-value/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			const $scope1_id = _scope_id();
 			_html(`<input${_attr_input_checkedValue($scope1_id, "#input/0", checkedValue, $checkedValueChange, "b")} type=radio>${_el_resume($scope1_id, "#input/0")}`);
 			_script($scope1_id, "__tests__/template.marko_1");
-			writeScope($scope1_id, {}, "__tests__/template.marko", "5:2");
+			writeScope($scope1_id, {}, "__tests__/template.marko", "5:2", { "ControlledHandler:#input/0": ["checkedValueChange"] });
 			return 0;
 		}
 	}, $scope0_id, "#text/1", 1, 1, 1, 0, 1);
@@ -26,7 +26,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko", 0, {
 		show: "1:6",
 		checkedValue: "2:6",
-		$checkedValueChange: 0
+		$checkedValueChange: 0,
+		"ControlledHandler:#input/0": ["checkedValueChange"],
+		"ControlledHandler:#input/2": ["checkedValueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-member-modifier-value/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,8 @@ var custom_input_default = _template("__tests__/tags/custom-input.marko", (input
 		input_valueChange: input.valueChange
 	}, "__tests__/tags/custom-input.marko", 0, {
 		input_value: ["input.value"],
-		input_valueChange: ["input.valueChange"]
+		input_valueChange: ["input.valueChange"],
+		"ControlledHandler:#input/0": ["valueChange"]
 	});
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-destructured/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,8 @@ var my_input_default = _template("__tests__/tags/my-input.marko", (input) => {
 		count: _serialize_if($scope0_reason, 0) && count
 	}, "__tests__/tags/my-input.marko", 0, {
 		$countChange: 0,
-		count: "4:10"
+		count: "4:10",
+		"ControlledHandler:#input/0": ["valueChange"]
 	});
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-number-modifier-value/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		value = parseInt(_new_value);
 	}, "__tests__/template.marko_0/valueChange", $scope0_id))} type=number>${_el_resume($scope0_id, "#input/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")} <!>${_escape(typeof value)}${_el_resume($scope0_id, "#text/2")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#input/0": ["valueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,10 @@ var my_input_default = _template("__tests__/tags/my-input.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<input${_attrs(input, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/tags/my-input.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-input.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-input.marko", 0, {
+		"ControlledHandler:#input/0": ["...input", "1:11"],
+		"EventAttributes:#input/0": ["...input", "1:11"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		value = _new_value;
 	}, "__tests__/template.marko_0/valueChange", $scope0_id))} type=text>${_el_resume($scope0_id, "#input/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#input/0": ["valueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-merged-spread/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		rest
 	}, "__tests__/template.marko", 0, {
 		v: "1:6",
-		rest: "2:8"
+		rest: "2:8",
+		"ControlledHandler:#input/1": ["...rest", "4:39"],
+		"EventAttributes:#input/1": ["...rest", "4:39"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread-update/__snapshots__/html.bundle.debug.js
@@ -12,6 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "#input/1", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/1")}<div>${_escape(v)}${_el_resume($scope0_id, "#text/2")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0_rest#4");
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { rest }, "__tests__/template.marko", 0, { rest: "2:6" });
+	writeScope($scope0_id, { rest }, "__tests__/template.marko", 0, {
+		rest: "2:6",
+		"ControlledHandler:#input/1": ["valueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-partial-spread/__snapshots__/html.bundle.debug.js
@@ -24,7 +24,12 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		rest
 	}, "__tests__/template.marko", 0, {
 		v: "1:6",
-		rest: "2:8"
+		rest: "2:8",
+		"ControlledHandler:#input/1": ["...rest", "4:26"],
+		"EventAttributes:#input/1": ["...rest", "4:26"],
+		"ControlledHandler:#input/2": ["...rest", "5:11"],
+		"EventAttributes:#input/2": ["...rest", "5:11"],
+		"ControlledHandler:#input/3": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-radio-checkedvalue-form-reset/__snapshots__/html.bundle.debug.js
@@ -8,6 +8,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko_0/checkedValueChange2", $scope0_id);
 	_html(`<form><input${_attr_input_checkedValue($scope0_id, "#input/0", checkedValue, $checkedValueChange, "a")} type=radio name=p>${_el_resume($scope0_id, "#input/0")}<input${_attr_input_checkedValue($scope0_id, "#input/1", checkedValue, $checkedValueChange, "b")} type=radio name=p>${_el_resume($scope0_id, "#input/1")}<input${_attr_input_checkedValue($scope0_id, "#input/2", checkedValue, $checkedValueChange, "c")} type=radio name=p>${_el_resume($scope0_id, "#input/2")}<button type=reset>reset</button></form><span>v=<!>${_escape(checkedValue)}${_el_resume($scope0_id, "#text/3")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, { $checkedValueChange: 0 });
+	writeScope($scope0_id, { $checkedValueChange }, "__tests__/template.marko", 0, {
+		$checkedValueChange: 0,
+		"ControlledHandler:#input/0": ["checkedValueChange"],
+		"ControlledHandler:#input/1": ["checkedValueChange"],
+		"ControlledHandler:#input/2": ["checkedValueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-dynamic-spread/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_scope_reason();
 		_html(`<option${_attrs({ value: "a" }, "#option/0", $scope1_id, "option")}>A</option>${_el_resume($scope1_id, "#option/0")}<option${_attrs({ value: "b" }, "#option/1", $scope1_id, "option")}>B</option>${_el_resume($scope1_id, "#option/1")}<option${_attrs({ value: "c" }, "#option/2", $scope1_id, "option")}>C</option>${_el_resume($scope1_id, "#option/2")}`);
 		_script($scope1_id, "__tests__/template.marko_1");
-		writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
+		writeScope($scope1_id, {}, "__tests__/template.marko", "3:4", {
+			"EventAttributes:#option/0": ["...{ value:\"a\" }", "4:14"],
+			"EventAttributes:#option/1": ["...{ value:\"b\" }", "5:14"],
+			"EventAttributes:#option/2": ["...{ value:\"c\" }", "6:14"]
+		});
 	}, $scope0_id));
 	_html(`<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
 	writeScope($scope0_id, { tag }, "__tests__/template.marko", 0, { tag: "2:8" });

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-empty-value-spread/__snapshots__/html.bundle.debug.js
@@ -12,6 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`${_el_resume($scope0_id, "#select/0")}<output>${value === undefined ? "undefined" : _escape("value=" + value)}${_el_resume($scope0_id, "#text/2")}</output>`);
 	_script($scope0_id, "__tests__/template.marko_0_placeholder#4");
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#select/0": ["valueChange", "3:21"],
+		"EventAttributes:#option/1": ["...placeholder", "4:14"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-late-options/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-late-options/__snapshots__/html.bundle.debug.js
@@ -29,7 +29,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		calls
 	}, "__tests__/template.marko", 0, {
 		v: "3:6",
-		calls: "4:6"
+		calls: "4:6",
+		"ControlledHandler:#select/0": ["valueChange", "5:17"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-reordered/__snapshots__/html.bundle.debug.js
@@ -20,6 +20,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`<span>sel:<!>${_escape(selected.join(","))}${_el_resume($scope0_id, "#text/1")}</span><button>Add</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { options }, "__tests__/template.marko", 0, { options: "1:6" });
+	writeScope($scope0_id, { options }, "__tests__/template.marko", 0, {
+		options: "1:6",
+		"ControlledHandler:#select/0": ["valueChange", "3:33"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-multiple-value-number/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/0")}<span>${_escape(selected)}${_el_resume($scope0_id, "#text/1")}</span><button>Reset</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "3:33"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-mutated-option/__snapshots__/html.bundle.debug.js
@@ -21,6 +21,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`<button type=reset>reset</button></form><div>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</div><button class=remove>Remove option</button>${_el_resume($scope0_id, "#button/2")}<button class=add>Add option</button>${_el_resume($scope0_id, "#button/3")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { options }, "__tests__/template.marko", 0, { options: "1:6" });
+	writeScope($scope0_id, { options }, "__tests__/template.marko", 0, {
+		options: "1:6",
+		"ControlledHandler:#select/0": ["valueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-no-match/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "2:21"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,10 @@ var my_select_default = _template("__tests__/tags/my-select.marko", (input) => {
 	}, 1);
 	_html(_el_resume($scope0_id, "#select/0"));
 	_script($scope0_id, "__tests__/tags/my-select.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-select.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-select.marko", 0, {
+		"ControlledHandler:#select/0": ["...input", "1:12"],
+		"EventAttributes:#select/0": ["...input", "1:12"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-bigint/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(_el_resume($scope0_id, "#select/0"));
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "2:21"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-nan/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(_el_resume($scope0_id, "#select/0"));
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "2:21"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-value-number/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/0")}<span>${_escape(selected)}${_el_resume($scope0_id, "#text/1")}</span><button>Reset</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "3:24"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select/__snapshots__/html.bundle.debug.js
@@ -10,6 +10,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange", "2:21"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,10 @@ var my_textarea_default = _template("__tests__/tags/my-textarea.marko", (input) 
 	const $textarea_input = input;
 	_html(`<textarea${_attrs($textarea_input, "#textarea/0", $scope0_id, "textarea")}>${_attr_textarea_value($scope0_id, "#textarea/0", $textarea_input.value, $textarea_input.valueChange, 1)}</textarea>${_el_resume($scope0_id, "#textarea/0")}`);
 	_script($scope0_id, "__tests__/tags/my-textarea.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-textarea.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-textarea.marko", 0, {
+		"ControlledHandler:#textarea/0": ["...input", "1:14"],
+		"EventAttributes:#textarea/0": ["...input", "1:14"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		value = _new_value;
 	}, "__tests__/template.marko_0/valueChange", $scope0_id))}</textarea>${_el_resume($scope0_id, "#textarea/0")}<span>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</span>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#textarea/0": ["valueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-value-refinement-mixed/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$valueChange
 	}, "__tests__/template.marko", 0, {
 		$valueChange2: 0,
-		$valueChange: 0
+		$valueChange: 0,
+		"ControlledHandler:#input/0": ["valueChange"],
+		"ControlledHandler:#input/1": ["valueChange"],
+		"ControlledHandler:#input/2": ["valueChange"],
+		"ControlledHandler:#input/3": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/declared-alias-closure/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_attrs_content(input, "#div/0", $scope3_id, "div");
 		_html(`</div>${_el_resume($scope3_id, "#div/0")}`);
 		_script($scope3_id, "__tests__/template.marko_3_input#2");
-		writeScope($scope3_id, {}, "__tests__/template.marko", "2:2");
+		writeScope($scope3_id, {}, "__tests__/template.marko", "2:2", { "EventAttributes:#div/0": ["...input", "3:13"] });
 	}) };
 	Child.content({ content: _content("__tests__/template.marko_1*content", () => {
 		_scope_reason();

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	_dynamic_tag($scope0_id, "#text/1", content, {}, 0, 0, _serialize_guard($scope0_reason, 1));
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}<div>${_escape(Object.keys(input))}${_el_resume($scope0_id, "#text/2", _serialize_guard($scope0_reason, 0))}</div>`);
 	_script($scope0_id, "__tests__/tags/child.marko_0_rest#6");
-	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0, { "EventAttributes:#div/0": ["...rest", "2:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	_dynamic_tag($scope0_id, "#text/1", content, {}, 0, 0, _serialize_guard($scope0_reason, 0));
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0_rest#6");
-	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0, { "EventAttributes:#div/0": ["...rest", "2:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0_rest#4");
 	_script($scope0_id, "__tests__/tags/child.marko_0_$valueChange#3");
-	writeScope($scope0_id, { $valueChange }, "__tests__/tags/child.marko", 0, { $valueChange: "3:11" });
+	writeScope($scope0_id, { $valueChange }, "__tests__/tags/child.marko", 0, {
+		$valueChange: "3:11",
+		"EventAttributes:#div/0": ["...rest", "5:8"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	_dynamic_tag($scope0_id, "#text/1", content, {}, 0, 0, _serialize_guard($scope0_reason, 0));
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0_rest#5");
-	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0, { "EventAttributes:#div/0": ["...rest", "2:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native-variants/__snapshots__/html.bundle.debug.js
@@ -12,6 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/1")}<button>Swap</button>${_el_resume($scope0_id, "#button/2")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { tag }, "__tests__/template.marko", 0, { tag: "1:6" });
+	writeScope($scope0_id, { tag }, "__tests__/template.marko", 0, {
+		tag: "1:6",
+		"ControlledHandler:#select/1": ["valueChange", "4:16"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<input${_attrs(input.attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...input.attrs", "1:11"],
+		"EventAttributes:#input/0": ["...input.attrs", "1:11"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/csr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/csr.error.debug.txt
@@ -1,0 +1,1 @@
+The `valueChange` attribute cannot be a function. A change handler is only used when its matching controllable attribute combination applies.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,19 @@
+// template.marko
+const $template = "<input>";
+const $walks = " b";
+const $setup = () => {};
+const $input_attrs__OR__input_more__script = _script("__tests__/template.marko_0_input_attrs#3_input_more#4", ($scope) => _attrs_script($scope, "#input/0"));
+const $input_attrs__OR__input_more = /*@__PURE__*/ _or(5, ($scope) => {
+	_attrs($scope, "#input/0", {
+		...$scope.input_attrs,
+		...$scope.input_more
+	}, _controllable_input);
+	$input_attrs__OR__input_more__script($scope);
+});
+const $input_attrs = /*@__PURE__*/ _const("input_attrs", $input_attrs__OR__input_more);
+const $input_more = /*@__PURE__*/ _const("input_more", $input_attrs__OR__input_more);
+const $input = ($scope, input) => {
+	$input_attrs($scope, input.attrs);
+	$input_more($scope, input.more);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,11 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attrs({
+		...input.attrs,
+		...input.more
+	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3_input_more#4");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Unable to serialize the `valueChange` handler of `<input>` in packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/template.marko. Values referenced in the browser must be serializable.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/template.marko
@@ -1,0 +1,1 @@
+<input ...input.attrs ...input.more>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+// With two spreads a merged property could come from either, so the error
+// must not name one of them; it reports the runtime-read property instead.
+export const config: TestConfig = {
+  error_html: true,
+  error_dom: true,
+  skip_optimize: true,
+  steps: [{ attrs: { checked: true, valueChange: () => {} }, more: {} }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-partial-spread-native-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-partial-spread-native-attrs/__snapshots__/html.bundle.debug.js
@@ -8,5 +8,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		...{ checkedChange: _resume(function() {}, "__tests__/template.marko_0/checkedChange") }
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...{ checkedChange() {} }", "1:42"],
+		"EventAttributes:#input/0": ["...{ checkedChange() {} }", "1:42"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-spread-native-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-mututally-exclusive-spread-native-attrs/__snapshots__/html.bundle.debug.js
@@ -10,5 +10,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...{ checkedValue: 1, checkedChange() {} }", "1:27"],
+		"EventAttributes:#input/0": ["...{ checkedValue: 1, checkedChange() {} }", "1:27"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-change-handler-not-function/__snapshots__/html.bundle.debug.js
@@ -9,6 +9,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		input_onChange: _serialize_if($scope0_reason, 0) && input.onChange
 	}, "__tests__/template.marko", 0, {
 		input_value: ["input.value"],
-		input_onChange: ["input.onChange"]
+		input_onChange: ["input.onChange"],
+		"ControlledHandler:#input/0": ["valueChange", "1:26"]
 	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,5 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<div${_attrs(input.attrs, "#div/0", $scope0_id, "div")}>Hello</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "EventAttributes:#div/0": ["...input.attrs", "1:9"] });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<input${_attrs(input.attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...input.attrs", "1:11"],
+		"EventAttributes:#input/0": ["...input.attrs", "1:11"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/ssr.error.debug.txt
@@ -1,1 +1,1 @@
-Unable to serialize "\"ControlledHandler:#input/0\"" in packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/template.marko. Values referenced in the browser must be serializable.
+Unable to serialize `valueChange` from `...input.attrs` in packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/template.marko:1:11. Values referenced in the browser must be serializable.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-exclusive-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-exclusive-attrs/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3");
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { input_attrs: input.attrs }, "__tests__/template.marko", 0, { input_attrs: ["input.attrs"] });
+	writeScope($scope0_id, { input_attrs: input.attrs }, "__tests__/template.marko", 0, {
+		input_attrs: ["input.attrs"],
+		"ControlledHandler:#input/0": ["checkedChange", "2:39"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-invalid-attr-name/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-invalid-attr-name/__snapshots__/html.bundle.debug.js
@@ -6,5 +6,5 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_attrs_content(input.attrs, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_attrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "EventAttributes:#div/0": ["...input.attrs", "1:9"] });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,13 @@
+// template.marko
+const $template = "<input>";
+const $walks = " b";
+const $input_value__OR__input_valueChange = /*@__PURE__*/ _or(5, ($scope) => _attr_input_value($scope, "#input/0", $scope.input_value, $scope.input_valueChange));
+const $input_value = /*@__PURE__*/ _const("input_value", $input_value__OR__input_valueChange);
+const $input_valueChange = /*@__PURE__*/ _const("input_valueChange", $input_value__OR__input_valueChange);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#input/0"));
+const $setup = $setup__script;
+const $input = ($scope, input) => {
+	$input_value($scope, input.value);
+	$input_valueChange($scope, input.valueChange);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,15 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", input.value, input.valueChange)}>${_el_resume($scope0_id, "#input/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		input_value: _serialize_if($scope0_reason, 1) && input.value,
+		input_valueChange: _serialize_if($scope0_reason, 0) && input.valueChange
+	}, "__tests__/template.marko", 0, {
+		input_value: ["input.value"],
+		input_valueChange: ["input.valueChange"],
+		"ControlledHandler:#input/0": ["valueChange", "1:26"]
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/ssr.error.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/__snapshots__/ssr.error.debug.txt
@@ -1,0 +1,1 @@
+Unable to serialize "valueChange" in packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/template.marko:1:26. Values referenced in the browser must be serializable.

--- a/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/template.marko
@@ -1,0 +1,1 @@
+<input value=input.value valueChange=input.valueChange>

--- a/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-static-change-handler-unserializable/test.ts
@@ -1,0 +1,8 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  error_html: true,
+  skip_csr: true,
+  skip_optimize: true,
+  steps: [{ value: "x", valueChange: () => {} }],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-nonce/__snapshots__/html.bundle.debug.js
@@ -27,6 +27,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id, "#text/2", 1, 1, 1, 0, 1);
 	_script($scope0_id, "__tests__/template.marko_0");
 	_script($scope0_id, "__tests__/template.marko_0_spreadAttrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "EventAttributes:#script/1": ["...spreadAttrs", "11:30"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/html.bundle.debug.js
@@ -26,6 +26,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id, "#text/2", 1, 1, 1, 0, 1);
 	_script($scope0_id, "__tests__/template.marko_0");
 	_script($scope0_id, "__tests__/template.marko_0_spreadAttrs#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "EventAttributes:#style/1": ["...spreadAttrs", "11:16"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-checked-controlled-spread-value/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		checked
 	}, "__tests__/template.marko", 0, {
 		input_rest: ["input.rest"],
-		checked: "1:6"
+		checked: "1:6",
+		"ControlledHandler:#input/0": ["...input.rest", "2:51"],
+		"EventAttributes:#input/0": ["...input.rest", "2:51"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,11 @@ var my_input_default = _template("__tests__/tags/my-input.marko", (input) => {
 		...input,
 		checked: undefined,
 		checkedValue: undefined
-	} }, "__tests__/tags/my-input.marko", 0, { input: 0 });
+	} }, "__tests__/tags/my-input.marko", 0, {
+		input: 0,
+		"ControlledHandler:#input/0": ["...input", "1:11"],
+		"EventAttributes:#input/0": ["...input", "1:11"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 		$si__input_button && writeScope($scope1_id, { button }, "__tests__/tags/child.marko", "3:4", { button: "3:8" });
 	}, 0, $scope0_id, "#div/0", $sg__input_button, 1, $sg__input_button, "</div>");
 	_script($scope0_id, "__tests__/tags/child.marko_0_htmlInput#4");
-	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0, { "EventAttributes:#div/0": ["...htmlInput", "2:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 		input_valueChange: ["input.valueChange"],
 		state: "1:6",
 		otherState: "6:6",
-		thirdState: "11:6"
+		thirdState: "11:6",
+		"TagVariableChange:state": ["stateChange", "1:6"],
+		"TagVariableChange:otherState": ["otherStateChange", "6:6"],
+		"TagVariableChange:thirdState": ["thirdStateChange", "11:6"]
 	});
 	_resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-dynamic-change-handler/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko", 0, {
 		x: "1:6",
 		yChange: "2:6",
-		y: "3:6"
+		y: "3:6",
+		"TagVariableChange:y": ["yChange", "3:6"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-id/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		"TagVariableChange:y": handler || void 0
 	}, "__tests__/template.marko", 0, {
 		handler: "2:6",
-		y: "3:6"
+		y: "3:6",
+		"TagVariableChange:y": ["yChange", "3:6"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-static/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		"TagVariableChange:y": _resume(function(newValue) {
 			x = newValue + 1;
 		}, "__tests__/template.marko_0/valueChange", $scope0_id) || void 0
-	}, "__tests__/template.marko", 0, { y: "2:6" });
+	}, "__tests__/template.marko", 0, {
+		y: "2:6",
+		"TagVariableChange:y": ["yChange", "2:6"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		"TagVariableChange:y": false || void 0
 	}, "__tests__/template.marko", 0, {
 		x: "1:6",
-		y: "2:6"
+		y: "2:6",
+		"TagVariableChange:y": ["yChange", "2:6"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/logical-assign-to-let/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko", 0, {
 		changes: "1:6",
 		value: "2:6",
-		x: "3:6"
+		x: "3:6",
+		"TagVariableChange:x": ["xChange", "3:6"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-binds/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$valueChange
 	}, "__tests__/template.marko", 0, {
 		count: "1:5",
-		$valueChange: 0
+		$valueChange: 0,
+		"ControlledHandler:#input/1": ["valueChange"],
+		"ControlledHandler:#input/2": ["valueChange"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,9 @@ var _2counters_default = _template("__tests__/tags/2counters.marko", (input) => 
 		input_count2: ["input.count2"],
 		input_count2Change: ["input.count2Change"],
 		count1: "1:6",
-		count2: "2:6"
+		count2: "2:6",
+		"TagVariableChange:count1": ["count1Change", "1:6"],
+		"TagVariableChange:count2": ["count2Change", "2:6"]
 	});
 	_resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-dynamic-spread/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko", 0, {
 		enabled: "3:6",
 		count: "4:6",
-		log: "5:6"
+		log: "5:6",
+		"EventAttributes:#button/2": ["...{ onClick: enabled && (() => { log = `${log}a(${count})`; }) }", "9:14"],
+		"EventAttributes:#button/3": ["...enabled && { onClick() { log = `${log}b(${count})`; } }", "10:15"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-event-handler-lazy-read-spread/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		log
 	}, "__tests__/template.marko", 0, {
 		count: "2:6",
-		log: "3:6"
+		log: "3:6",
+		"EventAttributes:#button/1": ["...{ onClick() { log = `${log}[${count}]`; } }", "6:16"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_attrs_content(item, "#div/0", $scope2_id, "div");
 			_html(`</div>${_el_resume($scope2_id, "#div/0")}`);
 			_script($scope2_id, "__tests__/template.marko_2_item#2");
-			writeScope($scope2_id, {}, "__tests__/template.marko", "4:4");
+			writeScope($scope2_id, {}, "__tests__/template.marko", "4:4", { "EventAttributes:#div/0": ["...item", "5:13"] });
 		}, 0, $scope1_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "3:2");
 	}) };

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,10 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	writeScope($scope0_id, {
 		input_head: input.head,
 		"#childScope/1": _serialize_if($scope0_reason, 0) && _existing_scope($childScope)
-	}, "__tests__/tags/my-box.marko", 0, { input_head: ["input.head"] });
+	}, "__tests__/tags/my-box.marko", 0, {
+		input_head: ["input.head"],
+		"EventAttributes:#div/0": ["...input.head", "1:9"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,10 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_html(`</footer>${_el_resume($scope0_id, "#footer/1")}`);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input_foot#5");
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input_head#4");
-	writeScope($scope0_id, {}, "__tests__/tags/my-box.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-box.marko", 0, {
+		"EventAttributes:#section/0": ["...input.head", "1:13"],
+		"EventAttributes:#footer/1": ["...input.foot", "2:12"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,10 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	writeScope($scope0_id, {
 		input,
 		"#childScope/1": _serialize_if($scope0_reason, 0) && _existing_scope($childScope)
-	}, "__tests__/tags/my-box.marko", 0, { input: 0 });
+	}, "__tests__/tags/my-box.marko", 0, {
+		input: 0,
+		"EventAttributes:#div/0": ["...input", "1:9"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-handler-read/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,8 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 		input_content: input.content
 	}, "__tests__/tags/my-box.marko", 0, {
 		input: 0,
-		input_content: ["input.content"]
+		input_content: ["input.content"],
+		"EventAttributes:#div/0": ["...input", "3:9"]
 	});
 	_resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
@@ -31,7 +31,8 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 		show
 	}, "__tests__/tags/my-box.marko", 0, {
 		input: 0,
-		show: "1:6"
+		show: "1:6",
+		"EventAttributes:#div/0": ["...input", "3:9"]
 	});
 	_resume_branch($scope0_id);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_attrs_content(input, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-box.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-box.marko", 0, { "EventAttributes:#div/0": ["...input", "1:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/html.bundle.debug.js
@@ -29,7 +29,15 @@ var my_div_default = _template("__tests__/tags/my-div.marko", (input) => {
 	_html("</em>");
 	_script($scope0_id, "__tests__/tags/my-div.marko_0_input#8_CustomContent_content#10");
 	_script($scope0_id, "__tests__/tags/my-div.marko_0_input#8");
-	writeScope($scope0_id, { CustomContent_content: CustomContent?.content }, "__tests__/tags/my-div.marko", 0, { CustomContent_content: ["CustomContent.content", "10:8"] });
+	writeScope($scope0_id, { CustomContent_content: CustomContent?.content }, "__tests__/tags/my-div.marko", 0, {
+		CustomContent_content: ["CustomContent.content", "10:8"],
+		"EventAttributes:#div/0": ["...input", "1:8"],
+		"EventAttributes:#button/1": ["...input", "3:17"],
+		"EventAttributes:#span/2": ["...input", "5:9"],
+		"EventAttributes:#output/3": ["...input", "8:11"],
+		"EventAttributes:#strong/4": ["...input", "13:11"],
+		"EventAttributes:#p/5": ["...input", "15:36"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var my_img_default = _template("__tests__/tags/my-img.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<img${_attrs(input, "#img/0", $scope0_id, "img")}>${_el_resume($scope0_id, "#img/0")}`);
 	_script($scope0_id, "__tests__/tags/my-img.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-img.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-img.marko", 0, { "EventAttributes:#img/0": ["...input", "1:9"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var my_button_default = _template("__tests__/tags/my-button.marko", (input) => {
 	_attrs_content(input, "#button/0", $scope0_id, "button");
 	_html(`</button>${_el_resume($scope0_id, "#button/0")}`);
 	_script($scope0_id, "__tests__/tags/my-button.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/tags/my-button.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/tags/my-button.marko", 0, { "EventAttributes:#button/0": ["...input", "1:11"] });
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_attrs_content(rest, "#span/1", $scope1_id, "span");
 			_html(`</span>${_el_resume($scope1_id, "#span/1")}`);
 			_script($scope1_id, "__tests__/template.marko_1_rest#5");
-			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2");
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2", { "EventAttributes:#span/1": ["...rest", "6:12"] });
 			return 0;
 		}
 	}, $scope0_id, "#text/0", $sg__input_value, $sg__input_value, $sg__input_value);

--- a/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-controlled-after-sibling-options/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	_html(`${_el_resume($scope0_id, "#select/0")}<div>${_escape(value)}${_el_resume($scope0_id, "#text/1")}</div>`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#select/0": ["valueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/select-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-spread/__snapshots__/html.bundle.debug.js
@@ -11,6 +11,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(_el_resume($scope0_id, "#select/1"));
 	_script($scope0_id, "__tests__/template.marko_0_input_rest#5");
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#select/1": ["...input.rest", "3:12"],
+		"EventAttributes:#select/1": ["...input.rest", "3:12"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-native-event-handler-multi-alias/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			input_onClick: input.onClick
 		}, "__tests__/template.marko", "2:2", {
 			input: "2:18",
-			input_onClick: ["input.onClick", "2:18"]
+			input_onClick: ["input.onClick", "2:18"],
+			"EventAttributes:#button/0": ["...input", "3:14"]
 		});
 	}) };
 	MyButton.content({

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-controlled-handler/__snapshots__/html.bundle.debug.js
@@ -12,6 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<input${_attrs(attrs, "#input/0", $scope0_id, "input")}>${_el_resume($scope0_id, "#input/0")}<span>value=[<!>${_escape(value)}${_el_resume($scope0_id, "#text/1")}]</span><button>drop</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	_script($scope0_id, "__tests__/template.marko_0_attrs#4");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#input/0": ["...attrs", "5:11"],
+		"EventAttributes:#input/0": ["...attrs", "5:11"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-removed-event-handler/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		log
 	}, "__tests__/template.marko", 0, {
 		phase: "3:6",
-		log: "4:6"
+		log: "4:6",
+		"EventAttributes:#div/0": ["...attrs", "9:9"]
 	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 		_attrs_content(option, "#option/0", $scope1_id, "option");
 		_html(`</option>${_el_resume($scope1_id, "#option/0")}`);
 		_script($scope1_id, "__tests__/tags/child.marko_1_option#2");
-		writeScope($scope1_id, {}, "__tests__/tags/child.marko", "2:4");
+		writeScope($scope1_id, {}, "__tests__/tags/child.marko", "2:4", { "EventAttributes:#option/0": ["...option", "3:16"] });
 	}, 0, $scope0_id, "#select/0", $sg__input_option, _serialize_guard($scope0_reason, 0), $sg__input_option, "</select>", 1);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_attrs_content(option, "#option/0", $scope3_id, "option");
 			_html(`</option>${_el_resume($scope3_id, "#option/0")}`);
 			_script($scope3_id, "__tests__/template.marko_3_option#2");
-			writeScope($scope3_id, {}, "__tests__/template.marko", "3:6");
+			writeScope($scope3_id, {}, "__tests__/template.marko", "3:6", { "EventAttributes:#option/0": ["...option", "4:18"] });
 		}, 0, $scope1_id, "#select/0", $sg__input_option, _serialize_guard($scope1_reason, 0), $sg__input_option, "</select>", 1);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 	}) };

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	}, "#p/0", $scope0_id, "p");
 	_html(`</p>${_el_resume($scope0_id, "#p/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0_input_class#3_rest#4");
-	writeScope($scope0_id, { input_class: input.class }, "__tests__/tags/child.marko", 0, { input_class: ["input.class"] });
+	writeScope($scope0_id, { input_class: input.class }, "__tests__/tags/child.marko", 0, {
+		input_class: ["input.class"],
+		"EventAttributes:#p/0": ["...rest", "2:25"]
+	});
 });
 
 // tags/wrap.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	}, "#span/0", $scope0_id, "span");
 	_html(`</span>${_el_resume($scope0_id, "#span/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0__class#3_rest#4");
-	writeScope($scope0_id, { _class }, "__tests__/tags/child.marko", 0, { _class: "1:17" });
+	writeScope($scope0_id, { _class }, "__tests__/tags/child.marko", 0, {
+		_class: "1:17",
+		"EventAttributes:#span/0": ["...rest", "2:23"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 		_dynamic_tag($scope1_id, "#text/1", desc, {}, 0, 0, $sg__input_foo);
 		_html(`</span>${_el_resume($scope1_id, "#span/0")}`);
 		_script($scope1_id, "__tests__/tags/child.marko_1_item#5");
-		writeScope($scope1_id, {}, "__tests__/tags/child.marko", "2:2");
+		writeScope($scope1_id, {}, "__tests__/tags/child.marko", "2:2", { "EventAttributes:#span/0": ["...item", "3:12"] });
 	}, 0, $scope0_id, "#text/0", $sg__input_foo, $sg__input_foo, $sg__input_foo, 0, 1);
 	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/child.marko", 0);
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	}, "#span/0", $scope0_id, "span");
 	_html(`</span>${_el_resume($scope0_id, "#span/0")}`);
 	_script($scope0_id, "__tests__/tags/child.marko_0__class#3_rest#4");
-	writeScope($scope0_id, { _class }, "__tests__/tags/child.marko", 0, { _class: "1:17" });
+	writeScope($scope0_id, { _class }, "__tests__/tags/child.marko", 0, {
+		_class: "1:17",
+		"EventAttributes:#span/0": ["...rest", "2:23"]
+	});
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/__snapshots__/html.bundle.debug.js
@@ -12,5 +12,5 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "#button/0", $scope0_id, "button");
 	_html(`</button>${_el_resume($scope0_id, "#button/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_rest#3");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "EventAttributes:#button/0": ["...rest", "2:58"] });
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
@@ -7,6 +7,6 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		bound = _new_bound;
 	}, "__tests__/template.marko_0/valueChange", $scope0_id))}</textarea>${_el_resume($scope0_id, "#textarea/1")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/2", $sg__input_v)}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#textarea/1": ["valueChange"] });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/__snapshots__/html.bundle.debug.js
@@ -5,5 +5,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $textarea_input = input;
 	_html(`<textarea${_attrs($textarea_input, "#textarea/0", $scope0_id, "textarea")}>${_attr_textarea_value($scope0_id, "#textarea/0", $textarea_input.value, $textarea_input.valueChange, 1)}</textarea>${_el_resume($scope0_id, "#textarea/0")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input#2");
-	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, {
+		"ControlledHandler:#textarea/0": ["...input", "1:14"],
+		"EventAttributes:#textarea/0": ["...input", "1:14"]
+	});
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-only-child/__snapshots__/html.bundle.debug.js
@@ -16,6 +16,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		value = _new_value;
 	}, "__tests__/template.marko_0/valueChange", $scope0_id))}>${_el_resume($scope0_id, "#input/1")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
-	writeScope($scope0_id, { value }, "__tests__/template.marko", 0, { value: "1:6" });
+	writeScope($scope0_id, { value }, "__tests__/template.marko", 0, {
+		value: "1:6",
+		"ControlledHandler:#input/1": ["valueChange"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-dynamic-attrs/__snapshots__/html.bundle.debug.js
@@ -15,6 +15,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`</div>${_el_resume($scope0_id, "#div/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0_input_value#5_a#6");
 	_script($scope0_id, "__tests__/template.marko_0_input_value#5");
-	writeScope($scope0_id, { a }, "__tests__/template.marko", 0, { a: "1:6" });
+	writeScope($scope0_id, { a }, "__tests__/template.marko", 0, {
+		a: "1:6",
+		"EventAttributes:#div/0": ["...input.value", "2:9"],
+		"EventAttributes:#div/1": ["...input.value", "3:13"],
+		"EventAttributes:#div/2": ["...input.value", "4:9"]
+	});
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -2,7 +2,12 @@ import assert from "node:assert/strict";
 import { inspect } from "node:util";
 
 import type { ScopeFlush } from "../html/serializer";
-import { K_SCOPE_ID, register, Serializer } from "../html/serializer";
+import {
+  K_SCOPE_ID,
+  register,
+  Serializer,
+  setDebugInfo,
+} from "../html/serializer";
 import type { Boundary } from "../html/writer";
 
 const [major, minor] = process.version
@@ -1295,6 +1300,42 @@ describe("serializer", () => {
         [formData, formData],
         `[_.a=["a","1","b","2"].reduce((f,v,i,a)=>i%2&&f.append(a[i-1],v)||f,new FormData),_.a]`,
       );
+    });
+    it("names an escaped-key variable in the unserializable error", () => {
+      const scope = { "#LoopKey": new File(["x"], "x.txt") };
+      setDebugInfo(scope, "page.marko", "1:1", {
+        "#LoopKey": ["myVar", "2:6"],
+      });
+      assert.match(
+        String(abortedStringifying([[1, scope, scope]])),
+        /"myVar" in page\.marko:2:6/,
+      );
+    });
+    it("names the variable when the unserializable value sits in a Set", () => {
+      const scope = { selected: new Set([new File(["x"], "x.txt")]) };
+      setDebugInfo(scope, "page.marko", "1:1", {
+        selected: ["selected", "2:6"],
+      });
+      assert.match(
+        String(abortedStringifying([[1, scope, scope]])),
+        /"selected" in page\.marko:2:6/,
+      );
+    });
+    it("describes every internal accessor prefix", async () => {
+      const prefixes =
+        await import("../common/constants/accessor-prefix.debug");
+      for (const prefix of Object.values(prefixes)) {
+        if (typeof prefix !== "string") continue;
+        const scope = { [prefix + "#input/0"]: new File(["x"], "x.txt") };
+        setDebugInfo(scope, "page.marko", "1:1");
+        const message = String(abortedStringifying([[1, scope, scope]]));
+        assert.doesNotMatch(message, /ControlledHandler:|#input\/0/, message);
+        assert.match(
+          message,
+          /the [\w ]+( of `<input>`)? in page\.marko/,
+          message,
+        );
+      }
     });
     it("aborts on File/Blob values instead of dropping them", () => {
       const formData = new FormData();
@@ -2657,4 +2698,17 @@ function hasSymbolIterator(
   value: unknown,
 ): value is { [Symbol.iterator](): IterableIterator<unknown> } {
   return Symbol.iterator in (value as any);
+}
+
+function abortedStringifying(scopes: ScopeFlush[]) {
+  const serializer = new Serializer();
+  let aborted: unknown;
+  const boundary = {
+    signal: { aborted: false },
+    abort(err: unknown) {
+      aborted = err;
+    },
+  } as any as Boundary;
+  serializer.stringifyScopes(scopes, boundary);
+  return (aborted as Error)?.message;
 }

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -16,6 +16,7 @@ import {
 } from "../common/helpers";
 import { type Accessor, AccessorPrefix, ControlledType } from "../common/types";
 import { _escape } from "./content";
+import { setDebugSlotName } from "./serializer";
 import {
   _attr_content,
   _html,
@@ -440,19 +441,17 @@ function writeControlledScope(
   if (MARKO_DEBUG) {
     // Indexed by `ControlledType` so the error names the attribute the
     // author wrote, matching the client-side assertions in dom/controllable.ts.
-    assertHandlerIsFunction(
-      [
-        "checkedChange",
-        "checkedValueChange",
-        "valueChange",
-        "valueChange",
-        "openChange",
-      ][type]!,
-      valueChange,
-    );
+    var handlerName = [
+      "checkedChange",
+      "checkedValueChange",
+      "valueChange",
+      "valueChange",
+      "openChange",
+    ][type]!;
+    assertHandlerIsFunction(handlerName, valueChange);
   }
 
-  _scope(
+  const scope = _scope(
     scopeId,
     serializeType
       ? {
@@ -465,6 +464,14 @@ function writeControlledScope(
           [AccessorPrefix.ControlledHandler + nodeAccessor]: valueChange,
         },
   );
+
+  if (MARKO_DEBUG) {
+    setDebugSlotName(
+      scope,
+      AccessorPrefix.ControlledHandler + nodeAccessor,
+      handlerName!,
+    );
+  }
 }
 
 function stringAttr(name: string, value: string) {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -348,15 +348,32 @@ interface Debug {
   file: string;
   loc: string | 0;
   vars: Record<string, string | [name: string, loc?: string]> | undefined;
+  slots?: Record<string, string>;
 }
 const DEBUG = new WeakMap<WeakKey, Debug>();
 export function setDebugInfo(
   obj: WeakKey,
   file: string,
   loc: string | 0,
-  vars?: Record<string, string>,
+  vars?: Debug["vars"],
 ) {
-  DEBUG.set(obj, { file, loc, vars });
+  DEBUG.set(obj, { file, loc, vars, slots: DEBUG.get(obj)?.slots });
+}
+
+// Names an internal slot with the property the runtime actually read (eg the
+// `valueChange` a spread supplied); the translator only knows the spread.
+export function setDebugSlotName(obj: WeakKey, accessor: string, name: string) {
+  const debug = DEBUG.get(obj);
+  if (debug) {
+    (debug.slots ??= {})[accessor] = name;
+  } else {
+    DEBUG.set(obj, {
+      file: "",
+      loc: 0,
+      vars: undefined,
+      slots: { [accessor]: name },
+    });
+  }
 }
 
 export class Serializer {
@@ -1960,11 +1977,14 @@ function throwUnserializable(
   if (cause !== undefined && state.boundary?.abort) {
     let message = "Unable to serialize";
     let access = "";
-    while (ref?.accessor) {
+    while (ref) {
+      const { accessor } = ref;
       const debug = ref.parent?.debug;
-      if (debug) {
-        const varLoc = debug.vars?.[ref.accessor];
-        let debugAccess = ref.accessor;
+      if (accessor && debug) {
+        const rawAccessor = fromObjectKey(accessor);
+        const varLoc = debug.vars?.[rawAccessor];
+        const slotName = debug.slots?.[rawAccessor];
+        let debugAccess = varLoc ? rawAccessor : undefined;
         let debugLoc = debug.loc;
         if (varLoc) {
           if (Array.isArray(varLoc)) {
@@ -1975,11 +1995,25 @@ function throwUnserializable(
           }
         }
 
-        message += ` ${JSON.stringify(debugAccess)} in ${debug.file}`;
+        let display: string;
+        if (debugAccess !== undefined) {
+          // A `...spread` name composes with the property the runtime read.
+          display =
+            slotName && debugAccess.startsWith("...")
+              ? `\`${slotName}\` from \`${debugAccess}\``
+              : JSON.stringify(debugAccess);
+        } else {
+          display =
+            describeAccessor(rawAccessor, slotName) ??
+            JSON.stringify(rawAccessor);
+        }
+
+        message += ` ${display} in ${debug.file}`;
         if (debugLoc) message += `:${debugLoc}`;
         break;
       }
-      access = toAccess(ref.accessor) + access;
+      // A collection's backing-value link has no accessor; keep walking.
+      if (accessor) access = toAccess(accessor) + access;
       ref = ref.parent;
     }
 
@@ -2001,6 +2035,53 @@ function throwUnserializable(
     err.stack = undefined;
     state.boundary.abort(err);
   }
+}
+
+// Keep in sync with common/constants/accessor-prefix.debug.ts; the serializer
+// parity test walks every prefix.
+const accessorPrefixDescriptions: Record<string, string> = {
+  BranchScopes: "the branch scopes",
+  ClosureScopes: "the closure scopes",
+  ClosureSignalIndex: "the closure signal index",
+  ConditionalRenderer: "the conditional renderer",
+  ControlledObserver: "the controlled observer",
+  ControlledHandler: "the change handler",
+  ControlledType: "the controlled type",
+  ControlledValue: "the controlled value",
+  DynamicHTMLLastChild: "the dynamic html",
+  EventAttributes: "the event handlers",
+  KeyedScopes: "the keyed scopes",
+  Lifecycle: "the lifecycle handlers",
+  Promise: "the pending promise",
+  TagVariableChange: "the tag variable change handler",
+};
+
+// A readable phrase for an internal `<Prefix>:<node accessor>` scope slot.
+function describeAccessor(accessor: string, slotName?: string) {
+  const sep = accessor.indexOf(":");
+  if (~sep) {
+    const description =
+      slotName === undefined
+        ? accessorPrefixDescriptions[accessor.slice(0, sep)]
+        : `the \`${slotName}\` handler`;
+    if (description) {
+      const node = /^#([a-z-]+)\//i.exec(accessor.slice(sep + 1));
+      return node ? `${description} of \`<${node[1]}>\`` : description;
+    }
+  }
+}
+
+// Inverse of `toObjectKey` for error reporting; `quote` emits non-JSON `\x`.
+function fromObjectKey(key: string) {
+  try {
+    if (key[0] === '"') {
+      return JSON.parse(key.replace(/\\x/g, "\\u00")) as string;
+    }
+    if (key[0] === "[") return JSON.parse(key.slice(1, -1)) as string;
+  } catch {
+    /* fall through to the escaped form */
+  }
+  return key;
 }
 
 function trackChannel(state: State, ref: Reference) {

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -705,7 +705,7 @@ if (MARKO_DEBUG) {
       partialScope: PartialScope,
       file?: string,
       loc?: string | 0,
-      vars?: Record<string, string>,
+      vars?: Parameters<typeof setDebugInfo>[3],
     ) => {
       const scope = writeScope(scopeId, partialScope);
       if (file && loc !== undefined) {

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -148,11 +148,44 @@ export function setBindingSerializedValue(
 ) {
   const reason = getSerializeReason(section, binding, prefix);
   if (reason) {
-    getSerializedAccessors(section).set(
-      prefix === undefined
-        ? getScopeAccessor(binding)
-        : getPrefixedScopeAccessor(binding, prefix),
-      { expression, reason },
+    if (prefix === undefined) {
+      getSerializedAccessors(section).set(getScopeAccessor(binding), {
+        expression,
+        reason,
+      });
+    } else {
+      const accessor = getPrefixedScopeAccessor(binding, prefix);
+      getSerializedAccessors(section).set(accessor, { expression, reason });
+      // Name the change handler slot after the author's binding; structural
+      // prefixed slots are described generically by the serializer instead.
+      if (!isOptimize() && prefix === getAccessorPrefix().TagVariableChange) {
+        const { root, access } = getDebugScopeAccess(binding);
+        setSectionDebugVar(
+          section,
+          accessor,
+          `${root.name + access}Change`,
+          root.loc,
+        );
+      }
+    }
+  }
+}
+
+const [getSectionDebugVars] = createSectionState<
+  Map<string, [name: string, loc?: string]>
+>("sectionDebugVars", () => new Map());
+// Names a runtime-serialized internal slot (eg a controllable's handler) in
+// debug "Unable to serialize" errors; these never pass through `writeScope`.
+export function setSectionDebugVar(
+  section: Section,
+  accessor: string,
+  name: string,
+  loc: t.SourceLocation | null | undefined,
+) {
+  if (!isOptimize()) {
+    getSectionDebugVars(section).set(
+      accessor,
+      loc ? [name, `${loc.start.line}:${loc.start.column + 1}`] : [name],
     );
   }
 }
@@ -1402,6 +1435,12 @@ export function writeHTMLResumeStatements(
             )
           : t.numericLiteral(0),
       );
+
+      for (const [accessor, varLoc] of getSectionDebugVars(section)) {
+        (debugVars ||= []).push(
+          toObjectProperty(accessor, t.valueToNode(varLoc)),
+        );
+      }
 
       if (debugVars) {
         writeScopeArgs.push(t.objectExpression(debugVars));

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -25,11 +25,16 @@ import {
 import evaluate from "../../util/evaluate";
 import { generateUidIdentifier } from "../../util/generate-uid";
 import { getAccessorProp } from "../../util/get-accessor-enums";
+import { getAccessorPrefix } from "../../util/get-accessor-enums";
 import { getTagName } from "../../util/get-tag-name";
 import { isControlFlowTag } from "../../util/is-core-tag";
 import { isEventOrChangeHandler } from "../../util/is-event-or-change-handler";
 import { isTextOnlyNativeTag } from "../../util/is-non-html-text";
-import { getMarkoOpts, isOutputHTML } from "../../util/marko-config";
+import {
+  getMarkoOpts,
+  isOptimize,
+  isOutputHTML,
+} from "../../util/marko-config";
 import normalizeStringExpression from "../../util/normalize-string-expression";
 import { includes, type Opt, push } from "../../util/optional";
 import {
@@ -37,6 +42,7 @@ import {
   BindingType,
   createBinding,
   dropNodes,
+  getPrefixedScopeAccessor,
   getScopeAccessorLiteral,
   mergeReferences,
   trackDomVarReferences,
@@ -61,7 +67,11 @@ import {
   getSerializeReason,
 } from "../../util/serialize-reasons";
 import { addSetupExpr, addSetupStatement } from "../../util/setup-statements";
-import { addHTMLEffectCall, addStatement } from "../../util/signals";
+import {
+  addHTMLEffectCall,
+  addStatement,
+  setSectionDebugVar,
+} from "../../util/signals";
 import * as structure from "../../util/structure";
 import analyzeTagNameType, { TagNameType } from "../../util/tag-name-type";
 import {
@@ -489,6 +499,58 @@ export default {
           injectNonce,
         } = usedAttrs;
         let { spreadExpression } = usedAttrs;
+
+        // Name the change-handler slot after the attribute the author wrote;
+        // other internal slots get generic serializer descriptions instead.
+        if (!isOptimize() && nodeBinding) {
+          const changeAttr = staticControllable?.attrs[1];
+          if (changeAttr) {
+            const handler = evaluate(changeAttr.value);
+            if (!(handler.confident && handler.computed == null)) {
+              setSectionDebugVar(
+                tagSection,
+                getPrefixedScopeAccessor(
+                  nodeBinding,
+                  getAccessorPrefix().ControlledHandler,
+                ),
+                changeAttr.name,
+                changeAttr.loc,
+              );
+            }
+          } else if (spreadExpression) {
+            // A lone spread is unambiguous provenance; with several, a merged
+            // property could come from any, so the serializer's generic
+            // phrasing (plus the runtime-read property name) stays honest.
+            const spreads = tag.node.attributes.filter((attr) =>
+              t.isMarkoSpreadAttribute(attr),
+            );
+            const spreadLoc = spreads.length === 1 && spreads[0].value.loc;
+            if (spreadLoc && spreadLoc.start.index != null) {
+              const name =
+                "..." +
+                tag.hub.file.code.slice(
+                  spreadLoc.start.index,
+                  spreadLoc.end.index,
+                );
+              for (const prefix of [
+                getAccessorPrefix().ControlledHandler,
+                getAccessorPrefix().EventAttributes,
+              ] as const) {
+                if (
+                  prefix !== getAccessorPrefix().ControlledHandler ||
+                  getSpreadControllableValueProps(tagName)
+                ) {
+                  setSectionDebugVar(
+                    tagSection,
+                    getPrefixedScopeAccessor(nodeBinding, prefix),
+                    name,
+                    spreadLoc,
+                  );
+                }
+              }
+            }
+          }
+        }
 
         // A controlled `<select>` moves the whole pending buffer into its
         // content arrow at exit, so earlier siblings have to leave it first.


### PR DESCRIPTION
Debug "Unable to serialize" errors dropped or mangled debug info, printing raw internal accessors like `"ControlledHandler:#input/0"`. Unified fix, layered from generic to precise:

- **Serializer**: the reference walk continues past accessor-less collection-backing links; escaped keys unescape through a proper `toObjectKey` inverse; any internal `Prefix:#tag/N` slot with no better name renders a readable phrase from a prefix table covering every accessor prefix (parity-tested).
- **Runtime slot names**: `writeControlledScope` records which property it actually read (debug-only), so even a spread-supplied handler is named — `the \`valueChange\` handler of \`<input>\``.
- **Translator provenance**: prefixed binding slots auto-name at `setBindingSerializedValue` (`"countChange" in template.marko:2:6` for tag-variable change handlers); a statically-written change attribute reports its name and exact location (`"valueChange" in template.marko:1:26`); a **lone** spread composes with the runtime-read property into `"input.attrs.valueChange" in template.marko:1:11`, while multiple spreads deliberately fall back to the runtime-named form since a merged property could come from either (pinned by a dedicated fixture).

Reviewed adversarially by two external models; their findings (spread misattribution, structural incompleteness of emit-site registration, optimize-path waste, `JSON.parse` fragility in the error path) are addressed. Optimized output is byte-identical. Serializer unit tests plus three fixtures pin the message variants; debug HTML snapshots regenerate with the new vars entries.