### PR TITLE
refactor(runtime-tags): delete dead persisted helpers

### DIFF
--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -171,25 +171,6 @@ export function _fill_join_for<T extends SignalFn>(
   return fillJoin(key, valueAccessor, join, dispatch);
 }
 
-// A read below one hop composes the owner-side dispatch down the branch
-// chain: `[accessor, index]` conditional hops, `[accessor]` loop hops.
-export function _fill_join_deep<T extends SignalFn>(
-  key: string,
-  valueAccessor: EncodedAccessor,
-  join: T,
-  hops: [EncodedAccessor, number?][],
-): T {
-  let dispatch: SignalFn = join;
-  for (let i = hops.length; i--;) {
-    const hop = hops[i];
-    dispatch =
-      hop.length > 1
-        ? _if_closure(hop[0], hop[1]!, dispatch)
-        : _for_closure(hop[0], dispatch);
-  }
-  return fillJoin(key, valueAccessor, join, dispatch);
-}
-
 // Deep closure positions of one key reassemble the indexed composite:
 // each registers at its compile-time index; one dispatcher selects per
 // subscriber, and a shaken position is simply absent (nothing to update).

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -1145,7 +1145,7 @@ export function _existing_scope(scopeId: number) {
 }
 
 export function _scope_with_id(scopeId: number) {
-  return $chunk.boundary.state.scopeRef(scopeId);
+  return scopeWithId($chunk.boundary.state, scopeId);
 }
 
 function scopeWithId(state: State, scopeId: number) {
@@ -1573,10 +1573,6 @@ export class State implements SerializeState {
     }
     this.hasWrittenResume = true;
     return this.runtimePrefix + RuntimeKey.Resume + "=[" + resumes + "]";
-  }
-
-  scopeRef(scopeId: number): ScopeInternals | undefined {
-    return scopeWithId(this, scopeId);
   }
 
   get runtimePrefix() {

--- a/packages/runtime-tags/src/translator/util/optional.ts
+++ b/packages/runtime-tags/src/translator/util/optional.ts
@@ -140,16 +140,6 @@ export function concat<T>(a: Opt<T>, b: Opt<T>): Opt<T> {
   return b;
 }
 
-export function indexOf<T>(data: Opt<T>, item: T) {
-  return data !== undefined
-    ? Array.isArray(data)
-      ? data.indexOf(item)
-      : data === item
-        ? 0
-        : -1
-    : -1;
-}
-
 export function size<T>(data: Opt<T>) {
   return data !== undefined ? (Array.isArray(data) ? data.length : 1) : 0;
 }

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -50,24 +50,12 @@ export function getShellId(section: Section) {
 }
 
 // A construct blocker drops the section's shell: patches diverging to it
-// fail closed to a document navigation. Reasons accumulate for the shell
-// decision (and future diagnostics), never re-derived at use sites.
-const [getShellBlockers] = createProgramState(
-  () => new Map<Section, string[]>(),
-);
+// fail closed to a document navigation. The reason argument documents the
+// call site; only the blocked set is consulted.
+const [getShellBlockers] = createProgramState(() => new Set<Section>());
 
-export function recordConstructBlocker(section: Section, reason: string) {
-  const blockers = getShellBlockers();
-  const reasons = blockers.get(section);
-  if (reasons) {
-    reasons.push(reason);
-  } else {
-    blockers.set(section, [reason]);
-  }
-}
-
-export function getConstructBlockers(section: Section) {
-  return getShellBlockers().get(section);
+export function recordConstructBlocker(section: Section, _reason: string) {
+  getShellBlockers().add(section);
 }
 
 export function isShellDropped(section: Section) {


### PR DESCRIPTION
Removes code the 2026-08 audit found dead: the never-emitted `_fill_join_deep` runtime helper, the `State.scopeRef` virtual indirection nothing overrides, the accumulated construct-blocker reason strings (only the blocked set is consulted), and the unused `optional.ts` `indexOf`. No behavior change; full suite passes.