### PR TITLE
feat(runtime-tags): warn when an Intl.DateTimeFormat will not survive resume

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -122,27 +122,6 @@ When a property's value is circular, `writeProp` returns false, `writeObjectProp
 
 `getMarkoFile` invalidates a cache entry on its content hash or a newer mtime among `metadata.marko.watchFiles`, which holds only taglib JSON and plugin paths; the child `.marko` templates analysis read go to `metadata.marko.analyzedTags`, which the loop ignores, so a shared cache serves a stale parent after a child edit. Reach is narrow — `@marko/vite` clears `baseConfig.cache` on every hot update — leaving `@marko/compiler/register` and direct `compile[Sync]` reuse. Any fix has to be transitive, so every cache hit would stat the whole subtree. Re-verify: `compileSync` one parent twice through a single `new Map()` cache, rewriting its child from `<return=1/>` to a stateful `<let/x=1/><button onClick(){x++}/><return=x/>` in between — output stays byte-identical with no `_el_resume`, while a fresh cache emits it.
 
-## Round-trip `Intl.DateTimeFormat` through a form that preserves `month`/`weekday`, not `resolvedOptions()`
-
-`packages/runtime-tags/src/html/serializer.ts` › `writeIntl` | 2026-07-31 | impact:med | effort:med
-
-`Intl` serialization (added in #3566) rebuilds a formatter by feeding
-`resolvedOptions()` back into the constructor, but those options are not a
-faithful round trip: for `Intl.DateTimeFormat` the resolved `month` and
-`weekday` fields are normalized to values that re-resolve differently in some
-locales, notably `ja` and `zh`, so a date formatted on the server renders
-differently once the same formatter is used after resume. That is a silent
-server/client divergence in rendered text rather than a crash, which makes it
-harder to notice than the unserializable-value error it replaced, and the
-changeset currently records it as an accepted limitation. A fix likely needs to
-capture the constructor's original `options` argument at the call site (the
-compiler already sees `new Intl.DateTimeFormat(...)` in `<const>` position)
-rather than recovering them from the built formatter, or to special-case the
-fields whose resolved form is lossy. Re-verify by server-rendering
-`<const/fmt=new Intl.DateTimeFormat("ja", { month: "long", weekday: "long" })/>`
-reached from browser-updating content, then comparing `fmt.format(date)` before
-and after resume.
-
 ## Bridge Class-API function props nested below the top level of a Tags-API child's input
 
 `packages/runtime-tags/src/html/compat.ts` › `registerClassFunctions` | 2026-08-05 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $n__OR__day = /*@__PURE__*/ _or(4, ($scope) => _text($scope["#text/1"], $scope.day.format(new Date($scope.n))));
+const $n = /*@__PURE__*/ _let("n/2", $n__OR__day);
+const $day = /*@__PURE__*/ _const("day", $n__OR__day);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, $scope.n + 864e5);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$day($scope, new Intl.DateTimeFormat("ja", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+		weekday: "long",
+		timeZone: "UTC"
+	}));
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	const day = new Intl.DateTimeFormat("ja", {
+		year: "numeric",
+		month: "long",
+		day: "numeric",
+		weekday: "long",
+		timeZone: "UTC"
+	});
+	_html(`<button>${_escape(day.format(new Date(n)))}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {
+		n,
+		day
+	}, "__tests__/template.marko", 0, {
+		n: "1:6",
+		day: "2:8"
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render-csr.debug.md
@@ -1,0 +1,20 @@
+# Render
+```html
+<button>
+  1970年1月1日木曜日
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1970年1月2日金曜日
+</button>
+```
+## Change
+```
+UPDATE: button::text "1970年1月1日木曜日" => "1970年1月2日金曜日"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,33 @@
+# Render
+```html
+<button>
+  1970年1月1日木曜日
+</button>
+```
+## Console
+```
+ERROR "An `Intl.DateTimeFormat` does not survive serialization; it will format differently after resume:" {
+  locale: 'ja',
+  calendar: 'gregory',
+  numberingSystem: 'latn',
+  timeZone: 'UTC',
+  weekday: 'long',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric'
+}
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1970/1/2金曜日
+</button>
+```
+## Change
+```
+UPDATE: button::text "1970年1月1日木曜日" => "1970/1/2金曜日"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/render.debug.md
@@ -1,0 +1,33 @@
+# Render
+```html
+<button>
+  1970年1月1日木曜日
+</button>
+```
+## Console
+```
+ERROR "An `Intl.DateTimeFormat` does not survive serialization; it will format differently after resume:" {
+  locale: 'ja',
+  calendar: 'gregory',
+  numberingSystem: 'latn',
+  timeZone: 'UTC',
+  weekday: 'long',
+  year: 'numeric',
+  month: 'numeric',
+  day: 'numeric'
+}
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  1970/1/2金曜日
+</button>
+```
+## Change
+```
+UPDATE: button::text "1970年1月1日木曜日" => "1970/1/2金曜日"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/__snapshots__/writes.debug.html
@@ -1,0 +1,19 @@
+<button>1970年1月1日木曜日<!--M_*1 #text/1--></button><!--M_*1 #button/0-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 0,
+      day: new Intl.DateTimeFormat("ja", {
+        calendar: "gregory",
+        numberingSystem: "latn",
+        timeZone: "UTC",
+        weekday: "long",
+        year: "numeric",
+        month: "numeric",
+        day: "numeric"
+      })
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/template.marko
@@ -1,0 +1,3 @@
+<let/n=0/>
+<const/day=new Intl.DateTimeFormat("ja", { year: "numeric", month: "long", day: "numeric", weekday: "long", timeZone: "UTC" })/>
+<button onClick() { n += 86400000 }>${day.format(new Date(n))}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/intl-datetime-format-lossy/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  // SSR resumes the rebuilt formatter, CSR builds it from source; that gap is
+  // what the serializer warns about.
+  equivalent: false,
+  skip_optimize: true,
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1668,6 +1668,14 @@ function writeResponse(state: State, val: Response, ref: Reference) {
 // instead. Exact except `DateTimeFormat` widths in some locales (`ja`, `zh`).
 function writeIntl(state: State, val: object, name: string, ref: Reference) {
   const { locale, ...options } = (val as Intl.NumberFormat).resolvedOptions();
+  if (MARKO_DEBUG && name === "DateTimeFormat") {
+    warnLossyDateTimeFormat(
+      val as Intl.DateTimeFormat,
+      locale,
+      options as Intl.DateTimeFormatOptions,
+    );
+  }
+
   let needsId = false;
   for (const key in options) {
     if (isDedupedMember((options as Record<string, unknown>)[key])) {
@@ -1696,6 +1704,25 @@ function writeIntl(state: State, val: object, name: string, ref: Reference) {
   writeObjectProps(state, options, optionsRef);
   state.buf.push("})");
   return true;
+}
+
+// A formatter is rebuilt from `resolvedOptions()`, which drops the distinction
+// between eg `month: "long"` and `"numeric"` where a locale resolves them alike
+// but patterns them differently — `ja`/`zh` full dates are the known cases.
+function warnLossyDateTimeFormat(
+  val: Intl.DateTimeFormat,
+  locale: string,
+  options: Intl.DateTimeFormatOptions,
+) {
+  const probe = new Date(0);
+  if (
+    new Intl.DateTimeFormat(locale, options).format(probe) !== val.format(probe)
+  ) {
+    console.error(
+      "An `Intl.DateTimeFormat` does not survive serialization; it will format differently after resume:",
+      { locale, ...options },
+    );
+  }
 }
 
 function writeIntlLocale(state: State, val: Intl.Locale) {


### PR DESCRIPTION
Serializing an `Intl` formatter rebuilds it from `resolvedOptions()`, which is not a faithful round trip for `Intl.DateTimeFormat`: `ja` and `zh` full dates resolve `month` to a value that patterns differently, so a date renders one way on the server and another after resume. A sweep of 416 locale/option combinations found 24 that diverge, all `ja`/`zh`.

The options cannot be recovered from a built formatter, so rather than change behavior this adds a `MARKO_DEBUG` check that rebuilds the formatter from the options it just wrote and compares a probe format, reporting the mismatch. Optimized output is unchanged.