### PR TITLE
Emit a custom tag's HTML render call after its attribute tag statements

### DIFF
--- a/.changeset/tag-var-after-attr-tags.md
+++ b/.changeset/tag-var-after-attr-tags.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Emit a custom tag's HTML render call after its attribute tag statements, fixing a ReferenceError when a tag with a tag variable collects attribute tags under control flow.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -80,12 +80,6 @@ HTML `_attrs` picks an `<input>`'s controllable from the change handler (`data.c
 
 `preAnalyze` folds a `<textarea>` body into a synthetic `value` attribute by pushing each `MarkoText` child's raw source into `normalizeStringExpression`, and `_textarea_value` (`html/attrs.ts`) escapes it again: `<textarea>&lt;p&gt;hi</textarea>` compiles to `_textarea_value("&lt;p&gt;hi")` and shows the literal `&lt;p&gt;hi`, while the same body in `<title>`/`<div>` passes through, as it does in Marko 5. Entities are the only way to author literal markup in a text-only tag, so that case is unrepresentable. CSR matches SSR, so the fix is decoding `MarkoText` children at compile time — but `MarkoText.value` is raw source and the only decoder in the tree is `he` under `packages/compiler/node_modules` (~100KB, tree-shaken out today), so it needs a new `babel-utils` export; weigh that cost. Re-verify: compile `<textarea>&lt;p&gt;hi</textarea>` with `-o html` and check the emitted `_textarea_value` literal.
 
-## Emit a custom tag's HTML render call after its attribute tag statements
-
-`packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateHTML` | 2026-07-24 | impact:med | effort:med
-
-For a custom tag with both a tag variable and attribute tags under control flow, `translateVar`'s `tag.insertBefore` puts `let menuEl = _myMenu({ item: $item })` ahead of the `let $item; _forOf(…)` statements that `translateAttrs` built and `tag.replaceWithMultiple(statements)` emits, so the render call reads `$item` in its temporal dead zone and SSR throws a ReferenceError. Sequence the call after the attr-tag statements, as the non-tag-variable path already does by pushing it onto `statements`. Only the HTML output is affected — the DOM output calls `_myMenu_input_item` after the loop. Re-verify: compile `<my-menu/menuEl><for|x| of=list><@item label=x/></for></my-menu>` with `pnpm run compile -o html -d`; the `let menuEl = _myMenu(…)` precedes `let $item`.
-
 ## Catch effect errors in `runEffects`; a throwing `<script>` escapes `<try>`'s `@catch` and kills every queued effect
 
 `packages/runtime-tags/src/dom/queue.ts` › `runEffects` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.debug.js
@@ -9,23 +9,25 @@ var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", 
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<button>Toggle</button>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}& b`)("b%c");
+const $walks = /*@__PURE__*/ ((_w0) => `b0${_w0}& b`)("b%c");
 const $item_content__y = ($scope, y) => _text($scope["#text/0"], y);
 const $item_content__$params = ($scope, $params2) => $item_content__y($scope, $params2[0]);
 const $item_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "y: <!>", "b%", 0, $item_content__$params);
-const $x = /*@__PURE__*/ _let("x/2", ($scope) => {
+const $x = /*@__PURE__*/ _let("x/3", ($scope) => {
 	let $item;
 	if ($scope.x) {
 		$item = attrTag({ content: $item_content($scope) });
 	}
 	$input_item($scope["#childScope/0"], $item);
 });
-const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
 	$x($scope, !$scope.x);
 }));
 function $setup($scope) {
+	_var($scope, "#childScope/0", $menuEl);
 	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$x($scope, true);
 	$setup__script($scope);
 }
+const $menuEl = _var_resume("__tests__/template.marko_0_menuEl#4/var", ($scope, menuEl) => {});
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.js
@@ -6,11 +6,12 @@ const $input_item = ($scope, input_item) => $dynamicTag($scope, input_item, () =
 const $item_content__y = ($scope, y) => _text($scope.a, y);
 const $item_content__$params = ($scope, $params2) => $item_content__y($scope, $params2[0]);
 const $item_content = /*@__PURE__*/ _content("a0", "y: <!>", "b%", 0, $item_content__$params);
-const $x = /*@__PURE__*/ _let(2, ($scope) => {
+const $x = /*@__PURE__*/ _let(3, ($scope) => {
 	let $item;
-	if ($scope.c) $item = attrTag({ content: $item_content($scope) });
+	if ($scope.d) $item = attrTag({ content: $item_content($scope) });
 	$input_item($scope.a, $item);
 });
-const $setup__script = _script("a1", ($scope) => _on($scope.b, "click", function() {
-	$x($scope, !$scope.c);
+const $setup__script = _script("a2", ($scope) => _on($scope.c, "click", function() {
+	$x($scope, !$scope.d);
 }));
+const $menuEl = _var_resume("a1", ($scope, menuEl) => {});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
@@ -22,8 +22,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}) });
 	}
 	const $childScope = _peek_scope_id();
-	hello_default({ item: $item });
-	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/1")}`);
+	let menuEl = hello_default({ item: $item });
+	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_menuEl#4/var");
+	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {
 		x,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
@@ -21,10 +21,11 @@ var template_default = _template("a", (input) => {
 	}) });
 	const $childScope = _peek_scope_id();
 	hello_default({ item: $item });
-	_html(`<button>Toggle</button>${_el_resume($scope0_id, "b")}`);
-	_script($scope0_id, "a1");
+	_var($scope0_id, "b", $childScope, "a1");
+	_html(`<button>Toggle</button>${_el_resume($scope0_id, "c")}`);
+	_script($scope0_id, "a2");
 	writeScope($scope0_id, {
-		c: x,
+		d: x,
 		a: _existing_scope($childScope)
 	});
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/writes.debug.html
@@ -1,11 +1,15 @@
 <!--M_[-->y: <!>
-  1<!--M_*3 #text/0--><!--M_]2 #text/0 3--><button>Toggle</button><!--M_*1 #button/1-->
+  1<!--M_*3 #text/0--><!--M_]2 #text/0 3--><button>Toggle</button><!--M_*1 #button/2-->
   <script>
     WALKER_RUNTIME("M")("_");
     M._.r = [_ => [1, {
+        "#scopeOffset/1": 4,
         x: !0,
         "#childScope/0": _(2)
       }, {
+        "#TagVariable": _(1,
+          "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_0_menuEl#4/var"
+          ),
         "ConditionalRenderer:#text/0": "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_1*content"
       }],
       "packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko_0 1"

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/writes.html
@@ -1,12 +1,14 @@
 <!--M_[-->y: <!>
-  1<!--M_*3 a--><!--M_]2 a 3--><button>Toggle</button><!--M_*1 b-->
+  1<!--M_*3 a--><!--M_]2 a 3--><button>Toggle</button><!--M_*1 c-->
   <script>
     WALKER_RUNTIME("M")("_");
     M._.r = [_ => [1, {
-      c: !0,
+      b: 4,
+      d: !0,
       a: _(2)
     }, {
+      T: _(1, "a1"),
       Da: "a0"
-    }], "a1 1"];
+    }], "a2 1"];
     M._.w()
   </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/sizes.json
@@ -2,17 +2,17 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8876,
-        "brotli": 3866
+        "min": 8939,
+        "brotli": 3888
       },
       "files": {
         "tags/hello/index.marko": 194,
-        "template.marko": 561
+        "template.marko": 620
       }
     }
   },
   "html": {
-    "min": 407,
-    "brotli": 282
+    "min": 423,
+    "brotli": 297
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/template.marko
@@ -1,5 +1,5 @@
 <let/x=true>
-<hello>
+<hello/menuEl>
     <if=x>
         <@item|y|>
             y: ${y}

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.debug.js
@@ -23,8 +23,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(4);
+	const $childScope = _peek_scope_id();
 	let setCount = setter_default({
 		value: count,
 		valueChange: _resume((_new_count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.js
@@ -19,8 +19,8 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(4);
+	const $childScope = _peek_scope_id();
 	let setCount = setter_default({
 		value: count,
 		valueChange: _resume((_new_count) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 1;
 	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	let x = child_default({ value: count });
 	_var($scope0_id, "#scopeOffset/3", $childScope, "__tests__/template.marko_0_x#6/var");
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.js
@@ -21,8 +21,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 1;
 	_html(`<button>${_escape(count)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
-	const $childScope = _peek_scope_id();
 	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
 	child_default({ value: count });
 	_var($scope0_id, "d", $childScope, "a0");
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/translator/core/define.ts
+++ b/packages/runtime-tags/src/translator/core/define.ts
@@ -121,8 +121,13 @@ export default {
       if (isOutputHTML()) {
         writer.flushInto(tag);
         writeHTMLResumeStatements(tag.get("body"));
+        translateVar(
+          tag,
+          propsToExpression(translatedAttrs.properties),
+          "const",
+          translatedAttrs.statements,
+        );
         tag.insertBefore(translatedAttrs.statements);
-        translateVar(tag, propsToExpression(translatedAttrs.properties));
       } else {
         if (t.isIdentifier(node.var)) {
           const babelBinding = tag.scope.getBinding(node.var.name)!;

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -206,20 +206,16 @@ export function knownTagTranslateHTML(
     childScopeBinding,
   );
 
+  let varStatement: t.Statement | undefined;
   if (childScopeSerializeReason) {
     const peekScopeId = generateUidIdentifier(childScopeBinding?.name);
-    const peekScopeDeclaration = t.variableDeclaration("const", [
-      t.variableDeclarator(peekScopeId, callRuntime("_peek_scope_id")),
-    ]);
-    if (tagVar) {
-      // A tag variable renders the child from a declaration inserted before
-      // these statements, so the peek must precede it.
-      tag.insertBefore(peekScopeDeclaration);
-    } else {
-      // After the attr statements: building attribute tags can consume scope
-      // ids (eg `_resume_locals`), and the peek must see the child's root id.
-      statements.push(peekScopeDeclaration);
-    }
+    // After the attr statements: building attribute tags can consume scope
+    // ids (eg `_resume_locals`), and the peek must see the child's root id.
+    statements.push(
+      t.variableDeclaration("const", [
+        t.variableDeclarator(peekScopeId, callRuntime("_peek_scope_id")),
+      ]),
+    );
 
     setBindingSerializedValue(
       section,
@@ -228,16 +224,16 @@ export function knownTagTranslateHTML(
     );
 
     if (tagVar) {
-      statements.push(
-        t.expressionStatement(
-          callRuntime(
-            "_var",
-            getScopeIdIdentifier(section),
-            getScopeAccessorLiteral(tag.node.extra![kChildOffsetScopeBinding]!),
-            peekScopeId,
-            t.stringLiteral(
-              getResumeRegisterId(section, tagVar.extra?.binding, "var"),
-            ),
+      // Deferred below the render call: `_var` mints the post-render scope id
+      // for the scope offset.
+      varStatement = t.expressionStatement(
+        callRuntime(
+          "_var",
+          getScopeIdIdentifier(section),
+          getScopeAccessorLiteral(tag.node.extra![kChildOffsetScopeBinding]!),
+          peekScopeId,
+          t.stringLiteral(
+            getResumeRegisterId(section, tagVar.extra?.binding, "var"),
           ),
         ),
       );
@@ -328,7 +324,15 @@ export function knownTagTranslateHTML(
   };
 
   if (tagVar) {
-    translateVar(tag, callExpression(tagIdentifier, ...getArgs()), "let");
+    // The render call reads attr-tag bindings, so its declaration must follow
+    // the attr statements rather than precede the tag.
+    translateVar(
+      tag,
+      callExpression(tagIdentifier, ...getArgs()),
+      "let",
+      statements,
+    );
+    if (varStatement) statements.push(varStatement);
   } else {
     statements.push(callStatement(tagIdentifier, ...getArgs()));
   }

--- a/packages/runtime-tags/src/translator/util/translate-var.ts
+++ b/packages/runtime-tags/src/translator/util/translate-var.ts
@@ -13,6 +13,7 @@ export default function translateVar(
   tag: t.NodePath<t.MarkoTag>,
   initialValue: t.Expression,
   kind: "let" | "const" = "const",
+  statements?: t.Statement[],
 ) {
   const {
     node: { var: tagVar },
@@ -106,9 +107,14 @@ export default function translateVar(
     }
   });
 
-  tag.insertBefore(
-    t.variableDeclaration(kind, [t.variableDeclarator(tagVar, initialValue)]),
-  );
+  const declaration = t.variableDeclaration(kind, [
+    t.variableDeclarator(tagVar, initialValue),
+  ]);
+  if (statements) {
+    statements.push(declaration);
+  } else {
+    tag.insertBefore(declaration);
+  }
 }
 
 function getDestructurePattern(id: t.NodePath<t.Identifier>) {


### PR DESCRIPTION
For a custom tag with both a tag variable and attribute tags under control flow, the HTML output declared `let menuEl = _myMenu({ item: $item })` ahead of the `let $item` / loop statements that collect the attribute tags, so SSR threw a ReferenceError reading $item in its temporal dead zone. The tag-variable declaration is now sequenced after the attr-tag statements, matching the non-tag-variable path; the `_peek_scope_id`/`_var` ordering around the render call is preserved. DOM output was already correct.