### PR TITLE
Forward restOffset when an array rest is re-destructured or aliased

### DIFF
--- a/.changeset/rest-offset-forwarding.md
+++ b/.changeset/rest-offset-forwarding.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Forward `restOffset` when an array rest destructures into a nested pattern or is aliased through a tag variable, fixing silently wrong values in DOM output.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -110,12 +110,6 @@ HTML `_attrs` picks an `<input>`'s controllable from the change handler (`data.c
 
 The patched `MarkoTag` printer wraps every non-void body in `newline(1)`/`indent()`/`dedent()` plus a trailing `newline(1)`, guarded only by `voidElements`, `svgElements` and the concise `style`/`script` forms — never by the `parse-options.preserveWhitespace` tags (`pre`, `script`, `style`, `textarea`) declared in `packages/compiler/src/taglib/marko-html.json`. Those bodies render verbatim, so `output:"source"`/`"migrate"` silently rewrites user content and never reaches a fixed point, and `packages/runtime-class/bin/markoc.js --migrate` rewrites each file in place. Add a `preserveWhitespaceElements` set beside `voidElements` and print those bodies with no newline/indent (the concise `style { … }` branch is the shape to copy); the committed `packages/runtime-class/test/translator/fixtures/{textarea-tag,white-space-test}/snapshots/generated-expected.marko` already bake the extra whitespace and need refreshing. Re-verify: round-tripping `<textarea>abc</textarea>` through `output:"source"` turns the `output:"html"` result's `_textarea_value("abc")` into `_textarea_value("  abc\n")`.
 
-## Forward `restOffset` wherever an array rest's binding is re-created
-
-`packages/runtime-tags/src/translator/util/references.ts` › `createBindingsAndTrackReferences` | 2026-07-27 | impact:med | effort:med
-
-`restOffset` is assigned only in the `Identifier` case, so every path that re-creates a rest's binding drops it — the `ObjectPattern`/`ArrayPattern` cases reuse `upstreamAlias` verbatim when `property === undefined`, and `trackVarReferences` forwards `excludeProperties` but not `restOffset`. `<const/[first, ...[second, third]] = arr/>` then compiles in DOM to `$second` reading `$scope.first` and `$third` reading `$scope.arr[1]` (`1|1|2` vs HTML's `1|2|3`); `<for|a, ...[b, c]|>` maps `c` to `#LoopKey`; `<const/copy = rest/>` takes `getSignalFn`'s object-rest branch, so `copy.length` reads `$scope.arr.length`. All are silent SSR/CSR divergence with no diagnostic. Set `restOffset` in the pattern cases and thread it through `trackVarReferences`. Re-verify: `pnpm run compile -o dom -d` on the nested-rest template emits `_text($scope["#text/1"], $scope.first)` for `$second`.
-
 ## Mint `<id>`'s fallback once per scope
 
 `packages/runtime-tags/src/translator/core/id.ts` › `translate.exit` | 2026-07-27 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/dom.bundle.debug.js
@@ -1,18 +1,34 @@
 // template.marko
-const $template = "<div><!>|<!>|<!>|<!></div><button>update</button>";
-const $walks = "D%c%c%c%l b";
-const $list = /*@__PURE__*/ _let("list/5", ($scope) => {
+const $template = "<div><!>|<!>|<!>|<!></div><div><!>|<!></div><div><!>|<!></div><button>update</button>";
+const $walks = "D%c%c%c%lD%c%lD%c%l b";
+const $list = /*@__PURE__*/ _let("list/9", ($scope) => {
 	(([, ...rest]) => $rest($scope, rest))($scope.list);
+	(([, ...copy]) => $copy($scope, copy))($scope.list);
 	$first($scope, $scope.list[0]);
 	$list_($scope, $scope.list[1]);
 	$list_2($scope, $scope.list[2]);
 });
 const $rest = /*@__PURE__*/ _const("rest", ($scope) => $rest_length($scope, $scope.rest.length));
 const $rest_length = /*@__PURE__*/ _const("rest_length", ($scope) => _text($scope["#text/3"], $scope.rest_length));
+const $copy = /*@__PURE__*/ _const("copy", ($scope) => $copy_length($scope, $scope.copy.length));
+const $copy_length = /*@__PURE__*/ _const("copy_length", ($scope) => _text($scope["#text/7"], $scope.copy_length));
 const $first = /*@__PURE__*/ _const("first", ($scope) => _text($scope["#text/0"], $scope.first));
-const $list_ = /*@__PURE__*/ _const("list_1", ($scope) => _text($scope["#text/1"], $scope.list_1));
-const $list_2 = /*@__PURE__*/ _const("list_2", ($scope) => _text($scope["#text/2"], $scope.list_2));
-const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/4"], "click", function() {
+const $list_ = /*@__PURE__*/ _const("list_1", ($scope) => {
+	_text($scope["#text/1"], $scope.list_1);
+	_text($scope["#text/6"], $scope.list_1);
+	$second($scope, $scope.list_1);
+});
+const $second = ($scope) => {
+	_text($scope["#text/4"], $scope.list_1);
+};
+const $list_2 = /*@__PURE__*/ _const("list_2", ($scope) => {
+	_text($scope["#text/2"], $scope.list_2);
+	$third($scope, $scope.list_2);
+});
+const $third = ($scope) => {
+	_text($scope["#text/5"], $scope.list_2);
+};
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/8"], "click", function() {
 	$list($scope, [4, 5]);
 }));
 function $setup($scope) {

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/dom.bundle.js
@@ -1,15 +1,31 @@
 // template.marko
-const $list = /*@__PURE__*/ _let(5, ($scope) => {
-	(([, ...rest]) => $rest($scope, rest))($scope.f);
-	$first($scope, $scope.f[0]);
-	$list_($scope, $scope.f[1]);
-	$list_2($scope, $scope.f[2]);
+const $list = /*@__PURE__*/ _let(9, ($scope) => {
+	(([, ...rest]) => $rest($scope, rest))($scope.j);
+	(([, ...copy]) => $copy($scope, copy))($scope.j);
+	$first($scope, $scope.j[0]);
+	$list_($scope, $scope.j[1]);
+	$list_2($scope, $scope.j[2]);
 });
-const $rest = /*@__PURE__*/ _const(7, ($scope) => $rest_length($scope, $scope.h.length));
-const $rest_length = /*@__PURE__*/ _const(10, ($scope) => _text($scope.d, $scope.k));
-const $first = /*@__PURE__*/ _const(6, ($scope) => _text($scope.a, $scope.g));
-const $list_ = /*@__PURE__*/ _const(8, ($scope) => _text($scope.b, $scope.i));
-const $list_2 = /*@__PURE__*/ _const(9, ($scope) => _text($scope.c, $scope.j));
-const $setup__script = _script("a0", ($scope) => _on($scope.e, "click", function() {
+const $rest = /*@__PURE__*/ _const(11, ($scope) => $rest_length($scope, $scope.l.length));
+const $rest_length = /*@__PURE__*/ _const(14, ($scope) => _text($scope.d, $scope.o));
+const $copy = /*@__PURE__*/ _const(15, ($scope) => $copy_length($scope, $scope.p.length));
+const $copy_length = /*@__PURE__*/ _const(16, ($scope) => _text($scope.h, $scope.q));
+const $first = /*@__PURE__*/ _const(10, ($scope) => _text($scope.a, $scope.k));
+const $list_ = /*@__PURE__*/ _const(12, ($scope) => {
+	_text($scope.b, $scope.m);
+	_text($scope.g, $scope.m);
+	$second($scope, $scope.m);
+});
+const $second = ($scope) => {
+	_text($scope.e, $scope.m);
+};
+const $list_2 = /*@__PURE__*/ _const(13, ($scope) => {
+	_text($scope.c, $scope.n);
+	$third($scope, $scope.n);
+});
+const $third = ($scope) => {
+	_text($scope.f, $scope.n);
+};
+const $setup__script = _script("a0", ($scope) => _on($scope.i, "click", function() {
 	$list($scope, [4, 5]);
 }));

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		3
 	];
 	const [first, ...rest] = list;
-	_html(`<div>${_escape(first)}${_el_resume($scope0_id, "#text/0")}|<!>${_escape(rest[0])}${_el_resume($scope0_id, "#text/1")}|<!>${_escape(rest[1])}${_el_resume($scope0_id, "#text/2")}|<!>${_escape(rest.length)}${_el_resume($scope0_id, "#text/3")}</div><button>update</button>${_el_resume($scope0_id, "#button/4")}`);
+	const [, ...[second, third]] = list;
+	const copy = rest;
+	_html(`<div>${_escape(first)}${_el_resume($scope0_id, "#text/0")}|<!>${_escape(rest[0])}${_el_resume($scope0_id, "#text/1")}|<!>${_escape(rest[1])}${_el_resume($scope0_id, "#text/2")}|<!>${_escape(rest.length)}${_el_resume($scope0_id, "#text/3")}</div><div>${_escape(second)}${_el_resume($scope0_id, "#text/4")}|<!>${_escape(third)}${_el_resume($scope0_id, "#text/5")}</div><div>${_escape(copy[0])}${_el_resume($scope0_id, "#text/6")}|<!>${_escape(copy.length)}${_el_resume($scope0_id, "#text/7")}</div><button>update</button>${_el_resume($scope0_id, "#button/8")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/html.bundle.js
@@ -2,12 +2,15 @@
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
-	const [first, ...rest] = [
+	let list = [
 		1,
 		2,
 		3
 	];
-	_html(`<div>${_escape(first)}${_el_resume($scope0_id, "a")}|<!>${_escape(rest[0])}${_el_resume($scope0_id, "b")}|<!>${_escape(rest[1])}${_el_resume($scope0_id, "c")}|<!>${_escape(rest.length)}${_el_resume($scope0_id, "d")}</div><button>update</button>${_el_resume($scope0_id, "e")}`);
+	const [first, ...rest] = list;
+	const [, ...[second, third]] = list;
+	const copy = rest;
+	_html(`<div>${_escape(first)}${_el_resume($scope0_id, "a")}|<!>${_escape(rest[0])}${_el_resume($scope0_id, "b")}|<!>${_escape(rest[1])}${_el_resume($scope0_id, "c")}|<!>${_escape(rest.length)}${_el_resume($scope0_id, "d")}</div><div>${_escape(second)}${_el_resume($scope0_id, "e")}|<!>${_escape(third)}${_el_resume($scope0_id, "f")}</div><div>${_escape(copy[0])}${_el_resume($scope0_id, "g")}|<!>${_escape(copy.length)}${_el_resume($scope0_id, "h")}</div><button>update</button>${_el_resume($scope0_id, "i")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {});
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/render.debug.md
@@ -3,6 +3,12 @@
 <div>
   1|2|3|2
 </div>
+<div>
+  2|3
+</div>
+<div>
+  2|2
+</div>
 <button>
   update
 </button>
@@ -16,14 +22,24 @@ document.querySelector("button").click();
 <div>
   4|5||1
 </div>
+<div>
+  5|
+</div>
+<div>
+  5|1
+</div>
 <button>
   update
 </button>
 ```
 ## Change
 ```
-UPDATE: div::text@5 "2" => "1"
-UPDATE: div::text@0 "1" => "4"
-UPDATE: div::text@2 "2" => "5"
-UPDATE: div::text "3" => ""
+UPDATE: div:nth-of-type(1)::text@5 "2" => "1"
+UPDATE: div:nth-of-type(3)::text@2 "2" => "1"
+UPDATE: div:nth-of-type(1)::text@0 "1" => "4"
+UPDATE: div:nth-of-type(1)::text@2 "2" => "5"
+UPDATE: div:nth-of-type(3)::text@0 "2" => "5"
+UPDATE: div:nth-of-type(2)::text@0 "2" => "5"
+UPDATE: div:nth-of-type(1)::text "3" => ""
+UPDATE: div:nth-of-type(2)::text "3" => ""
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/render.md
@@ -3,6 +3,12 @@
 <div>
   1|2|3|2
 </div>
+<div>
+  2|3
+</div>
+<div>
+  2|2
+</div>
 <button>
   update
 </button>
@@ -16,14 +22,24 @@ document.querySelector("button").click();
 <div>
   4|5||1
 </div>
+<div>
+  5|
+</div>
+<div>
+  5|1
+</div>
 <button>
   update
 </button>
 ```
 ## Change
 ```
-UPDATE: div::text@5 "2" => "1"
-UPDATE: div::text@0 "1" => "4"
-UPDATE: div::text@2 "2" => "5"
-UPDATE: div::text "3" => ""
+UPDATE: div:nth-of-type(1)::text@5 "2" => "1"
+UPDATE: div:nth-of-type(3)::text@2 "2" => "1"
+UPDATE: div:nth-of-type(1)::text@0 "1" => "4"
+UPDATE: div:nth-of-type(1)::text@2 "2" => "5"
+UPDATE: div:nth-of-type(3)::text@0 "2" => "5"
+UPDATE: div:nth-of-type(2)::text@0 "2" => "5"
+UPDATE: div:nth-of-type(1)::text "3" => ""
+UPDATE: div:nth-of-type(2)::text "3" => ""
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/writes.debug.html
@@ -1,5 +1,8 @@
 <div>1<!--M_*1 #text/0-->|<!>2<!--M_*1 #text/1-->|<!>3<!--M_*1 #text/2-->|<!>
-        2<!--M_*1 #text/3--></div><button>update</button><!--M_*1 #button/4-->
+        2<!--M_*1 #text/3--></div>
+<div>2<!--M_*1 #text/4-->|<!>3<!--M_*1 #text/5--></div>
+<div>2<!--M_*1 #text/6-->|<!>2<!--M_*1 #text/7--></div>
+<button>update</button><!--M_*1 #button/8-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/__snapshots__/writes.html
@@ -1,5 +1,6 @@
 <div>1<!--M_*1 a-->|<!>2<!--M_*1 b-->|<!>3<!--M_*1 c-->|<!>2<!--M_*1 d--></div>
-<button>update</button><!--M_*1 e-->
+<div>2<!--M_*1 e-->|<!>3<!--M_*1 f--></div>
+<div>2<!--M_*1 g-->|<!>2<!--M_*1 h--></div><button>update</button><!--M_*1 i-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = ["a0 1"];

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/sizes.json
@@ -1,12 +1,12 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 2841,
-      "brotli": 1433
+      "min": 2988,
+      "brotli": 1482
     }
   },
   "html": {
-    "min": 410,
-    "brotli": 263
+    "min": 496,
+    "brotli": 277
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-rest-reads/template.marko
@@ -1,4 +1,8 @@
 <let/list=[1, 2, 3]/>
 <const/[first, ...rest]=list>
+<const/[, ...[second, third]]=list>
+<const/copy=rest/>
 <div>${first}|${rest[0]}|${rest[1]}|${rest.length}</div>
+<div>${second}|${third}</div>
+<div>${copy[0]}|${copy.length}</div>
 <button onClick() { list = [4, 5] }>update</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/dom.bundle.debug.js
@@ -12,20 +12,32 @@ const $input = ($scope, input) => $input_content($scope, input.content);
 var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
 
 // template.marko
-const $template = /*@__PURE__*/ ((_w0) => `<!><!>${_w0}<!>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b%b/${_w0}&b`)("b%c");
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<!><!><!>${_w0}${_w1}<!>`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `b%b%b/${_w0}&/${_w1}&b`)("b%c", "b%c");
+const $child_content2__x = ($scope, x) => _text($scope["#text/0"], x);
+const $child_content2__y = ($scope, y) => _text($scope["#text/1"], y);
+const $child_content2__z = ($scope, z) => _text($scope["#text/2"], z);
+const $child_content2__$params = ($scope, $params5) => {
+	$child_content2__x($scope, $params5[0]);
+	$child_content2__y($scope, $params5[1]);
+	$child_content2__z($scope, $params5[2]);
+};
+const $child_content2 = /*@__PURE__*/ _content("__tests__/template.marko_4*content", "<div><!>-<!>-<!></div>", "D%c%c%", 0, $child_content2__$params);
 const $child_content__first = ($scope, first) => _text($scope["#text/0"], first);
-const $child_content__$params3_ = ($scope, $params3_1) => _text($scope["#text/1"], $params3_1);
-const $child_content__$params3_2 = ($scope, $params3_2) => _text($scope["#text/2"], $params3_2);
+const $child_content__$params4_ = ($scope, $params4_1) => _text($scope["#text/1"], $params4_1);
+const $child_content__$params4_2 = ($scope, $params4_2) => _text($scope["#text/2"], $params4_2);
 const $child_content__others_length = ($scope, others_length) => _text($scope["#text/3"], others_length);
-const $child_content__$params = ($scope, $params3) => {
-	(([, ...others]) => $child_content__others($scope, others))($params3);
-	$child_content__first($scope, $params3[0]);
-	$child_content__$params3_($scope, $params3[1]);
-	$child_content__$params3_2($scope, $params3[2]);
+const $child_content__$params = ($scope, $params4) => {
+	(([, ...others]) => $child_content__others($scope, others))($params4);
+	$child_content__first($scope, $params4[0]);
+	$child_content__$params4_($scope, $params4[1]);
+	$child_content__$params4_2($scope, $params4[2]);
 };
 const $child_content__others = ($scope, others) => $child_content__others_length($scope, others.length);
-const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_2*content", "<div><!>|<!>|<!>|<!></div>", "D%c%c%c%", 0, $child_content__$params);
+const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_3*content", "<div><!>|<!>|<!>|<!></div>", "D%c%c%c%", 0, $child_content__$params);
+const $for_content2__item = ($scope, item) => _text($scope["#text/0"], item);
+const $for_content2__setup = ($scope) => _text($scope["#text/1"], $scope["#LoopKey"]);
+const $for_content2__$params = ($scope, $params3) => $for_content2__item($scope, $params3[0]);
 const $for_content__item = ($scope, item) => _text($scope["#text/0"], item);
 const $for_content__setup = ($scope) => _text($scope["#text/1"], $scope["#LoopKey"]);
 const $for_content__meta_length = ($scope, meta_length) => _text($scope["#text/2"], meta_length);
@@ -35,10 +47,16 @@ const $for_content__$params = ($scope, $params2) => {
 };
 const $for_content__meta = ($scope, meta) => $for_content__meta_length($scope, meta.length);
 const $for = /*@__PURE__*/ _for_of("#text/0", "<div><!>:<!>:<!></div>", "D%c%c%", $for_content__setup, $for_content__$params);
-const $list = /*@__PURE__*/ _let("list/2", ($scope) => $for($scope, [$scope.list]));
+const $for2 = /*@__PURE__*/ _for_of("#text/1", "<div><!>@<!></div>", "D%c%", $for_content2__setup, $for_content2__$params);
+const $list = /*@__PURE__*/ _let("list/4", ($scope) => {
+	$for($scope, [$scope.list]);
+	$for2($scope, [$scope.list]);
+});
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
-	$input_content($scope["#childScope/1"], $child_content($scope));
+	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
+	$input_content($scope["#childScope/2"], $child_content($scope));
+	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
+	$input_content($scope["#childScope/3"], $child_content2($scope));
 	$list($scope, ["a", "b"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.debug.js
@@ -19,11 +19,21 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		const $scope1_id = _scope_id();
 		_html(`<div>${_escape(item)}:${_escape(meta[0])}:${_escape(meta.length)}</div>`);
 	});
-	child_default({ content: _content("__tests__/template.marko_2*content", (first, ...others) => {
-		const $scope2_reason = _scope_reason(), $sg__$params3_ = _serialize_guard($scope2_reason, 2), $sg__$params3_2 = _serialize_guard($scope2_reason, 3), $sg__others_length = _serialize_guard($scope2_reason, 4);
+	forOf(list, (item, ...[idx]) => {
 		const $scope2_id = _scope_id();
-		_html(`<div>${_escape(first)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 1))}|${_sep($sg__$params3_)}${_escape(others[0])}${_el_resume($scope2_id, "#text/1", $sg__$params3_)}|${_sep($sg__$params3_2)}${_escape(others[1])}${_el_resume($scope2_id, "#text/2", $sg__$params3_2)}|${_sep($sg__others_length)}${_escape(others.length)}${_el_resume($scope2_id, "#text/3", $sg__others_length)}</div>`);
-		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "5:2");
+		_html(`<div>${_escape(item)}@${_escape(idx)}</div>`);
+	});
+	child_default({ content: _content("__tests__/template.marko_3*content", (first, ...others) => {
+		const $scope3_reason = _scope_reason(), $sg__$params4_ = _serialize_guard($scope3_reason, 2), $sg__$params4_2 = _serialize_guard($scope3_reason, 3), $sg__others_length = _serialize_guard($scope3_reason, 4);
+		const $scope3_id = _scope_id();
+		_html(`<div>${_escape(first)}${_el_resume($scope3_id, "#text/0", _serialize_guard($scope3_reason, 1))}|${_sep($sg__$params4_)}${_escape(others[0])}${_el_resume($scope3_id, "#text/1", $sg__$params4_)}|${_sep($sg__$params4_2)}${_escape(others[1])}${_el_resume($scope3_id, "#text/2", $sg__$params4_2)}|${_sep($sg__others_length)}${_escape(others.length)}${_el_resume($scope3_id, "#text/3", $sg__others_length)}</div>`);
+		_serialize_if($scope3_reason, 0) && writeScope($scope3_id, {}, "__tests__/template.marko", "8:2");
+	}) });
+	child_default({ content: _content("__tests__/template.marko_4*content", (x, ...[y, z]) => {
+		const $scope4_reason = _scope_reason(), $sg__y = _serialize_guard($scope4_reason, 2), $sg__z = _serialize_guard($scope4_reason, 3);
+		const $scope4_id = _scope_id();
+		_html(`<div>${_escape(x)}${_el_resume($scope4_id, "#text/0", _serialize_guard($scope4_reason, 1))}-${_sep($sg__y)}${_escape(y)}${_el_resume($scope4_id, "#text/1", $sg__y)}-${_sep($sg__z)}${_escape(z)}${_el_resume($scope4_id, "#text/2", $sg__z)}</div>`);
+		_serialize_if($scope4_reason, 0) && writeScope($scope4_id, {}, "__tests__/template.marko", "11:2");
 	}) });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.js
@@ -14,15 +14,26 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
-	forOf(["a", "b"], (item, ...meta) => {
+	let list = ["a", "b"];
+	forOf(list, (item, ...meta) => {
 		_scope_id();
 		_html(`<div>${_escape(item)}:${_escape(meta[0])}:${_escape(meta.length)}</div>`);
 	});
+	forOf(list, (item, ...[idx]) => {
+		_scope_id();
+		_html(`<div>${_escape(item)}@${_escape(idx)}</div>`);
+	});
 	child_default({ content: _content("a0", (first, ...others) => {
-		const $scope2_reason = _scope_reason(), $sg__$params3_ = _serialize_guard($scope2_reason, 2), $sg__$params3_2 = _serialize_guard($scope2_reason, 3), $sg__others_length = _serialize_guard($scope2_reason, 4);
-		const $scope2_id = _scope_id();
-		_html(`<div>${_escape(first)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 1))}|${_sep($sg__$params3_)}${_escape(others[0])}${_el_resume($scope2_id, "b", $sg__$params3_)}|${_sep($sg__$params3_2)}${_escape(others[1])}${_el_resume($scope2_id, "c", $sg__$params3_2)}|${_sep($sg__others_length)}${_escape(others.length)}${_el_resume($scope2_id, "d", $sg__others_length)}</div>`);
-		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
+		const $scope3_reason = _scope_reason(), $sg__$params4_ = _serialize_guard($scope3_reason, 2), $sg__$params4_2 = _serialize_guard($scope3_reason, 3), $sg__others_length = _serialize_guard($scope3_reason, 4);
+		const $scope3_id = _scope_id();
+		_html(`<div>${_escape(first)}${_el_resume($scope3_id, "a", _serialize_guard($scope3_reason, 1))}|${_sep($sg__$params4_)}${_escape(others[0])}${_el_resume($scope3_id, "b", $sg__$params4_)}|${_sep($sg__$params4_2)}${_escape(others[1])}${_el_resume($scope3_id, "c", $sg__$params4_2)}|${_sep($sg__others_length)}${_escape(others.length)}${_el_resume($scope3_id, "d", $sg__others_length)}</div>`);
+		_serialize_if($scope3_reason, 0) && writeScope($scope3_id, {});
+	}) });
+	child_default({ content: _content("a1", (x, ...[y, z]) => {
+		const $scope4_reason = _scope_reason(), $sg__y = _serialize_guard($scope4_reason, 2), $sg__z = _serialize_guard($scope4_reason, 3);
+		const $scope4_id = _scope_id();
+		_html(`<div>${_escape(x)}${_el_resume($scope4_id, "a", _serialize_guard($scope4_reason, 1))}-${_sep($sg__y)}${_escape(y)}${_el_resume($scope4_id, "b", $sg__y)}-${_sep($sg__z)}${_escape(z)}${_el_resume($scope4_id, "c", $sg__z)}</div>`);
+		_serialize_if($scope4_reason, 0) && writeScope($scope4_id, {});
 	}) });
 	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/render.debug.md
@@ -7,6 +7,15 @@
   b:1:1
 </div>
 <div>
+  a@0
+</div>
+<div>
+  b@1
+</div>
+<div>
   1|2|3|2
+</div>
+<div>
+  1-2-3
 </div>
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/render.md
@@ -7,6 +7,15 @@
   b:1:1
 </div>
 <div>
+  a@0
+</div>
+<div>
+  b@1
+</div>
+<div>
   1|2|3|2
+</div>
+<div>
+  1-2-3
 </div>
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/writes.debug.html
@@ -1,3 +1,6 @@
 <div>a:0:1</div>
 <div>b:1:1</div>
+<div>a@0</div>
+<div>b@1</div>
 <div>1|2|3|2</div>
+<div>1-2-3</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/writes.html
@@ -1,3 +1,6 @@
 <div>a:0:1</div>
 <div>b:1:1</div>
+<div>a@0</div>
+<div>b@1</div>
 <div>1|2|3|2</div>
+<div>1-2-3</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/sizes.json
@@ -6,7 +6,7 @@
     }
   },
   "html": {
-    "min": 50,
-    "brotli": 48
+    "min": 94,
+    "brotli": 65
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/template.marko
@@ -2,6 +2,12 @@
 <for|item, ...meta| of=list>
   <div>${item}:${meta[0]}:${meta.length}</div>
 </for>
+<for|item, ...[idx]| of=list>
+  <div>${item}@${idx}</div>
+</for>
 <child|first, ...others|>
   <div>${first}|${others[0]}|${others[1]}|${others.length}</div>
+</child>
+<child|x, ...[y, z]|>
+  <div>${x}-${y}-${z}</div>
 </child>

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -357,7 +357,7 @@ export function trackVarReferences(
     let canonicalUpstreamAlias =
       upstreamAlias && getCanonicalBinding(upstreamAlias);
     if (canonicalUpstreamAlias) {
-      const { excludeProperties } = canonicalUpstreamAlias;
+      const { excludeProperties, restOffset } = canonicalUpstreamAlias;
       if (excludeProperties !== undefined) {
         canonicalUpstreamAlias = canonicalUpstreamAlias.upstreamAlias!;
       }
@@ -369,6 +369,7 @@ export function trackVarReferences(
         canonicalUpstreamAlias,
         undefined,
         excludeProperties,
+        restOffset,
       );
       return canonicalUpstreamAlias;
     }
@@ -766,14 +767,16 @@ function createBindingsAndTrackReferences(
           lVal.loc,
         ));
 
-      let i = -1;
+      // A pattern that is itself a rest argument mirrors the source at
+      // shifted indices, so its elements index from the inherited offset.
+      let index = (restOffset || 0) - 1;
       for (const element of lVal.elements) {
-        i++;
+        index++;
         if (element) {
           if (element.type === "RestElement") {
             excludeProperties =
-              i > 0
-                ? addNumericPropertiesUntil(excludeProperties, i)
+              index > 0
+                ? addNumericPropertiesUntil(excludeProperties, index)
                 : undefined;
             createBindingsAndTrackReferences(
               element.argument,
@@ -785,7 +788,7 @@ function createBindingsAndTrackReferences(
               // `restOffset`; passing its own `property` would collide with a sibling binding.
               undefined,
               excludeProperties,
-              i,
+              index,
             );
           } else if (t.isLVal(element)) {
             createBindingsAndTrackReferences(
@@ -794,7 +797,7 @@ function createBindingsAndTrackReferences(
               scope,
               section,
               patternBinding,
-              `${i}`,
+              `${index}`,
               undefined,
             );
           }


### PR DESCRIPTION
`restOffset` was only assigned in `createBindingsAndTrackReferences`' Identifier case, so a nested rest pattern (`<const/[first, ...[second, third]] = arr/>`), a rest pattern in tag params (`<for|a, ...[b, c]|>`), and a tag-variable alias of a rest (`<const/copy = rest/>`) all dropped the offset in DOM output and silently read the wrong indices (or the source array's `length`), diverging from HTML. The `ArrayPattern` case now indexes elements from the inherited offset and `trackVarReferences` threads `restOffset` alongside `excludeProperties`.