### PR TITLE
test(runtime-tags): persisted async boundary matrix; fail closed with clear messages

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -149,3 +149,22 @@ client readers/writers should skip the passive write entirely.
 Re-verify: a template rendering only `<doubler/double value=input.n/>`
 into a second tag's attr, no other client code — the page bundle
 imports only feat modules.
+
+## Post-flush patch writes fail closed via two divergent channels
+
+`packages/runtime-tags/src/html/writer.ts` › `writePatch` | 2026-08-12 | impact:low | effort:med
+
+A patch frame has two fail-closed surfaces with different caller
+contracts: `patchPoison` (in `html/patch.ts` › `PatchState.resumeScript`)
+ships a poison frame the client rejects (`applyPatch` returns false →
+navigate), while a write after the frame flushed makes `writePatch`
+throw, rejecting the `renderPatch` async iterable mid-stream — after any
+earlier frame may already have applied to the DOM. The compile-time
+admission gate now rejects `<try>`/`<await>` so translator output cannot
+reach the throw, but the runtime is callable directly and any future
+async admission would surface as a stream error, not a poison frame.
+Suggested direction: on a post-flush write, set `patchPoison` and emit a
+poison frame from the next flush instead of throwing (or document that
+renderPatch consumers must navigate on rejection as well as on a false
+applyPatch). Re-verify: grep `patchFlushed` in `html/writer.ts` — the
+throw in `writePatch` vs the poison return in `resumeScript`.

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko:3:5
+      1 | <main>
+      2 |   <if=input.show>
+    > 3 |     <await|value|=input.promise>
+        |     ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      4 |       <em>${value}</em>
+      5 |     </await>
+      6 |   </if>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko:3:5
+      1 | <main>
+      2 |   <if=input.show>
+    > 3 |     <await|value|=input.promise>
+        |     ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      4 |       <em>${value}</em>
+      5 |     </await>
+      6 |   </if>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko:3:5
+      1 | <main>
+      2 |   <if=input.show>
+    > 3 |     <await|value|=input.promise>
+        |     ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      4 |       <em>${value}</em>
+      5 |     </await>
+      6 |   </if>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko:3:5
+      1 | <main>
+      2 |   <if=input.show>
+    > 3 |     <await|value|=input.promise>
+        |     ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      4 |       <em>${value}</em>
+      5 |     </await>
+      6 |   </if>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/template.marko
@@ -1,0 +1,10 @@
+<main>
+  <if=input.show>
+    <await|value|=input.promise>
+      <em>${value}</em>
+    </await>
+  </if>
+  <else>
+    <em>closed</em>
+  </else>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// An `<await>` inside a diverging server-driven branch (the construct case): fails closed at compile.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=resolveAfter(input.delay, 1)>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 | </main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=resolveAfter(input.delay, 1)>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 | </main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=resolveAfter(input.delay, 1)>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 | </main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=resolveAfter(input.delay, 1)>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 | </main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/template.marko
@@ -1,0 +1,7 @@
+import { resolveAfter } from "../../utils/resolve";
+<main>
+  <h1>${input.title}</h1>
+  <await|value|=resolveAfter(input.delay, 1)>
+    <em>${value}</em>
+  </await>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// An `<await>` still pending at patch flush time (the multi-frame case): the compile gate rejects it before the single-frame fence could be reached at runtime.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <@placeholder>loading</@placeholder>
+      4 |     <await|value|=input.promise>
+      5 |       <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <@placeholder>loading</@placeholder>
+      4 |     <await|value|=input.promise>
+      5 |       <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <@placeholder>loading</@placeholder>
+      4 |     <await|value|=input.promise>
+      5 |       <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <@placeholder>loading</@placeholder>
+      4 |     <await|value|=input.promise>
+      5 |       <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/template.marko
@@ -1,0 +1,9 @@
+<main>
+  <try>
+    <@placeholder>loading</@placeholder>
+    <await|value|=input.promise>
+      <em>${value}</em>
+    </await>
+    <@catch|err|><em>${err.message}</em></@catch>
+  </try>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// An `<await>` that rejects into an enclosing `<try>` catch during a patch render: fails closed at compile.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=input.promise>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 |   <button onClick() { count++ }>Count ${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=input.promise>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 |   <button onClick() { count++ }>Count ${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=input.promise>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 |   <button onClick() { count++ }>Count ${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/__snapshots__/error-compile-html.txt
@@ -1,0 +1,9 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko:4:3
+      2 | <main>
+      3 |   <h1>${input.title}</h1>
+    > 4 |   <await|value|=input.promise>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<await>` can settle after the patch frame flushes (async patch content is not supported).
+      5 |     <em>${value}</em>
+      6 |   </await>
+      7 |   <button onClick() { count++ }>Count ${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/template.marko
@@ -1,0 +1,8 @@
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <await|value|=input.promise>
+    <em>${value}</em>
+  </await>
+  <button onClick() { count++ }>Count ${count}</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// A settled `<await>` on the page with patched values inside and around it: async boundaries fail closed at compile even when the promise would settle before the frame flushes.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <em>${input.message}</em>
+      4 |     <@catch><em>bad</em></@catch>
+      5 |   </try>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <em>${input.message}</em>
+      4 |     <@catch><em>bad</em></@catch>
+      5 |   </try>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <em>${input.message}</em>
+      4 |     <@catch><em>bad</em></@catch>
+      5 |   </try>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <em>${input.message}</em>
+      4 |     <@catch><em>bad</em></@catch>
+      5 |   </try>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/template.marko
@@ -1,0 +1,6 @@
+<main>
+  <try>
+    <em>${input.message}</em>
+    <@catch><em>bad</em></@catch>
+  </try>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// A catch-only `<try>` (no `<await>`) whose body patches a server value: boundaries fail closed at compile regardless of async content.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-dom.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-dom.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <try>
+      4 |       <await|value|=input.promise>
+      5 |         <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-dom.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-dom.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <try>
+      4 |       <await|value|=input.promise>
+      5 |         <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-html.debug.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-html.debug.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <try>
+      4 |       <await|value|=input.promise>
+      5 |         <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-html.txt
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/__snapshots__/error-compile-html.txt
@@ -1,0 +1,8 @@
+
+    at packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko:2:3
+      1 | <main>
+    > 2 |   <try>
+        |   ^ Persisted templates cannot patch this faithfully yet: `<try>` boundaries rely on placeholder and catch machinery patches do not carry.
+      3 |     <try>
+      4 |       <await|value|=input.promise>
+      5 |         <em>${value}</em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/template.marko
@@ -1,0 +1,11 @@
+<main>
+  <try>
+    <try>
+      <await|value|=input.promise>
+        <em>${value}</em>
+      </await>
+      <@catch><em>inner</em></@catch>
+    </try>
+    <@catch><em>outer</em></@catch>
+  </try>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/test.ts
@@ -1,0 +1,7 @@
+import type { TestConfig } from "../../main.test";
+
+// Nested `<try>` boundaries around an `<await>`: the outer boundary fails closed at compile.
+export const config: TestConfig = {
+  error_compiler: true,
+  persisted: true,
+};

--- a/packages/runtime-tags/src/translator/util/persisted/admission.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/admission.ts
@@ -341,6 +341,16 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
       const { node } = tag;
       const tagName = t.isStringLiteral(node.name) && node.name.value;
       const tagDef = getTagDef(tag);
+      // A patch is one frame: `<await>` can settle after it flushes, and
+      // `<try>` recovery rides placeholder machinery a frame never carries.
+      if (isCoreTagName(tag, "await") || isCoreTagName(tag, "try")) {
+        unsupported(
+          node,
+          tagName === "await"
+            ? "`<await>` can settle after the patch frame flushes (async patch content is not supported)"
+            : "`<try>` boundaries rely on placeholder and catch machinery patches do not carry",
+        );
+      }
       // A server-driven conditional's patches swap in rendered html, so
       // branches must be inert; a pure-state chain is client-owned instead.
       if (isConditionTag(tag) || isCoreTagName(tag, "for")) {


### PR DESCRIPTION
## Description

Pins the persisted async-boundary support surface: six `persisted-async-*` fixtures (settled await, pending-at-flush, rejection into catch, nested try, catch-only try, await in a diverging branch) — the matrix future async support turns green. Investigation showed every `<try>`/`<await>` shape already fails closed at compile via the admission catch-all, so no runtime gate was needed; a dedicated admission check replaces the catch-all's misleading message with boundary-specific ones. Also records the dual post-flush fail-closed channels (stream throw vs poison frame) in agent-feedback for the eventual async implementation.

No behavior change outside new compile errors' wording; non-persisted output untouched.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.