### PR TITLE
fix(runtime-tags): keep `undefined` in the `<let>` tag variable type

### DIFF
--- a/.changeset/let-undefined-type.md
+++ b/.changeset/let-undefined-type.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `<let>` dropping `undefined` from an explicitly typed value, so `<let/x=undefined as Foo | undefined>` can be reassigned `undefined` again.

--- a/packages/runtime-tags/tags/let.d.marko
+++ b/packages/runtime-tags/tags/let.d.marko
@@ -1,8 +1,7 @@
 /** File for types only, not actual implementation **/
 
-export interface Input<T, K = T> {
-  value?: T;
-  valueChange?: ((newValue: K) => void) | false | null;
-}
+export type Input<T = undefined, K = T> =
+  | { value: T; valueChange?: ((newValue: K) => void) | false | null }
+  | { value?: undefined; valueChange?: ((newValue: K) => void) | false | null };
 
 return=(input.value as T) valueChange=(input.valueChange as (newValue: K) => void)


### PR DESCRIPTION
Making `value` optional in `tags/let.d.marko` (#3852) had a side effect: TypeScript strips `undefined` from inference candidates for optional properties, so `<let/formData=undefined as FormData | undefined>` inferred `T = FormData` and rejected a later `formData = undefined`.

`Input` is now a union — a valued branch that keeps `value` required, so nothing is stripped, plus a valueless branch for `<let/x/>` backed by `T = undefined`. Valued inference, controllable `valueChange`, and excess-property checks are unchanged.

Fixes #3906