### PR TITLE
refactor(runtime-tags): shared capturesPatchAttr; shell construct blockers decided at analyze

### DIFF
--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -67,7 +67,7 @@ import {
   getSerializeSourcesForExpr,
   getSerializeSourcesForRef,
 } from "../util/serialize-reasons";
-import { getShellId, getShells, isShellDropped } from "../util/shell";
+import { getShellId, getShells } from "../util/shell";
 import {
   addValue,
   getSignal,
@@ -376,7 +376,7 @@ export default {
             // a bare `0` makes any addition reject the patch. (`singleChild`
             // and `skipParentEnd` are forced off above, so the two optional
             // marker args are always the unset placeholders here.)
-            const id = !isShellDropped(bodySection) && getShellId(bodySection);
+            const id = !bodySection.shellBlocked && getShellId(bodySection);
             forTagArgs.push(
               undefined,
               undefined,

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -63,7 +63,7 @@ import {
   getSerializeSourcesForExpr,
   type SerializeReasons,
 } from "../util/serialize-reasons";
-import { getShellId, getShells, isShellDropped } from "../util/shell";
+import { getShellId, getShells } from "../util/shell";
 import {
   addValue,
   getSignal,
@@ -338,7 +338,7 @@ export const IfTag = {
                         // divergence to the branch reject the patch.
                         const id =
                           branchBody &&
-                          !isShellDropped(branchBody) &&
+                          !branchBody.shellBlocked &&
                           getShellId(branchBody);
                         return id && getShells()?.[id]
                           ? t.stringLiteral(id)

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -144,6 +144,9 @@ export interface Section {
   /** Branch body whose selection can re-run on the client (classified at
    * persisted finalize): patch renders skip it and frames omit its entry. */
   isClientReselectable: true | undefined;
+  /** Branch whose shell would construct unfaithfully (state-fed holes/attrs,
+   * derived at persisted finalize): no shell ships, patches fail closed. */
+  shellBlocked: true | undefined;
   /** Input props this section renders as fed renderers: a patch poisons
    * while they are non-nullish (a stopgap, dropped once they dispatch). */
   opaqueRenderProps: string[] | undefined;
@@ -231,6 +234,7 @@ export function startSection(
       readsOwner: false,
       isBranch: false,
       isClientReselectable: undefined,
+      shellBlocked: undefined,
       opaqueRenderProps: undefined,
       structure: parentSection && !parentSection.structure ? null : [],
     };

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -5,7 +5,6 @@ import normalizeStringExpression from "./normalize-string-expression";
 import { isCapturePathSection } from "./persisted/structure";
 import { forEachSection, type Section, StructureKind } from "./sections";
 import { getResumeRegisterId } from "./signals";
-import { createProgramState } from "./state";
 import { resolveStructure, trimTrailingExits } from "./structure";
 
 declare module "@marko/compiler/dist/types" {
@@ -23,6 +22,15 @@ export function getShells() {
 // Builds every branch shell as pre-serialized frame chunks the html
 // output registers as data.
 export function buildShells() {
+  // Enclosing branches of a client-reselectable selection also construct
+  // unfaithfully: the frame cannot reproduce the selection inside them.
+  forEachSection((section) => {
+    if (section.isClientReselectable) {
+      for (let cur = section.parent; cur?.parent; cur = cur.parent) {
+        if (cur.isBranch) cur.shellBlocked = true;
+      }
+    }
+  });
   forEachSection((section) => {
     // Every capture-position branch body ships a shell, except
     // client-reselectable bodies: they never construct from a frame.
@@ -37,7 +45,9 @@ export function buildShells() {
     // Frame headers reserve `;`/`,`/space, which neither ids (normalized
     // at the source) nor walk codes can carry; the template part is free.
     if (shell) {
+      // The id interns even for a blocked shell so register ids stay stable.
       const id = getShellId(section);
+      if (section.shellBlocked) return;
       (getProgram().node.extra.persistedShells ??= {})[id] = shell[1]
         ? `${id};${shell[1]};${shell[0]}`
         : `${id},${shell[0]}`;
@@ -47,34 +57,6 @@ export function buildShells() {
 
 export function getShellId(section: Section) {
   return getResumeRegisterId(section, "shell");
-}
-
-// A construct blocker drops the section's shell: patches diverging to it
-// fail closed to a document navigation. Enclosing branches of a
-// client-reselectable selection derive as blocked; translate observations
-// (state-fed holes/attrs, server effects) add theirs via the recorder.
-const [getShellBlockers] = createProgramState(() => {
-  const blocked = new Set<Section>();
-  forEachSection((section) => {
-    if (section.isClientReselectable) {
-      for (let cur = section.parent; cur?.parent; cur = cur.parent) {
-        if (cur.isBranch) blocked.add(cur);
-      }
-    }
-  });
-  return blocked;
-});
-
-export function recordConstructBlocker(section: Section, _reason: string) {
-  getShellBlockers().add(section);
-}
-
-export function isShellDropped(section: Section) {
-  return getShellBlockers().has(section);
-}
-
-export function getDroppedShellIds() {
-  return [...getShellBlockers().keys()].map(getShellId);
 }
 
 // A branch's shell is its resolved structure — the same inert template and

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -76,7 +76,6 @@ import {
   isSameReason,
   type SerializeReason,
 } from "./serialize-reasons";
-import { isShellDropped } from "./shell";
 import { simplifyFunction } from "./simplify-fn";
 import { createSectionState } from "./state";
 import { toFirstExpressionOrBlock } from "./to-first-expression-or-block";
@@ -1195,7 +1194,7 @@ export function writeSignals(section: Section) {
           signal.section.isBranch &&
           isCapturePathSection(signal.section) &&
           isDirectClosure(signal.section, signal.referencedBindings) &&
-          !isShellDropped(signal.section) &&
+          !signal.section.shellBlocked &&
           !sectionHasServerEffect(signal.section)
         ) {
           // A direct state closure anchors its construct render on itself:

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -10,6 +10,7 @@ import { isOutputHTML, isPersisted } from "../util/marko-config";
 import normalizeStringExpression from "../util/normalize-string-expression";
 import { type Opt } from "../util/optional";
 import { constructRendersReads } from "../util/persisted/delivery";
+import { onFinalizePersisted } from "../util/persisted/lifecycle";
 import {
   ensurePersistedCaptureGroups,
   inClientReselectableStructure,
@@ -47,7 +48,6 @@ import {
   getSerializeSourcesForExpr,
 } from "../util/serialize-reasons";
 import { addSetupExpr } from "../util/setup-statements";
-import { recordConstructBlocker } from "../util/shell";
 import { addStatement } from "../util/signals";
 import { getPrevStaticSibling, isStaticText } from "../util/static-text";
 import * as structure from "../util/structure";
@@ -108,6 +108,22 @@ export default {
             `${getRuntimePath("dom")}/patch-text.feat`,
           );
           ensurePersistedCaptureGroups(() => valueExtra);
+          // A state-fed hole the construct cannot render faithfully (no
+          // seed fill or INIT closure) drops the branch's shell.
+          onFinalizePersisted(() => {
+            const holeSources = getSerializeSourcesForExpr(valueExtra);
+            if (
+              holeSources?.state &&
+              !holeSources.global &&
+              section.isBranch &&
+              !constructRendersReads(
+                section,
+                valueExtra.referencedBindings as Opt<Binding>,
+              )
+            ) {
+              section.shellBlocked = true;
+            }
+          });
         }
       }
     },
@@ -204,19 +220,6 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
       throw placeholder.buildCodeFrameError(
         "Persisted templates do not yet support `$global` contributions to stateful expressions.",
       );
-    }
-    // Seedable local state and direct parent-state closures both construct
-    // faithfully (seed fills + the registered INIT render every read);
-    // anything else state-fed still drops the shell.
-    if (
-      holeSources?.state &&
-      section.isBranch &&
-      !constructRendersReads(
-        section,
-        valueExtra.referencedBindings as Opt<Binding>,
-      )
-    ) {
-      recordConstructBlocker(section, "state-fed hole");
     }
     // A state-fed hole recomputes through the signal graph, and inside
     // client-owned structure delivery is owner fills: neither captures.

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -34,12 +34,7 @@ import {
 } from "../../util/sections";
 import { getScopeReasonDeclaration } from "../../util/serialize-guard";
 import { isReasonDynamic } from "../../util/serialize-reasons";
-import {
-  getDroppedShellIds,
-  getShellId,
-  getShells,
-  recordConstructBlocker,
-} from "../../util/shell";
+import { getShellId, getShells } from "../../util/shell";
 import {
   addWriteScopeBuilder,
   getBindingGetterIdentifier,
@@ -192,17 +187,14 @@ export default {
       if (persisted && shells) {
         // Branch shells, derived during analyze, register at server module
         // load so patches can ship constructible shells without the client
-        // bundling conditional content. Translate may have dropped some
-        // (state-fed holes construct unfaithfully).
+        // bundling conditional content.
         const active = { ...shells };
-        // Every blocker funnels through the recorded shell decision; the
-        // packaging below only reads it.
+        // The one translate-side blocker: `hasHTMLEffect` only exists once
+        // translate registers effects, so this drop cannot move to analyze.
         forEachSection((section) => {
-          if (shells[getShellId(section)] && sectionHasServerEffect(section)) {
-            recordConstructBlocker(section, "effect reads the server");
-          }
+          const id = getShellId(section);
+          if (active[id] && sectionHasServerEffect(section)) delete active[id];
         });
-        for (const id of getDroppedShellIds()) delete active[id];
         // Mount-effect register ids ride the shell's id token (entries
         // reference the bare id).
         forEachSection((section) => {

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -42,6 +42,7 @@ import {
 import normalizeStringExpression from "../../util/normalize-string-expression";
 import { includes, type Opt, push } from "../../util/optional";
 import { constructRendersReads } from "../../util/persisted/delivery";
+import { onFinalizePersisted } from "../../util/persisted/lifecycle";
 import {
   ensurePersistedCaptureGroups,
   inClientReselectableStructure,
@@ -72,6 +73,7 @@ import {
   getScopeIdIdentifier,
   getSection,
   type StructureVisit,
+  type Section,
 } from "../../util/sections";
 import {
   getPatchWriteOwnership,
@@ -84,7 +86,6 @@ import {
   getSerializeSourcesForExpr,
 } from "../../util/serialize-reasons";
 import { addSetupExpr, addSetupStatement } from "../../util/setup-statements";
-import { recordConstructBlocker } from "../../util/shell";
 import {
   addHTMLEffectCall,
   addStatement,
@@ -356,6 +357,36 @@ export default {
               ensurePersistedCaptureGroups(() => value.extra || {});
             }
           }
+          // A patched attr `capturesPatchAttr` rejects as state-fed makes the
+          // shell construct unfaithfully; see the placeholder's hole check.
+          onFinalizePersisted(() => {
+            if (
+              !tagSection.isBranch ||
+              inClientReselectableStructure(tagSection)
+            ) {
+              return;
+            }
+            for (const { name, value } of getUsedAttrs(tagName, node, true)
+              .staticAttrs) {
+              if (
+                isEventHandler(name) ||
+                (tagName === "option" && name === "value")
+              ) {
+                continue;
+              }
+              const sources = getSerializeSourcesForExpr(value.extra || {});
+              if (
+                sources?.state &&
+                !sources.global &&
+                !constructRendersReads(
+                  tagSection,
+                  value.extra?.referencedBindings as Opt<Binding>,
+                )
+              ) {
+                tagSection.shellBlocked = true;
+              }
+            }
+          });
         }
 
         if (spreadReferenceNodes) {
@@ -756,35 +787,6 @@ export default {
           }
         }
 
-        // A state-fed attribute recomputes client-side, and inside
-        // client-owned structure delivery is owner fills: neither captures.
-        const capturesPatchAttr = (name: string, value: t.Expression) => {
-          if (
-            !(isPersisted() && isCapturePathSection(tagSection)) ||
-            inClientReselectableStructure(tagSection)
-          ) {
-            return false;
-          }
-          const attrSources = getSerializeSourcesForExpr(value.extra || {});
-          if (!attrSources?.state) return true;
-          if (attrSources.global) {
-            throw tag.buildCodeFrameError(
-              `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
-            );
-          }
-          if (
-            tagSection.isBranch &&
-            !constructRendersReads(
-              tagSection,
-              value.extra?.referencedBindings as Opt<Binding>,
-            )
-          ) {
-            // A state-fed attribute never captures; see placeholder.
-            recordConstructBlocker(tagSection, "state-fed attribute");
-          }
-          return false;
-        };
-
         for (const attr of staticAttrs) {
           const { name, value } = attr;
           const { confident, computed } = value.extra || {};
@@ -804,7 +806,7 @@ export default {
               } else {
                 // The capture renders the attribute itself (expression
                 // appears once); ownership rides as trailing args.
-                if (capturesPatchAttr(name, value)) {
+                if (capturesPatchAttr(tag, tagSection, name, value)) {
                   write`${callRuntime(
                     `_patch_attr_${name as "class" | "style"}`,
                     getScopeIdIdentifier(tagSection),
@@ -842,7 +844,7 @@ export default {
               } else {
                 // The capture renders the attribute itself (expression
                 // appears once); ownership rides as trailing args.
-                if (capturesPatchAttr(name, value)) {
+                if (capturesPatchAttr(tag, tagSection, name, value)) {
                   write`${callRuntime(
                     "_patch_attr",
                     getScopeIdIdentifier(tagSection),
@@ -1146,37 +1148,6 @@ export default {
           }
         }
 
-        // The dom compile shares the capture gating (errors and construct
-        // blockers must match the html output) and imports the feature:
-        // an interactive page receives assets transitively through its dom
-        // program, so the analyze-phase asset import alone cannot load it.
-        const capturesPatchAttr = (name: string, value: t.Expression) => {
-          if (!(isPersisted() && isCapturePathSection(tagSection))) {
-            return false;
-          }
-          const attrSources = getSerializeSourcesForExpr(value.extra || {});
-          if (!attrSources?.state) {
-            importRuntimeFeature("patch-attr");
-            return true;
-          }
-          if (attrSources.global) {
-            throw tag.buildCodeFrameError(
-              `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
-            );
-          }
-          if (
-            tagSection.isBranch &&
-            !constructRendersReads(
-              tagSection,
-              value.extra?.referencedBindings as Opt<Binding>,
-            )
-          ) {
-            // A state-fed attribute never captures; see placeholder.
-            recordConstructBlocker(tagSection, "state-fed attribute");
-          }
-          return false;
-        };
-
         for (const attr of staticAttrs) {
           const { name, value } = attr;
           const { confident } = value.extra || {};
@@ -1187,7 +1158,11 @@ export default {
             case "style": {
               const helper = `_attr_${name}` as const;
               if (!confident) {
-                capturesPatchAttr(name, value);
+                // The dom compile shares the capture gating (errors must
+                // match html) and imports the feature the capture applies.
+                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                  importRuntimeFeature("patch-attr");
+                }
                 const nodeExpr = createScopeReadExpression(nodeBinding!);
                 const meta: DelimitedAttrMeta = {
                   staticItems: undefined,
@@ -1267,7 +1242,9 @@ export default {
                   ),
                 );
               } else {
-                capturesPatchAttr(name, value);
+                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                  importRuntimeFeature("patch-attr");
+                }
                 addStatement(
                   "render",
                   tagSection,
@@ -1415,6 +1392,30 @@ function getSpreadControllableValueProps(tagName: string) {
 }
 
 type RelatedControllable = ReturnType<typeof getRelatedControllable>;
+// A state-fed attribute recomputes client-side, and inside client-owned
+// structure delivery is owner fills: neither captures.
+function capturesPatchAttr(
+  tag: t.NodePath<t.MarkoTag>,
+  tagSection: Section,
+  name: string,
+  value: t.Expression,
+) {
+  if (
+    !(isPersisted() && isCapturePathSection(tagSection)) ||
+    inClientReselectableStructure(tagSection)
+  ) {
+    return false;
+  }
+  const attrSources = getSerializeSourcesForExpr(value.extra || {});
+  if (!attrSources?.state) return true;
+  if (attrSources.global) {
+    throw tag.buildCodeFrameError(
+      `Persisted templates do not yet support \`$global\` contributions to stateful expressions (\`${name}\` attribute).`,
+    );
+  }
+  return false;
+}
+
 export function getRelatedControllable(
   tagName: string,
   attrs: Record<string, t.MarkoAttribute | undefined>,


### PR DESCRIPTION
## Description

- The duplicated `capturesPatchAttr` closures in native-tag's html and dom translate arms are one module-level function; the dom arm gains the html arm's client-reselectable bail and imports the `patch-attr` feature explicitly at its call sites instead of as a side effect inside the gate.
- Shell construct blockers are now decided at analyze on a new `Section.shellBlocked` field (evaluated at persisted finalize, before `buildShells`), so a blocked section never gets a shell instead of building one and deleting it at translate. The state-fed attribute/hole recorders moved to their analyze arms; the client-reselectable-ancestor rule derives in `buildShells`; the one translate-only case (sections whose effects read the server, known only once `hasHTMLEffect` is set) is handled directly in the html packaging with a comment saying why. `recordConstructBlocker`, `isShellDropped`, `getDroppedShellIds`, and the translate-phase blocker set are deleted.

No behavior change: snapshots are byte-identical across the full suite.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.