### PR TITLE
fix(compiler): preserve whitespace-preserving tag bodies in source output

### DIFF
--- a/.changeset/preserve-whitespace-printer.md
+++ b/.changeset/preserve-whitespace-printer.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Stop the source printer reindenting the body of a whitespace-preserving tag (`pre`, `script`, `style`, `textarea`), which rewrote user content on every `output: "source"` / `markoc --migrate` pass.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -74,12 +74,6 @@ HTML `_attrs` picks an `<input>`'s controllable from the change handler (`data.c
 
 `analyzeTagNameType` downgrades a custom tag whose child template is Class API to `TagNameType.DynamicTag` but leaves `extra.tagNameLoad` attached, so `translate.exit`'s DOM branch still sees `allKnownTagReferences` and deletes the whole `import Child … with { load: … }`, while the compat dynamic-tag path never reads `tagNameLoad` and emits a bare `$dynamicTag($scope, Child, …)`. `Child` is left undeclared, so `$setup` throws `ReferenceError` at first render with zero diagnostics, and every `fixtures-interop/lazy-class-child*` fixture uses a Class parent, so this direction is uncovered. Either wire `tagNameLoad` into the compat path or `buildCodeFrameError` in `analyze` when a `load` import resolves to a Class-API template. Re-verify: compile a `<!-- use tags -->` parent holding that import plus `<Child value=1/>` against a `class {}` child with `{ output: "dom", linkAssets, translator: "marko/translator" }`; Babel puts `Child` in the Program scope's `globals`, empty with a Tags-API child.
 
-## Skip the source printer's reindent for whitespace-preserving tags
-
-`patches/@babel__generator@7.29.7.patch` › `MarkoTag` | 2026-07-27 | impact:med | effort:med
-
-The patched `MarkoTag` printer wraps every non-void body in `newline(1)`/`indent()`/`dedent()` plus a trailing `newline(1)`, guarded only by `voidElements`, `svgElements` and the concise `style`/`script` forms — never by the `parse-options.preserveWhitespace` tags (`pre`, `script`, `style`, `textarea`) declared in `packages/compiler/src/taglib/marko-html.json`. Those bodies render verbatim, so `output:"source"`/`"migrate"` silently rewrites user content and never reaches a fixed point, and `packages/runtime-class/bin/markoc.js --migrate` rewrites each file in place. Add a `preserveWhitespaceElements` set beside `voidElements` and print those bodies with no newline/indent (the concise `style { … }` branch is the shape to copy); the committed `packages/runtime-class/test/translator/fixtures/{textarea-tag,white-space-test}/snapshots/generated-expected.marko` already bake the extra whitespace and need refreshing. Re-verify: round-tripping `<textarea>abc</textarea>` through `output:"source"` turns the `output:"html"` result's `_textarea_value("abc")` into `_textarea_value("  abc\n")`.
-
 ## Queue pending `onNextSibling` callbacks in the inline reorder runtime
 
 `packages/runtime-tags/src/html/inlined-runtimes.debug.ts` › `REORDER_RUNTIME_CODE` | 2026-07-10 | impact:low | effort:med

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/cjs-expected.js
@@ -1,0 +1,23 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+var _index = require("marko/src/runtime/html/index.js");
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = exports.default = _marko_template;
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
+  out.w("<html-script>");
+  out.w("\n  console.log(\"hi\");\n");
+  out.w("</html-script>");
+  out.w("<html-style>");
+  out.w("\n  div { color: green }\n");
+  out.w("</html-style>");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/generated-expected.marko
@@ -1,0 +1,6 @@
+<html-script>
+  console.log("hi");
+</html-script>
+<html-style>
+  div { color: green }
+</html-style>

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/html-expected.js
@@ -1,0 +1,18 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.w("<html-script>");
+  out.w("\n  console.log(\"hi\");\n");
+  out.w("</html-script>");
+  out.w("<html-style>");
+  out.w("\n  div { color: green }\n");
+  out.w("</html-style>");
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/htmlProduction-expected.js
@@ -1,0 +1,12 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "HSQu5Ew",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.w("<html-script>\n  console.log(\"hi\");\n</html-script><html-style>\n  div { color: green }\n</html-style>");
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/vdom-expected.js
@@ -1,0 +1,22 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.be("html-script", null, "0", _component, null, 0);
+  out.t("\n  console.log(\"hi\");\n", _component);
+  out.ee();
+  out.be("html-style", null, "1", _component, null, 0);
+  out.t("\n  div { color: green }\n", _component);
+  out.ee();
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/snapshots/vdomProduction-expected.js
@@ -1,0 +1,20 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "HSQu5Ew",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_constElement from "marko/dist/runtime/vdom/helpers/const-element.js";
+const _marko_node = _marko_constElement("html-script", null, 1).t("\n  console.log(\"hi\");\n");
+const _marko_node2 = _marko_constElement("html-style", null, 1).t("\n  div { color: green }\n");
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.n(_marko_node, _component);
+  out.n(_marko_node2, _component);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/html-script-style-tag/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/html-script-style-tag/template.marko
@@ -1,0 +1,6 @@
+<html-script>
+  console.log("hi");
+</html-script>
+<html-style>
+  div { color: green }
+</html-style>

--- a/packages/runtime-class/test/translator/fixtures/placeholders/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/placeholders/snapshots/generated-expected.marko
@@ -1,13 +1,9 @@
 <div>
   ${input.x}${"Hello world <a/>"}$!{input.x}$!{null}$!{"Hello world <a/>"}
   <script>
-    
     ${"Hello <b> </script>"}
-  
   </script>
   <style>
-    
     ${"Hello <b> </style>"}
-  
   </style>
 </div>

--- a/packages/runtime-class/test/translator/fixtures/sanity-check/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/sanity-check/snapshots/generated-expected.marko
@@ -6,16 +6,12 @@ style {
   }
 }
 <style id="css">
-  
   div {
     color: ${x};
   }
-
 </style>
 <script>
-  
   var y = ${x};
-
 </script>
 static {
   doThings();

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/cjs-expected.js
@@ -1,0 +1,22 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+var _index = require("marko/src/runtime/html/index.js");
+var _attr = _interopRequireDefault(require("marko/src/runtime/html/helpers/attr.js"));
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = exports.default = _marko_template;
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (input, out, _componentDef, _component, state, $global) {
+  out.w(`<script${(0, _attr.default)("value", () => {
+    const a = 1;
+    console.log(a);
+  })}></script>`);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/generated-expected.marko
@@ -1,0 +1,4 @@
+<script >
+  const a = 1;
+  console.log(a);
+</script>

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/html-expected.js
@@ -1,0 +1,17 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_attr from "marko/src/runtime/html/helpers/attr.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.w(`<script${_marko_attr("value", () => {
+    const a = 1;
+    console.log(a);
+  })}></script>`);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/htmlProduction-expected.js
@@ -1,0 +1,16 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "FRcM4Mh",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_attr from "marko/dist/runtime/html/helpers/attr.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.w(`<script${_marko_attr("value", () => {
+    const a = 1;
+    console.log(a);
+  })}></script>`);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/vdom-expected.js
@@ -1,0 +1,22 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.e("script", {
+    "value": () => {
+      const a = 1;
+      console.log(a);
+    }
+  }, "0", _component, 0, 0);
+}, {
+  t: _marko_componentType,
+  i: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/snapshots/vdomProduction-expected.js
@@ -1,0 +1,21 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "FRcM4Mh",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.e("script", {
+    "value": () => {
+      const a = 1;
+      console.log(a);
+    }
+  }, "0", _component, 0, 0);
+}, {
+  t: _marko_componentType,
+  i: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/script-body-override/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/script-body-override/template.marko
@@ -1,0 +1,4 @@
+<script value=() => {
+  const a = 1;
+  console.log(a);
+}/>

--- a/packages/runtime-class/test/translator/fixtures/svg-tag/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/svg-tag/snapshots/generated-expected.marko
@@ -2,12 +2,8 @@
   <circle cx="50" cy="50" r="40" stroke="black" stroke-width="3" fill="red"/>
   <!-- Maybe SVG's-->
   <a/>
-  <style>
-    div { color: green }
-  </style>
-  <script>
-    alert("Hello");
-  </script>
+  <style>div { color: green }</style>
+  <script>alert("Hello");</script>
   <title>
     Test
   </title>

--- a/packages/runtime-class/test/translator/fixtures/textarea-tag/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/textarea-tag/snapshots/generated-expected.marko
@@ -1,5 +1,3 @@
 <textarea>
-  
   hello world
-
 </textarea>

--- a/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/white-space-test/snapshots/generated-expected.marko
@@ -10,16 +10,10 @@
      Hello
   </div>
   <pre>
-    
     This should  
       be preserved
-    
-    <textarea>
-      nested
-    </textarea>
-    
+    <textarea>nested</textarea>
     still   preserved
-  
   </pre>
   <div>
     <div>

--- a/patches/@babel__generator@7.29.7.patch
+++ b/patches/@babel__generator@7.29.7.patch
@@ -1,9 +1,9 @@
 diff --git a/lib/generators/marko.js b/lib/generators/marko.js
 new file mode 100644
-index 0000000..16c2e02
+index 0000000000000000000000000000000000000000..ce3901856985a26fa933855208916d240d2b1a54
 --- /dev/null
 +++ b/lib/generators/marko.js
-@@ -0,0 +1,389 @@
+@@ -0,0 +1,405 @@
 +"use strict";
 +
 +const svgElements = new Set([
@@ -16,6 +16,16 @@ index 0000000..16c2e02
 +  'rect',
 +  'stop',
 +  'use'
++]);
++
++// Bodies of these render verbatim, so reindenting them rewrites user content.
++const preserveWhitespaceElements = new Set([
++  'html-script',
++  'html-style',
++  'pre',
++  'script',
++  'style',
++  'textarea'
 +]);
 +
 +const voidElements = new Set([
@@ -259,9 +269,15 @@ index 0000000..16c2e02
 +  } else {
 +    this.token(">");
 +    const bodyNodes = bodyOverride || zipAttributeTagsAndBody(node);
++    // A body override is statements, not verbatim text, so it still needs indenting.
++    const preserveWhitespace =
++      !bodyOverride && preserveWhitespaceElements.has(tagName);
 +    for (let i = 0; i < bodyNodes.length; i++) {
 +      const node = bodyNodes[i];
-+      if (i > 0 && isInlineMarkoNode(bodyNodes[i - 1]) && isInlineMarkoNode(node)) {
++      if (
++        preserveWhitespace ||
++        (i > 0 && isInlineMarkoNode(bodyNodes[i - 1]) && isInlineMarkoNode(node))
++      ) {
 +        this.print(node, false, true);
 +      } else {
 +        this.newline(1);
@@ -270,7 +286,7 @@ index 0000000..16c2e02
 +        this.dedent();
 +      }
 +    }
-+    if (bodyNodes.length > 0) this.newline(1);
++    if (bodyNodes.length > 0 && !preserveWhitespace) this.newline(1);
 +    this.token("</");
 +    if (!isDynamicTag) {
 +      this.token(tagName);
@@ -394,7 +410,7 @@ index 0000000..16c2e02
 +  return result;
 +}
 diff --git a/lib/nodes.js b/lib/nodes.js
-index 8754a38..4321759 100644
+index 8754a38931a98eba6dfc4621980cad6b952a93e0..4321759547d3df5c5f5c2a5832f4f1e8949bcb43 100644
 --- a/lib/nodes.js
 +++ b/lib/nodes.js
 @@ -16,4 +16,9 @@ for (const key of Object.keys(deprecatedGeneratorFunctions)) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 patchedDependencies:
-  '@babel/generator@7.29.7': 1cf8bf38ea4ea6a0ce1f6a646a2f2523e4721ad1b044b8806fab7591aeedda0a
+  '@babel/generator@7.29.7': 5201f57bde2ba46af9898d8fd637b4ab563fee7232625f30a7acda60e5a29a7f
   '@babel/helper-compilation-targets@7.29.7': e98b468bdfe20d08a48f6ee078ac991affe4c54d99c96a56ab50fb71b8601b03
   '@babel/traverse@7.29.7': 831f9092cade155e5b2c5b6b6109643387b1b7a674245caa9073652b8eac637c
   '@babel/types@7.29.7': 600297d6e82d0bae1c281caf15e85f8012e0c4faf86de92b0e2fe0de8652104e
@@ -27,7 +27,7 @@ importers:
         version: 7.29.7(supports-color@8.1.1)
       '@babel/generator':
         specifier: ^7.29.1
-        version: 7.29.7(patch_hash=1cf8bf38ea4ea6a0ce1f6a646a2f2523e4721ad1b044b8806fab7591aeedda0a)
+        version: 7.29.7(patch_hash=5201f57bde2ba46af9898d8fd637b4ab563fee7232625f30a7acda60e5a29a7f)
       '@babel/parser':
         specifier: ^7.29.3
         version: 7.29.7
@@ -3163,7 +3163,7 @@ snapshots:
   '@babel/core@7.29.7(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7(patch_hash=1cf8bf38ea4ea6a0ce1f6a646a2f2523e4721ad1b044b8806fab7591aeedda0a)
+      '@babel/generator': 7.29.7(patch_hash=5201f57bde2ba46af9898d8fd637b4ab563fee7232625f30a7acda60e5a29a7f)
       '@babel/helper-compilation-targets': 7.29.7(patch_hash=e98b468bdfe20d08a48f6ee078ac991affe4c54d99c96a56ab50fb71b8601b03)
       '@babel/helper-module-transforms': 7.29.7(@babel/core@7.29.7(supports-color@8.1.1))(supports-color@8.1.1)
       '@babel/helpers': 7.29.7
@@ -3180,7 +3180,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@babel/generator@7.29.7(patch_hash=1cf8bf38ea4ea6a0ce1f6a646a2f2523e4721ad1b044b8806fab7591aeedda0a)':
+  '@babel/generator@7.29.7(patch_hash=5201f57bde2ba46af9898d8fd637b4ab563fee7232625f30a7acda60e5a29a7f)':
     dependencies:
       '@babel/parser': 7.29.7
       '@babel/types': 7.29.7(patch_hash=600297d6e82d0bae1c281caf15e85f8012e0c4faf86de92b0e2fe0de8652104e)
@@ -3817,7 +3817,7 @@ snapshots:
   '@babel/traverse@7.29.7(patch_hash=831f9092cade155e5b2c5b6b6109643387b1b7a674245caa9073652b8eac637c)(supports-color@8.1.1)':
     dependencies:
       '@babel/code-frame': 7.29.7
-      '@babel/generator': 7.29.7(patch_hash=1cf8bf38ea4ea6a0ce1f6a646a2f2523e4721ad1b044b8806fab7591aeedda0a)
+      '@babel/generator': 7.29.7(patch_hash=5201f57bde2ba46af9898d8fd637b4ab563fee7232625f30a7acda60e5a29a7f)
       '@babel/helper-globals': 7.29.7
       '@babel/parser': 7.29.7
       '@babel/template': 7.29.7


### PR DESCRIPTION
The patched `MarkoTag` printer wrapped every non-void body in a newline and an indent, guarded only by void/SVG elements. Tags whose body renders verbatim — `pre`, `script`, `style`, `textarea` — were reindented too, so `output: "source"` and `markoc --migrate` rewrote user content: `<textarea>abc</textarea>` became `<textarea>\n  abc\n</textarea>`, changing the emitted `out.w("abc")` to `out.w("\\n  abc\\n")`. It also never reached a fixed point, so each migrate pass grew the file again.

Those bodies now print with no newline or indent. Five committed Marko 5 translator snapshots had baked in the extra whitespace and are refreshed here.