### PR TITLE
Mark split class/style item writes pure so derived bindings skip _const

### DIFF
--- a/.changeset/pure-class-style-items.md
+++ b/.changeset/pure-class-style-items.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Mark split class/style item writes as pure so a single-consumer derived binding compiles to a plain function instead of a `_const` signal with a scope slot.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -146,12 +146,6 @@ The closure `signal` is assigned only in the `pending.then((mod) => queueAsyncRe
 
 `Boundary.flush()` runs `flushSerializer` on every call, and `ServerRendered.#read`'s `onNext` calls it on each `boundary.endAsync()` even when the HTML write is deferred to the next `queueTick`. Each call appends its own `_=>[…]` closure to `state.resumes`, so N awaits settling in one chunk emit N payloads and the delta scope-id encoding in `writeScopesRoot` cannot span them — see `fixtures/async-reorder-nested-batched-resolve/__snapshots__/writes.html`, where one chunk pushes `_ => [5,…], _ => [7,…]`. Serialization cannot simply be skipped, since the serializer itself calls `boundary.startAsync()`; take `flush(write?)` and serialize only when `write` or `this.count === 0`, with `#read` passing through its existing `write` flag. Re-verify: that snapshot should regenerate with a single `_ =>` closure per chunk.
 
-## Mark class/style item writes pure so a single-consumer derived binding skips `_const`
-
-`packages/runtime-tags/src/translator/visitors/tag/native-tag.ts` › `translate.dom.enter` | 2026-07-23 | impact:med | effort:low
-
-The DOM `class`/`style` branch passes `!!meta.dynamicItems` as `addStatement`'s `isPure`, so the split `_attr_class_item` / `_attr_style_item(s)` path is marked impure; that sets `signal.hasSideEffect` (`util/signals.ts`) and forces `signal.build` to emit `_const(accessor, fn)` plus a scope slot instead of a plain function. Those helpers are idempotent (`classList.toggle`, `style.setProperty`) and every other DOM write (`_attr`, `_attr_content`, `_text_content`) passes `true`. Confirmed with `-o dom`: `<let/x=1/><const/y=x % 2/><div class={ active: y }>` yields `const $y = _const(3, $scope => _attr_class_item($scope.a, "active", $scope.d))`, while `data-active=y` yields `const $y = ($scope, y) => _attr($scope.a, "data-active", y)`. Intersection signals already force `hasSideEffect` at creation, so passing `true` only affects the single-derived-binding case. Re-verify: flip the flag, recompile both templates, and audit the snapshot diff.
-
 ## Pass `0` for an empty `$setup` in `_template`, and keep `setupEmpty` for dynamic tags
 
 `packages/runtime-tags/src/translator/visitors/program/dom.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/__snapshots__/dom.bundle.debug.js
@@ -2,9 +2,9 @@
 const $template = "<svg class=icon><circle cx=50 cy=50 r=40></circle></svg>";
 const $walks = " D l";
 const $setup = () => {};
-const $active = /*@__PURE__*/ _const("active", ($scope) => {
-	_attr_class_item($scope["#svg/0"], "active", $scope.active);
-	_attr_class($scope["#circle/1"], $scope.active ? "on" : "off");
-});
+const $active = ($scope, active) => {
+	_attr_class_item($scope["#svg/0"], "active", active);
+	_attr_class($scope["#circle/1"], active ? "on" : "off");
+};
 const $input = ($scope, input) => $active($scope, input.active);
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
@@ -29,11 +29,11 @@ const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<div></div><div style=width
 const $walks = /*@__PURE__*/ ((_w0, _w1, _w2) => ` d b/${_w0}&/${_w1}&/${_w2}&%c`)($walks$1, $walks$1, $walks$1);
 const TestTag = custom_tag_default;
 const $test_content = _content_resume("__tests__/template.marko_1*content", "Hello");
-const $input_color = /*@__PURE__*/ _const("input_color", ($scope) => {
-	_attr_style_item($scope["#div/0"], "color", $scope.input_color);
-	_attr_style($scope["#div/1"], $scope.input_color && "color:red");
-	$input_style($scope["#childScope/2"], { color: $scope.input_color });
-});
+const $input_color = ($scope, input_color) => {
+	_attr_style_item($scope["#div/0"], "color", input_color);
+	_attr_style($scope["#div/1"], input_color && "color:red");
+	$input_style($scope["#childScope/2"], { color: input_color });
+};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/5");
 function $setup($scope) {
 	$input_test($scope["#childScope/2"]);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "<div><!></div>";
 const $walks$1 = " D%l";
 const $setup$1 = () => {};
 const $input_thing_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/1");
-const $input_thing_selected = /*@__PURE__*/ _const("input_thing_selected", ($scope) => _attr_class_item($scope["#div/0"], "selected", $scope.input_thing_selected));
+const $input_thing_selected = ($scope, input_thing_selected) => _attr_class_item($scope["#div/0"], "selected", input_thing_selected);
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
 const $input_thing_content = $dynamicTag;
 const $input = ($scope, input) => $input_thing($scope, input.thing);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // tags/child.marko
-const $input_thing_selected = /*@__PURE__*/ _const(5, ($scope) => _attr_class_item($scope.a, "selected", $scope.f));
+const $input_thing_selected = ($scope, input_thing_selected) => _attr_class_item($scope.a, "selected", input_thing_selected);
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(1);
 const $input_thing_content = $dynamicTag;
 const $input_thing = ($scope, input_thing) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8822,
-        "brotli": 3820
+        "min": 8737,
+        "brotli": 3794
       },
       "files": {
-        "tags/child.marko": 409,
+        "tags/child.marko": 418,
         "template.marko": 443
       }
     }

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -1049,7 +1049,7 @@ export default {
                     tagSection,
                     valueReferences,
                     stmt,
-                    !!meta.dynamicItems,
+                    true,
                   );
                 }
               }


### PR DESCRIPTION
The DOM class/style branch passed `!!meta.dynamicItems` as `addStatement`'s `isPure`, so the split `_attr_class_item`/`_attr_style_item(s)` path was marked impure and a single-consumer derived binding compiled to a `_const` signal with a scope slot instead of a plain function. These helpers are idempotent DOM writes like `_attr`, which already passes `true`, so the wrapper was pure overhead in compiled output.