### PR TITLE
fix(compiler): invalidate a cached template when an analyzed child changes

### DIFF
--- a/.changeset/olive-donuts-smile.md
+++ b/.changeset/olive-donuts-smile.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Invalidate a cached template when a child template it analyzed changes, including transitively.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -62,12 +62,6 @@ A reorder flush appends `<t hidden {commentPrefix}={reorderId}>reorderHTML</t>`,
 
 `preserveBoundary` is a per-call-site decision (`!tagsSerializeReason && …`), but `s(id, renderer, mode)` is emitted once per renderer and `boundaryModeByRenderer` in `packages/runtime-class/src/runtime/helpers/tags-compat/runtime-html.js` is keyed by renderer too. The order-dependence is fixed (commit fe76065063): any call site that cannot preserve truncates the emitted call to two arguments for the whole program, and `register` keeps a plain `true` sticky across modules. That fix is a downgrade, so one updating call site costs every inert call site of that class its split-component optimization. Carrying the mode on the per-call-site `_dynamic_tag` invocation would keep both, at the cost of a parameter every dynamic tag pays for — measure before taking it. Re-verify: `interop-mixed-boundary-split-tags-to-class` emits `s(…, renderer)` with no `"preserve"`, while `interop-self-interactive-split-tags-to-class` still emits it.
 
-## Fold `analyzedTags` into the compile cache's mtime invalidation
-
-`packages/compiler/src/babel-plugin/index.js` › `getMarkoFile` | 2026-07-27 | impact:low | effort:med
-
-`getMarkoFile` invalidates a cache entry on its content hash or a newer mtime among `metadata.marko.watchFiles`, which holds only taglib JSON and plugin paths; the child `.marko` templates analysis read go to `metadata.marko.analyzedTags`, which the loop ignores, so a shared cache serves a stale parent after a child edit. Reach is narrow — `@marko/vite` clears `baseConfig.cache` on every hot update — leaving `@marko/compiler/register` and direct `compile[Sync]` reuse. Any fix has to be transitive, so every cache hit would stat the whole subtree. Re-verify: `compileSync` one parent twice through a single `new Map()` cache, rewriting its child from `<return=1/>` to a stateful `<let/x=1/><button onClick(){x++}/><return=x/>` in between — output stays byte-identical with no `_el_resume`, while a fresh cache emits it.
-
 ## Round-trip `Intl.DateTimeFormat` through a form that preserves `month`/`weekday`, not `resolvedOptions()`
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeIntl` | 2026-07-31 | impact:med | effort:med

--- a/packages/compiler/src/babel-plugin/index.js
+++ b/packages/compiler/src/babel-plugin/index.js
@@ -173,21 +173,9 @@ function getMarkoFile(code, fileOpts, markoOpts) {
     if (cached.contentHash !== contentHash) {
       // File content changed, invalidate the cache.
       cached = undefined;
-    } else {
-      for (const watchFile of cached.file.metadata.marko.watchFiles) {
-        let mtime = Infinity;
-        try {
-          mtime = markoOpts.fileSystem.statSync(watchFile).mtime;
-        } catch {
-          // ignore
-        }
-
-        if (mtime > cached.time) {
-          // Some dependency changed, invalidate the cache.
-          cached = undefined;
-          break;
-        }
-      }
+    } else if (hasStaleDependency(cached, compileCache, markoOpts)) {
+      // Some dependency changed, invalidate the cache.
+      cached = undefined;
     }
   }
 
@@ -361,6 +349,43 @@ function getMarkoFile(code, fileOpts, markoOpts) {
     taglibConfig.fs = prevFs;
     setFileInternal(prevFile);
   }
+}
+
+function hasStaleDependency(cached, compileCache, markoOpts) {
+  const seen = new Set();
+  const pending = [cached.file.metadata.marko];
+  let meta;
+
+  while ((meta = pending.pop())) {
+    for (const watchFile of meta.watchFiles) {
+      if (isNewerThan(watchFile, cached.time, markoOpts)) return true;
+    }
+
+    // A child's own analysis feeds this file, so its children count too; a
+    // cached child carries the next level, and an uncached one ends the walk.
+    for (const analyzedTag of meta.analyzedTags || []) {
+      if (seen.has(analyzedTag)) continue;
+      seen.add(analyzedTag);
+      if (isNewerThan(analyzedTag, cached.time, markoOpts)) return true;
+
+      const child = compileCache.get(getTemplateId(markoOpts, analyzedTag));
+      if (child) pending.push(child.file.metadata.marko);
+    }
+  }
+
+  return false;
+}
+
+function isNewerThan(filename, time, markoOpts) {
+  // An unreadable dependency invalidates, since its contribution is unknown.
+  let mtime = Infinity;
+  try {
+    mtime = markoOpts.fileSystem.statSync(filename).mtime;
+  } catch {
+    // ignore
+  }
+
+  return mtime > time;
 }
 
 function shallowClone(data) {

--- a/packages/compiler/test/compile.test.js
+++ b/packages/compiler/test/compile.test.js
@@ -1,5 +1,6 @@
 import assert from "assert/strict";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 
 import {
@@ -72,6 +73,57 @@ describe("compiler/compile", () => {
 
     it("falls back for a translator that has no version", () =>
       assert.equal(getRuntimeVersion({}), "0.0.0"));
+  });
+
+  describe("cache", () => {
+    // Analysis reads through child templates, so an edit below the compiled
+    // file has to invalidate it even though its own content is unchanged.
+    const STATEFUL = `<let/x=1/>\n<button onClick() { x++ }>bump</button>\n<return=x/>\n`;
+
+    let dir;
+    beforeEach(() => {
+      dir = fs.mkdtempSync(path.join(os.tmpdir(), "marko-cache-"));
+      fs.mkdirSync(path.join(dir, "tags"));
+      fs.writeFileSync(
+        path.join(dir, "template.marko"),
+        `<my-child/x/>\n<div>\${x}</div>\n`,
+      );
+    });
+    afterEach(() => fs.rmSync(dir, { recursive: true, force: true }));
+
+    const writeTag = (name, src) => {
+      const file = path.join(dir, "tags", `${name}.marko`);
+      fs.writeFileSync(file, src);
+      // Pin the mtime ahead so invalidation does not race the clock's resolution.
+      const ahead = new Date(Date.now() + 1000);
+      fs.utimesSync(file, ahead, ahead);
+    };
+
+    const compileParent = (cache) =>
+      compileFileSync(path.join(dir, "template.marko"), {
+        cache,
+        output: "dom",
+        writeVersionComment: false,
+      }).code;
+
+    it("invalidates when an analyzed child changes", () => {
+      writeTag("my-child", `<return=1/>\n`);
+      const cache = new Map();
+      assert.doesNotMatch(compileParent(cache), /_var_resume/);
+
+      writeTag("my-child", STATEFUL);
+      assert.match(compileParent(cache), /_var_resume/);
+    });
+
+    it("invalidates when a transitively analyzed template changes", () => {
+      writeTag("my-child", `<my-grandchild/y/>\n<return=y/>\n`);
+      writeTag("my-grandchild", `<return=1/>\n`);
+      const cache = new Map();
+      assert.doesNotMatch(compileParent(cache), /_var_resume/);
+
+      writeTag("my-grandchild", STATEFUL);
+      assert.match(compileParent(cache), /_var_resume/);
+    });
   });
 
   it("keeps the compile error when compiling asynchronously", () =>


### PR DESCRIPTION
`getMarkoFile` invalidated a cache entry on its own content hash or a newer mtime among `metadata.marko.watchFiles`, which holds only taglib JSON and plugin paths. The child templates analysis reads go to `metadata.marko.analyzedTags`, which the loop ignored, so a shared cache served a stale parent after a child edit — dropping `_var_resume` for a tag variable whose child had become stateful, so the child's state was dead after hydration.

The invalidation walk now also follows `analyzedTags`, stepping through each cached child's own set so a grandchild edit invalidates too.

Reach is narrow: `@marko/vite` both clears the compiler cache on hot update and tracks `analyzedTags` itself, so this is for `@marko/compiler/register` and direct `compile[Sync]` callers that reuse a cache.