### PR TITLE
refactor(runtime-tags): shell blocker reason codes; patch writers live in html/patch

### DIFF
--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -42,7 +42,22 @@ export { _content, _content_resume, _dynamic_tag } from "./html/dynamic-tag";
 export { forIn, forOf, forTo, forUntil } from "./html/for";
 export { _renderer_shells } from "./html/renderer-shells";
 export { _template } from "./html/template";
-export { _must_render, _template_persisted, renderPatch } from "./html/patch";
+export {
+  _must_render,
+  _patch_attr,
+  _patch_attr_class,
+  _patch_attr_style,
+  _patch_bind,
+  _patch_child,
+  _patch_control,
+  _patch_effect,
+  _patch_poison,
+  _patch_text,
+  _patch_value,
+  _patch_write,
+  _template_persisted,
+  renderPatch,
+} from "./html/patch";
 export {
   _attr_content,
   _await,
@@ -59,17 +74,6 @@ export {
   _if,
   _mask_group,
   _owned_guard,
-  _patch_attr,
-  _patch_attr_class,
-  _patch_attr_style,
-  _patch_bind,
-  _patch_control,
-  _patch_child,
-  _patch_effect,
-  _patch_poison,
-  _patch_text,
-  _patch_value,
-  _patch_write,
   _peek_scope_id,
   _persisted_ownership,
   _persisted_reason,

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -1,14 +1,30 @@
+import {
+  normalizeAttrValue,
+  stringifyClassObject,
+  stringifyStyleObject,
+  toDelimitedString,
+} from "../common/helpers";
 import type {
+  Accessor,
   RenderedTemplate,
   Template,
   TemplateInput,
 } from "../common/types";
 import { AccessorPrefix, PatchKey } from "../common/types";
+import { _attr, stringAttr } from "./attrs";
+import { _escape, _to_text } from "./content";
 import { serverRenderers } from "./renderer-shells";
+import { getRegistered, K_SCOPE_ID } from "./serializer";
 import { _template, type ServerRenderer, startRender } from "./template";
 import {
   _peek_scope_id,
+  getChunk,
+  getState,
+  isInResumedBranch,
+  maskGroup,
   patchPartial,
+  type ScopeInternals,
+  type SerializeReasonValue,
   State,
   withBranchId,
   writePatch,
@@ -230,6 +246,321 @@ class PatchState extends State {
     });
     return 1 as const;
   }
+}
+
+// Patch writers double as the output writers so the compiled template
+// evaluates each captured expression once.
+export function _patch_attr(
+  scopeId: number,
+  accessor: Accessor,
+  name: string,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    // `0` is the removal sentinel: normalized values are always strings and
+    // `undefined` entries are dropped entirely.
+    if (serverOwned(owned, group)) {
+      writePatch(scopeId, {
+        [PatchKey.Attr + accessor + " " + name]: normalizeAttrValue(value) ?? 0,
+      });
+    }
+  } else {
+    getChunk()!.needsWalk = true;
+  }
+
+  return _attr(name, value);
+}
+
+// Class/style normalize on the server into the same string the dom helper
+// writes, so the client applies them as plain attr entries.
+export function _patch_attr_class(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  return patchStringAttr(
+    scopeId,
+    accessor,
+    "class",
+    toDelimitedString(value, " ", stringifyClassObject),
+    owned,
+    group,
+  );
+}
+
+export function _patch_attr_style(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  return patchStringAttr(
+    scopeId,
+    accessor,
+    "style",
+    toDelimitedString(value, ";", stringifyStyleObject),
+    owned,
+    group,
+  );
+}
+
+// Links a child scope into its parent's entry: immediately when already
+// written (tag-variable children render first), else on its first write.
+export function _patch_child(
+  scopeId: number,
+  accessor: Accessor,
+  childScopeId: number,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    (state.patchParents ??= {})[childScopeId] = [scopeId, accessor];
+    const partial = state.patchPartials?.[childScopeId];
+    if (partial) {
+      writePatch(scopeId, {
+        [PatchKey.Child + accessor]: partial,
+      });
+    } else {
+      (state.patchPending ??= {})[childScopeId] = [
+        scopeId,
+        PatchKey.Child + accessor,
+      ];
+    }
+  }
+}
+
+// Emitted as the scope reason's complement (`$reason || _patch_value(...)`):
+// a page render serializes the value through the reason-gated scope write,
+// so only a patch (the falsy persisted reason) ever reaches here.
+export function _patch_value(
+  scopeId: number,
+  key: string,
+  value: unknown,
+  setup?: 1,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    // A scope-bound registration cannot ride the wire as data: a source
+    // entry at its bound scope re-binds it against the paired live scope,
+    // and the fill entry references the deposit instead.
+    let kind: string = PatchKey.Value;
+    const registered = !!value && getRegistered(value as WeakKey);
+    const bound =
+      registered && (registered.scope as ScopeInternals | undefined);
+    if (bound) {
+      const n = (state.patchBinds = (state.patchBinds || 0) + 1);
+      writePatch(bound[K_SCOPE_ID]!, {
+        [PatchKey.BindSource + n]: registered.id,
+      });
+      kind = PatchKey.ValueBind;
+      value = n;
+    }
+    if (setup) {
+      if (state.patchFlushed) {
+        throw new Error(
+          "A persisted patch cannot write after its frame flushed (async patch content is not supported).",
+        );
+      }
+      // Setup entries nest under `s`: the client applies them only to
+      // freshly constructed scopes, via the shell content's setup.
+      const partial = patchPartial(state, scopeId);
+      ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
+        kind + key
+      ] = value;
+    } else {
+      writePatch(scopeId, {
+        [kind + key]: value,
+      });
+    }
+  }
+  return "";
+}
+
+// A control entry: the kind (a `ControlledType` digit) rides the key
+// ahead of the node accessor, and the kind's registered helper applies
+// the value against the frame's final handler slot.
+export function _patch_control(
+  scopeId: number,
+  accessor: Accessor,
+  type: number,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  if (getState().writesPatches && serverOwned(owned, group)) {
+    writePatch(scopeId, { [PatchKey.Control + type + accessor]: value });
+  }
+  return "";
+}
+
+// Handler wiring: a scope-bound registration ships as a bind entry, any
+// other value rides the construct seeds as a plain write.
+export function _patch_bind(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  const state = getState();
+  if (state.writesPatches && serverOwned(owned, group)) {
+    const registered = !!value && getRegistered(value as WeakKey);
+    const bound =
+      registered && (registered.scope as ScopeInternals | undefined);
+    if (bound) {
+      // A scope-bound registration installs the way CSR setup does: the
+      // entry anchors at the scope this instance was registered against
+      // and names the child-link path down to the slot, so the factory
+      // receives its own live scope. A target the bound scope cannot
+      // reach through recorded links poisons (`0`): reject, never
+      // install a silently broken handler.
+      const boundId = bound[K_SCOPE_ID]!;
+      let depth = 0;
+      let cur: number | undefined = scopeId;
+      let link;
+      while (cur !== undefined && cur !== boundId) {
+        link = state.patchParents?.[cur];
+        if (!link?.[1]) {
+          cur = undefined;
+        } else {
+          depth++;
+          cur = link[0];
+        }
+      }
+      let entry: 0 | unknown[] = 0;
+      if (cur !== undefined) {
+        entry = new Array(depth + 2);
+        entry[0] = registered.id;
+        entry[depth + 1] = accessor;
+        for (let i = depth, scope = scopeId; i; i--) {
+          link = state.patchParents![scope]!;
+          entry[i] = link[1];
+          scope = link[0];
+        }
+      }
+      writePatch(cur ?? scopeId, {
+        [PatchKey.Bind + (state.patchBinds = (state.patchBinds || 0) + 1)]:
+          entry,
+      });
+    } else {
+      // Both forms where a construct is possible: the plain write reaches
+      // PAIRED scopes (a handler removed between frames clears its live
+      // slot), while the setup entry lands after a construct's seeds — a
+      // seed's first-render write resets the change slot, so walk-time
+      // installs cannot last.
+      const partial = patchPartial(state, scopeId);
+      partial[PatchKey.Write + accessor] = value;
+      if (isInResumedBranch()) {
+        ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
+          PatchKey.Write + accessor
+        ] = value;
+      }
+    }
+  }
+  return "";
+}
+
+// A patched scope write: setup entries nest under `s` AFTER the seeds, so
+// a controllable seed cannot clobber its handler.
+export function _patch_write(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  setup?: 1,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    if (setup) {
+      const partial = patchPartial(state, scopeId);
+      ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
+        PatchKey.Write + accessor
+      ] = value;
+    } else {
+      writePatch(scopeId, {
+        [PatchKey.Write + accessor]: value,
+      });
+    }
+  }
+  return "";
+}
+
+// No client patcher registers this kind, so applying the frame rejects
+// and the navigation fallback runs. A stopgap like the admission guard:
+// fed renderers should eventually dispatch like any dynamic hop.
+export function _patch_poison(scopeId: number) {
+  if (getState().writesPatches) {
+    writePatch(scopeId, { [PatchKey.Poison]: 1 });
+  }
+  return "";
+}
+
+export function _patch_effect(
+  scopeId: number,
+  registerId: string,
+  accessors: string,
+  globals?: 1,
+) {
+  if (getState().writesPatches) {
+    writePatch(scopeId, {
+      [(globals ? PatchKey.GlobalEffect : PatchKey.Effect) + registerId]:
+        accessors,
+    });
+  }
+  return "";
+}
+
+export function _patch_text(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    if (serverOwned(owned, group)) {
+      writePatch(scopeId, {
+        [PatchKey.Text + accessor]: _to_text(value),
+      });
+    }
+  } else {
+    getChunk()!.needsWalk = true;
+  }
+
+  return _escape(value);
+}
+
+function patchStringAttr(
+  scopeId: number,
+  accessor: Accessor,
+  name: string,
+  value: string,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    if (serverOwned(owned, group)) {
+      writePatch(scopeId, {
+        [PatchKey.Attr + accessor + " " + name]: value || 0,
+      });
+    }
+  } else {
+    getChunk()!.needsWalk = true;
+  }
+
+  return stringAttr(name, value);
+}
+
+// A patch write needs exclusive server ownership: a client contribution
+// means the live value wins, and a contribution-less group cannot change.
+function serverOwned(owned?: SerializeReasonValue, group?: number) {
+  return owned === undefined || maskGroup(owned, group!) === 2;
 }
 
 // Only a shell the server can ship rides an entry: a missing one makes a

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -4,14 +4,7 @@ import {
   assertValidLoopKey,
 } from "../common/errors";
 import { forIn, forOf, forTo, forUntil } from "../common/for";
-import {
-  isPromise,
-  normalizeAttrValue,
-  normalizeDynamicRenderer,
-  stringifyClassObject,
-  stringifyStyleObject,
-  toDelimitedString,
-} from "../common/helpers";
+import { isPromise, normalizeDynamicRenderer } from "../common/helpers";
 /* eslint-disable @typescript-eslint/no-this-alias */
 import { concat, forEach, type Opt, push } from "../common/opt";
 import {
@@ -24,11 +17,10 @@ import {
   ResumeSymbol,
 } from "../common/types";
 import { RendererProp } from "../common/types";
-import { _attr, attrAssignment, stringAttr } from "./attrs";
+import { attrAssignment } from "./attrs";
 import * as FlushStatus from "./constants/flush-status";
 import * as Mark from "./constants/mark";
 import * as RuntimeKey from "./constants/runtime-key";
-import { _escape, _to_text } from "./content";
 import { forInBy, forOfBy, forStepBy } from "./for";
 import {
   REORDER_RUNTIME_CODE,
@@ -37,7 +29,6 @@ import {
 import {
   K_SCOPE_ID,
   quote,
-  getRegistered,
   register as serializerRegister,
   type ScopeFlush,
   Serializer,
@@ -58,7 +49,7 @@ interface SerializeState {
   flushScopes: boolean;
 }
 
-type ScopeInternals = PartialScope & {
+export type ScopeInternals = PartialScope & {
   [K_SCOPE_ID]?: number;
 };
 
@@ -277,314 +268,6 @@ export function patchPartial(state: State, scopeId: number) {
     }
   }
   return partial;
-}
-
-// Patch writers double as the output writers so the compiled template
-// evaluates each captured expression once.
-export function _patch_attr(
-  scopeId: number,
-  accessor: Accessor,
-  name: string,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches) {
-    // `0` is the removal sentinel: normalized values are always strings and
-    // `undefined` entries are dropped entirely.
-    if (serverOwned(owned, group)) {
-      writePatch(scopeId, {
-        [PatchKey.Attr + accessor + " " + name]: normalizeAttrValue(value) ?? 0,
-      });
-    }
-  } else {
-    $chunk.needsWalk = true;
-  }
-
-  return _attr(name, value);
-}
-
-// Class/style normalize on the server into the same string the dom helper
-// writes, so the client applies them as plain attr entries.
-export function _patch_attr_class(
-  scopeId: number,
-  accessor: Accessor,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  return patchStringAttr(
-    scopeId,
-    accessor,
-    "class",
-    toDelimitedString(value, " ", stringifyClassObject),
-    owned,
-    group,
-  );
-}
-
-export function _patch_attr_style(
-  scopeId: number,
-  accessor: Accessor,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  return patchStringAttr(
-    scopeId,
-    accessor,
-    "style",
-    toDelimitedString(value, ";", stringifyStyleObject),
-    owned,
-    group,
-  );
-}
-
-function patchStringAttr(
-  scopeId: number,
-  accessor: Accessor,
-  name: string,
-  value: string,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches) {
-    if (serverOwned(owned, group)) {
-      writePatch(scopeId, {
-        [PatchKey.Attr + accessor + " " + name]: value || 0,
-      });
-    }
-  } else {
-    $chunk.needsWalk = true;
-  }
-
-  return stringAttr(name, value);
-}
-
-// Links a child scope into its parent's entry: immediately when already
-// written (tag-variable children render first), else on its first write.
-export function _patch_child(
-  scopeId: number,
-  accessor: Accessor,
-  childScopeId: number,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches) {
-    (state.patchParents ??= {})[childScopeId] = [scopeId, accessor];
-    const partial = state.patchPartials?.[childScopeId];
-    if (partial) {
-      writePatch(scopeId, {
-        [PatchKey.Child + accessor]: partial,
-      });
-    } else {
-      (state.patchPending ??= {})[childScopeId] = [
-        scopeId,
-        PatchKey.Child + accessor,
-      ];
-    }
-  }
-}
-
-// Emitted as the scope reason's complement (`$reason || _patch_value(...)`):
-// a page render serializes the value through the reason-gated scope write,
-// so only a patch (the falsy persisted reason) ever reaches here.
-export function _patch_value(
-  scopeId: number,
-  key: string,
-  value: unknown,
-  setup?: 1,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches) {
-    // A scope-bound registration cannot ride the wire as data: a source
-    // entry at its bound scope re-binds it against the paired live scope,
-    // and the fill entry references the deposit instead.
-    let kind: string = PatchKey.Value;
-    const registered = !!value && getRegistered(value as WeakKey);
-    const bound =
-      registered && (registered.scope as ScopeInternals | undefined);
-    if (bound) {
-      const n = (state.patchBinds = (state.patchBinds || 0) + 1);
-      writePatch(bound[K_SCOPE_ID]!, {
-        [PatchKey.BindSource + n]: registered.id,
-      });
-      kind = PatchKey.ValueBind;
-      value = n;
-    }
-    if (setup) {
-      if (state.patchFlushed) {
-        throw new Error(
-          "A persisted patch cannot write after its frame flushed (async patch content is not supported).",
-        );
-      }
-      // Setup entries nest under `s`: the client applies them only to
-      // freshly constructed scopes, via the shell content's setup.
-      const partial = patchPartial(state, scopeId);
-      ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
-        kind + key
-      ] = value;
-    } else {
-      writePatch(scopeId, {
-        [kind + key]: value,
-      });
-    }
-  }
-  return "";
-}
-
-// A control entry: the kind (a `ControlledType` digit) rides the key
-// ahead of the node accessor, and the kind's registered helper applies
-// the value against the frame's final handler slot.
-export function _patch_control(
-  scopeId: number,
-  accessor: Accessor,
-  type: number,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  if ($chunk.boundary.state.writesPatches && serverOwned(owned, group)) {
-    writePatch(scopeId, { [PatchKey.Control + type + accessor]: value });
-  }
-  return "";
-}
-
-// Handler wiring: a scope-bound registration ships as a bind entry, any
-// other value rides the construct seeds as a plain write.
-export function _patch_bind(
-  scopeId: number,
-  accessor: Accessor,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches && serverOwned(owned, group)) {
-    const registered = !!value && getRegistered(value as WeakKey);
-    const bound =
-      registered && (registered.scope as ScopeInternals | undefined);
-    if (bound) {
-      // A scope-bound registration installs the way CSR setup does: the
-      // entry anchors at the scope this instance was registered against
-      // and names the child-link path down to the slot, so the factory
-      // receives its own live scope. A target the bound scope cannot
-      // reach through recorded links poisons (`0`): reject, never
-      // install a silently broken handler.
-      const boundId = bound[K_SCOPE_ID]!;
-      let depth = 0;
-      let cur: number | undefined = scopeId;
-      let link;
-      while (cur !== undefined && cur !== boundId) {
-        link = state.patchParents?.[cur];
-        if (!link?.[1]) {
-          cur = undefined;
-        } else {
-          depth++;
-          cur = link[0];
-        }
-      }
-      let entry: 0 | unknown[] = 0;
-      if (cur !== undefined) {
-        entry = new Array(depth + 2);
-        entry[0] = registered.id;
-        entry[depth + 1] = accessor;
-        for (let i = depth, scope = scopeId; i; i--) {
-          link = state.patchParents![scope]!;
-          entry[i] = link[1];
-          scope = link[0];
-        }
-      }
-      writePatch(cur ?? scopeId, {
-        [PatchKey.Bind + (state.patchBinds = (state.patchBinds || 0) + 1)]:
-          entry,
-      });
-    } else {
-      // Both forms where a construct is possible: the plain write reaches
-      // PAIRED scopes (a handler removed between frames clears its live
-      // slot), while the setup entry lands after a construct's seeds — a
-      // seed's first-render write resets the change slot, so walk-time
-      // installs cannot last.
-      const partial = patchPartial(state, scopeId);
-      partial[PatchKey.Write + accessor] = value;
-      if (isInResumedBranch()) {
-        ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
-          PatchKey.Write + accessor
-        ] = value;
-      }
-    }
-  }
-  return "";
-}
-
-// A patched scope write: setup entries nest under `s` AFTER the seeds, so
-// a controllable seed cannot clobber its handler.
-export function _patch_write(
-  scopeId: number,
-  accessor: Accessor,
-  value: unknown,
-  setup?: 1,
-) {
-  if ($chunk.boundary.state.writesPatches) {
-    if (setup) {
-      const partial = patchPartial($chunk.boundary.state, scopeId);
-      ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
-        PatchKey.Write + accessor
-      ] = value;
-    } else {
-      writePatch(scopeId, {
-        [PatchKey.Write + accessor]: value,
-      });
-    }
-  }
-  return "";
-}
-
-// No client patcher registers this kind, so applying the frame rejects
-// and the navigation fallback runs. A stopgap like the admission guard:
-// fed renderers should eventually dispatch like any dynamic hop.
-export function _patch_poison(scopeId: number) {
-  if ($chunk.boundary.state.writesPatches) {
-    writePatch(scopeId, { [PatchKey.Poison]: 1 });
-  }
-  return "";
-}
-
-export function _patch_effect(
-  scopeId: number,
-  registerId: string,
-  accessors: string,
-  globals?: 1,
-) {
-  if ($chunk.boundary.state.writesPatches) {
-    writePatch(scopeId, {
-      [(globals ? PatchKey.GlobalEffect : PatchKey.Effect) + registerId]:
-        accessors,
-    });
-  }
-  return "";
-}
-
-export function _patch_text(
-  scopeId: number,
-  accessor: Accessor,
-  value: unknown,
-  owned?: SerializeReasonValue,
-  group?: number,
-) {
-  const { state } = $chunk.boundary;
-  if (state.writesPatches) {
-    if (serverOwned(owned, group)) {
-      writePatch(scopeId, {
-        [PatchKey.Text + accessor]: _to_text(value),
-      });
-    }
-  } else {
-    $chunk.needsWalk = true;
-  }
-
-  return _escape(value);
 }
 
 export function _sep(shouldResume: number) {
@@ -1187,18 +870,12 @@ export function _persisted_ownership() {
   return state.writesPatches ? (state.serializeReason ?? 1) : 1;
 }
 
-function maskGroup(mask: SerializeReasonValue, group: number) {
+export function maskGroup(mask: SerializeReasonValue, group: number) {
   return mask === 1
     ? 2
     : typeof mask === "number"
       ? (mask >>> (1 + 2 * group)) & 3
       : ((mask as Partial<Record<number, number>>)[group] ?? 0);
-}
-
-// A patch write needs exclusive server ownership: a client contribution
-// means the live value wins, and a contribution-less group cannot change.
-function serverOwned(owned?: SerializeReasonValue, group?: number) {
-  return owned === undefined || maskGroup(owned, group!) === 2;
 }
 
 export function _owned_guard(mask: SerializeReasonValue, group: number) {

--- a/packages/runtime-tags/src/translator/util/constants/shell-blocker.ts
+++ b/packages/runtime-tags/src/translator/util/constants/shell-blocker.ts
@@ -1,0 +1,11 @@
+// Why a branch's shell would construct unfaithfully. Values are truthy
+// (readers test truthiness) and the first blocker recorded wins.
+
+// A state-fed hole/attr the construct cannot render: client state a
+// server fallback can never solve.
+export const stateFed = 1;
+// Encloses a client-reselectable selection the frame cannot reproduce.
+export const reselectableEnclosure = 2;
+
+type Self = typeof import("./shell-blocker");
+export type Value = Self[keyof Self];

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -9,6 +9,7 @@ import {
 import type { AccessorPrefix } from "../../common/accessor.debug";
 import type { WalkCode } from "../../common/types";
 import * as ContentType from "./constants/content-type";
+import type * as ShellBlocker from "./constants/shell-blocker";
 import type * as Step from "./constants/step";
 import * as StructureKind from "./constants/structure-kind";
 import { generateUid, generateUidIdentifier } from "./generate-uid";
@@ -144,9 +145,9 @@ export interface Section {
   /** Branch body whose selection can re-run on the client (classified at
    * persisted finalize): patch renders skip it and frames omit its entry. */
   isClientReselectable: true | undefined;
-  /** Branch whose shell would construct unfaithfully (state-fed holes/attrs,
-   * derived at persisted finalize): no shell ships, patches fail closed. */
-  shellBlocked: true | undefined;
+  /** Branch whose shell would construct unfaithfully: the first blocker's
+   * reason code sticks, no shell ships, patches fail closed. */
+  shellBlocked: ShellBlocker.Value | undefined;
   /** Input props this section renders as fed renderers: a patch poisons
    * while they are non-nullish (a stopgap, dropped once they dispatch). */
   opaqueRenderProps: string[] | undefined;

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import { getProgram } from "@marko/compiler/babel-utils";
 
+import * as ShellBlocker from "./constants/shell-blocker";
 import normalizeStringExpression from "./normalize-string-expression";
 import { isCapturePathSection } from "./persisted/structure";
 import { forEachSection, type Section, StructureKind } from "./sections";
@@ -27,7 +28,9 @@ export function buildShells() {
   forEachSection((section) => {
     if (section.isClientReselectable) {
       for (let cur = section.parent; cur?.parent; cur = cur.parent) {
-        if (cur.isBranch) cur.shellBlocked = true;
+        if (cur.isBranch) {
+          cur.shellBlocked ??= ShellBlocker.reselectableEnclosure;
+        }
       }
     }
   });

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -3,6 +3,7 @@ import { types as t } from "@marko/compiler";
 import { WalkCode } from "../../common/types";
 import { addAssetImport } from "../util/asset-imports";
 import { injectTextCoercion, kRawText } from "../util/body-to-text-literal";
+import * as ShellBlocker from "../util/constants/shell-blocker";
 import evaluate from "../util/evaluate";
 import { isCoreTagName } from "../util/is-core-tag";
 import { isNonHTMLText } from "../util/is-non-html-text";
@@ -121,7 +122,7 @@ export default {
                 valueExtra.referencedBindings as Opt<Binding>,
               )
             ) {
-              section.shellBlocked = true;
+              section.shellBlocked ??= ShellBlocker.stateFed;
             }
           });
         }

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -23,6 +23,7 @@ import {
   bodyToRawTextLiteral,
   bodyToTextLiteral,
 } from "../../util/body-to-text-literal";
+import * as ShellBlocker from "../../util/constants/shell-blocker";
 import evaluate from "../../util/evaluate";
 import { generateUidIdentifier } from "../../util/generate-uid";
 import {
@@ -383,7 +384,7 @@ export default {
                   value.extra?.referencedBindings as Opt<Binding>,
                 )
               ) {
-                tagSection.shellBlocked = true;
+                tagSection.shellBlocked ??= ShellBlocker.stateFed;
               }
             }
           });


### PR DESCRIPTION
## Description

- `Section.shellBlocked` is now a reason code (`util/constants/shell-blocker.ts`, binding-type idiom): `stateFed` for client-state holes/attrs and `reselectableEnclosure` for branches enclosing a client-reselectable selection. First blocker wins (`??=`); readers stay truthiness-based. This makes the blocked set measurable and lets a future fallback distinguish server-solvable blockers from ones that must stay fail-closed.
- The `_patch_*` helper bodies (eleven helpers plus private dependencies) move from `html/writer.ts` to `html/patch.ts`, so the shared writer stops carrying patch-only code. Compiled templates resolve helpers through the `html.ts` facade, so re-pointing its re-exports is the whole wiring change. `_persisted_reason`/`_persisted_ownership` stay in the writer — they share its serialize-reason internals with the page-side guards.

No behavior change: snapshots are byte-identical across the full suite.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.