### PR TITLE
Escape carriage returns in server-rendered text content

### DIFF
--- a/.changeset/textarea-cr-escape.md
+++ b/.changeset/textarea-cr-escape.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Escape carriage returns in server-rendered text content (including `<textarea>` values and `<title>`) so the parsed result matches client rendering.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -134,12 +134,6 @@ For DOM, `translate.exit` folds the fallback into the derived signal itself (`va
 
 `runtime.x` keeps a single `nextSibling`/`onNextSibling` pair. A `<t hidden>` swap callback pending on that element's next sibling is silently dropped if, while walking the `<t>`'s children, a placeholder-end comment (`!id`) hits the `runtime.l[id] && placeholders[id]` branch and reassigns the pair — the outer swap then never fires and hydration freezes. Current server flush ordering appears to keep this unreachable, so this is robustness, not a live bug: fire the pending callback before reassigning (or queue), weighed against inline-runtime bytes. Re-verify: read `REORDER_RUNTIME_CODE` and confirm both the `op == "!"` and `<t>` branches assign `nextSibling`/`onNextSibling` without first draining a pending one.
 
-## Escape a carriage return in a `<textarea>` body so SSR and CSR agree
-
-`packages/runtime-tags/src/html/attrs.ts` › `_textarea_value` | 2026-07-27 | impact:low | effort:low
-
-`_textarea_value` writes the value as element text and the HTML tokenizer normalizes every CR and CRLF in text to a single LF, so a `\r` anywhere — not just at the start, which commit a6acdde917 already handles — is lost: `"a\rb"` and `"a\r\nb"` both parse back to `defaultValue === "a\nb"`. CSR keeps the CR, since `_attr_input_value_default` (`dom/controllable.ts`) assigns `el.defaultValue` verbatim and `_attr_input_value_script` seeds the resumed `ControlledValue` from `el.defaultValue`, so a resumed controlled `<textarea>` holds a different string than a client-rendered one. Writing `\r` as `&#13;` survives, because character references are decoded after newline normalization; weigh that against the bytes it costs every textarea. The attribute-value escaper has the identical gap in the entry "Escape a carriage return in an attribute value so SSR and CSR agree" — a separate fix in `attrAssignment` rather than this `_escape`-based path, but landing only one still leaves a resumed controlled `<input value=…>` diverging from its client-rendered twin. Re-verify in jsdom: `<textarea>a\rb</textarea>` reports `defaultValue === "a\nb"`, `<textarea>a&#13;b</textarea>` reports `"a\rb"`.
-
 ## Renumber alias bindings too, or stop using `Binding.id` as the `bindingUtil` identity tiebreak
 
 `packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-23 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.debug.js
@@ -1,10 +1,11 @@
 // template.marko
-const $template = "<textarea id=attr></textarea><textarea id=bound></textarea><textarea id=body></textarea>";
-const $walks = " b b b";
-const $bound = /*@__PURE__*/ _let("bound/6", ($scope) => _attr_input_value($scope, "#textarea/1", $scope.bound, $valueChange($scope)));
+const $template = "<textarea id=attr></textarea><textarea id=bound></textarea><textarea id=body></textarea><p id=text> </p>";
+const $walks = " b b bD l";
+const $bound = /*@__PURE__*/ _let("bound/7", ($scope) => _attr_input_value($scope, "#textarea/1", $scope.bound, $valueChange($scope)));
 const $input_v = /*@__PURE__*/ _const("input_v", ($scope) => {
 	_attr_input_value_default($scope, "#textarea/0", $scope.input_v);
 	_attr_input_value_default($scope, "#textarea/2", $scope.input_v);
+	_text($scope["#text/3"], $scope.input_v);
 	$bound($scope, $scope.input_v);
 });
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#textarea/1"));

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/dom.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-const $bound = /*@__PURE__*/ _let(6, ($scope) => _attr_input_value($scope, "b", $scope.g, $valueChange($scope)));
+const $bound = /*@__PURE__*/ _let(7, ($scope) => _attr_input_value($scope, "b", $scope.h, $valueChange($scope)));
 const $setup__script = _script("a1", ($scope) => _attr_input_value_script($scope, "b"));
 const $valueChange = ($scope) => (_new_bound) => {
 	$bound($scope, _new_bound);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let bound = input.v;
 	_html(`<textarea id=attr>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/0", $sg__input_v)}<textarea id=bound>${_attr_textarea_value($scope0_id, "#textarea/1", bound, _resume((_new_bound) => {
 		bound = _new_bound;
-	}, "__tests__/template.marko_0/valueChange", $scope0_id))}</textarea>${_el_resume($scope0_id, "#textarea/1")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/2", $sg__input_v)}`);
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))}</textarea>${_el_resume($scope0_id, "#textarea/1")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "#textarea/2", $sg__input_v)}<p id=text>${_escape(input.v)}${_el_resume($scope0_id, "#text/3", $sg__input_v)}</p>`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#textarea/1": ["valueChange"] });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/html.bundle.js
@@ -5,7 +5,7 @@ var template_default = _template("a", (input) => {
 	let bound = input.v;
 	_html(`<textarea id=attr>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "a", $sg__input_v)}<textarea id=bound>${_attr_textarea_value($scope0_id, "b", bound, _resume((_new_bound) => {
 		bound = _new_bound;
-	}, "a0", $scope0_id))}</textarea>${_el_resume($scope0_id, "b")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "c", $sg__input_v)}`);
+	}, "a0", $scope0_id))}</textarea>${_el_resume($scope0_id, "b")}<textarea id=body>${_textarea_value(input.v)}</textarea>${_el_resume($scope0_id, "c", $sg__input_v)}<p id=text>${_escape(input.v)}${_el_resume($scope0_id, "d", $sg__input_v)}</p>`);
 	_script($scope0_id, "a1");
 	writeScope($scope0_id, {});
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.debug.md
@@ -1,21 +1,43 @@
-# Render `{"v":"\nkept"}`
+# Render `{"v":"\nkept a\rb\r\nc"}`
 ```html
 <textarea
+  default-value="
+kept ab
+c"
   id="attr"
 >
   
-kept
+kept a
+b
+c
 </textarea>
 <textarea
+  default-value="
+kept ab
+c"
   id="bound"
 >
   
-kept
+kept a
+b
+c
 </textarea>
 <textarea
+  default-value="
+kept ab
+c"
   id="body"
 >
   
-kept
+kept a
+b
+c
 </textarea>
+<p
+  id="text"
+>
+  
+kept ab
+c
+</p>
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/render.md
@@ -1,21 +1,43 @@
-# Render `{"v":"\nkept"}`
+# Render `{"v":"\nkept a\rb\r\nc"}`
 ```html
 <textarea
+  default-value="
+kept ab
+c"
   id="attr"
 >
   
-kept
+kept a
+b
+c
 </textarea>
 <textarea
+  default-value="
+kept ab
+c"
   id="bound"
 >
   
-kept
+kept a
+b
+c
 </textarea>
 <textarea
+  default-value="
+kept ab
+c"
   id="body"
 >
   
-kept
+kept a
+b
+c
 </textarea>
+<p
+  id="text"
+>
+  
+kept ab
+c
+</p>
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.debug.html
@@ -1,10 +1,16 @@
 <textarea id=attr>
 
-kept</textarea><textarea id=bound>
+kept a&#13;b&#13;
+c</textarea><textarea id=bound>
 
-kept</textarea><!--M_*1 #textarea/1--><textarea id=body>
+kept a&#13;b&#13;
+c</textarea><!--M_*1 #textarea/1--><textarea id=body>
 
-kept</textarea>
+kept a&#13;b&#13;
+c</textarea>
+<p id=text>
+  kept a&#13;b&#13;
+  c</p>
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/__snapshots__/writes.html
@@ -1,10 +1,16 @@
 <textarea id=attr>
 
-kept</textarea><textarea id=bound>
+kept a&#13;b&#13;
+c</textarea><textarea id=bound>
 
-kept</textarea><!--M_*1 b--><textarea id=body>
+kept a&#13;b&#13;
+c</textarea><!--M_*1 b--><textarea id=body>
 
-kept</textarea>
+kept a&#13;b&#13;
+c</textarea>
+<p id=text>
+  kept a&#13;b&#13;
+  c</p>
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "min": 3720,
-      "brotli": 1760
+      "brotli": 1762
     }
   },
   "html": {
-    "min": 436,
-    "brotli": 274
+    "min": 516,
+    "brotli": 291
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/template.marko
@@ -2,3 +2,4 @@
 <textarea id="attr" value=input.v/>
 <textarea id="bound" value:=bound/>
 <textarea id="body">${input.v}</textarea>
+<p id="text">${input.v}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-leading-newline/test.ts
@@ -1,5 +1,5 @@
 import type { TestConfig } from "../../main.test";
 
 export const config: TestConfig = {
-  steps: [{ v: "\nkept" }],
+  steps: [{ v: "\nkept a\rb\r\nc" }],
 };

--- a/packages/runtime-tags/src/html/attrs.ts
+++ b/packages/runtime-tags/src/html/attrs.ts
@@ -136,7 +136,7 @@ export function _textarea_value(value: unknown) {
   const escaped = _escape(normalizeStrAttrValue(value));
   // The tokenizer drops one newline directly after the start tag, so a value
   // beginning with one needs a second to survive the round trip.
-  return escaped[0] === "\n" || escaped[0] === "\r" ? "\n" + escaped : escaped;
+  return escaped[0] === "\n" ? "\n" + escaped : escaped;
 }
 
 export function _attr_input_value(

--- a/packages/runtime-tags/src/html/content.ts
+++ b/packages/runtime-tags/src/html/content.ts
@@ -17,8 +17,11 @@ export function _unescaped(val: unknown) {
   return val ? val + "" : val === 0 ? "0" : "";
 }
 
-const unsafeXMLReg = /[<&]/g;
-const replaceUnsafeXML = (c: string) => (c === "&" ? "&amp;" : "&lt;");
+// A raw carriage return would parse back as a newline (CSR keeps it); the
+// reference survives, decoded after newline normalization.
+const unsafeXMLReg = /[<&\r]/g;
+const replaceUnsafeXML = (c: string) =>
+  c === "&" ? "&amp;" : c === "<" ? "&lt;" : "&#13;";
 const escapeXMLStr = (str: string) =>
   unsafeXMLReg.test(str) ? str.replace(unsafeXMLReg, replaceUnsafeXML) : str;
 export function _escape(val: unknown) {


### PR DESCRIPTION
The HTML preprocessor normalizes every raw CR/CRLF to LF, so a `\r` in server-rendered text content — a placeholder, a `<title>`, or a `<textarea>` value (where it also corrupts a resumed controlled value seeded from `defaultValue`) — was lost on parse while client rendering keeps it. `_escape` now writes `\r` as `&#13;`, which survives because character references decode after newline normalization; attribute values already did this. Script/style/comment data decode no references and are unchanged.