### PR TITLE
fix(marko): hydrate a stateful Tags child under an inert Class component

### DIFF
--- a/.changeset/lucky-pandas-invite.md
+++ b/.changeset/lucky-pandas-invite.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Hydrate a stateful Tags-API template rendered through an inert Class-API component, which previously left it dead after server rendering.

--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,12 +2,6 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
-## Resume a stateful Tags-API descendant rendered through an inert Class-API parent
-
-`packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts` › `translate.exit` | 2026-07-13 | impact:high | effort:high
-
-A Tags page rendering an inert Class component (no class block) that renders a stateful Tags grandchild leaves the grandchild dead after SSR — its `<button onClick>` does nothing, in debug and optimize. `getClassHydrationMode` (`packages/runtime-class/src/translator/index.js`) detects interactivity only via `meta.component`, never a Tags child's `isInteractive` (on `program.node.extra`, not `metadata.marko`), so `classHydration` is undefined and the optimize path here (`!classHydration && !tagsSerializeReason` → `tag.remove()`) deletes the boundary outright; disabling that removal alone does not revive the button, so the resume gap is deeper. A fix likely needs the tags translator to surface interactivity on `metadata.marko`, `getClassHydrationMode` to return DESCENDANT for it, and the boundary to actually resume. Re-verify: with `template.marko` = `// use tags` + `<class-wrapper/>`, `components/class-wrapper.marko` = `<div><tags-counter/></div>` and `tags/tags-counter.marko` = `<let/n=0/><button onClick(){n++}>${n}</button>`, run `scripts/inspect-compiled-output.mts -t class -o dom` — today it emits `$setup = () => {}`.
-
 ## Wrap reordered out-of-order content in a parser-context-legal container
 
 `packages/runtime-tags/src/html/writer.ts` › `Chunk.flushScript` | 2026-07-23 | impact:high | effort:high

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -730,6 +730,12 @@ function getClassHydrationMode(file, visited = new Set()) {
     return (meta.classHydration = CLASS_HYDRATION_SELF);
   }
 
+  // A Tags template records interactivity on its program, not in metadata;
+  // it hydrates itself, so a Class ancestor has to keep the boundary.
+  if (file.ast.program.extra?.isInteractive) {
+    return (meta.classHydration = CLASS_HYDRATION_SELF);
+  }
+
   for (const tag of meta.tags) {
     if (tag.endsWith(".marko")) {
       const childFile = loadFileForImport(file, tag);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
@@ -1,42 +1,36 @@
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init();
-
-// v:template.marko.hydrate-5.js
-var v_template_marko_hydrate_5_default = () => {};
-
 // components/custom-tag.marko
 var import_vdom = require_vdom();
 const $template = "<button class=inc><!>,<!></button><!><!>";
 const $walks = " D%c%l%c";
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/3", 0, 0, 1);
-const $input_content__OR__x__OR__y = /*@__PURE__*/ _or(9, ($scope) => $dynamicTag($scope, $scope.input_content, () => [$scope.x, $scope.y]), 2);
-const $x = /*@__PURE__*/ _let("x/7", ($scope) => {
-	_text($scope["#text/1"], $scope.x);
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag(3, 0, 0, 1);
+const $input_content__OR__x__OR__y = /*@__PURE__*/ _or(9, ($scope) => $dynamicTag($scope, $scope.g, () => [$scope.h, $scope.i]), 2);
+const $x = /*@__PURE__*/ _let(7, ($scope) => {
+	_text($scope.b, $scope.h);
 	$input_content__OR__x__OR__y($scope);
 });
-const $y = /*@__PURE__*/ _let("y/8", ($scope) => {
-	_text($scope["#text/2"], $scope.y);
+const $y = /*@__PURE__*/ _let(8, ($scope) => {
+	_text($scope.c, $scope.i);
 	$input_content__OR__x__OR__y($scope);
 });
-const $setup__script = _script("__tests__/components/custom-tag.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$x($scope, +$scope.x + 1);
-	$y($scope, +$scope.y + 1);
+const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$x($scope, +$scope.h + 1);
+	$y($scope, +$scope.i + 1);
 }));
 function $setup($scope) {
 	$x($scope, 1);
 	$y($scope, 10);
 	$setup__script($scope);
 }
-const $input_content = /*@__PURE__*/ _const("input_content", $input_content__OR__x__OR__y);
+const $input_content = /*@__PURE__*/ _const(6, $input_content__OR__x__OR__y);
 const $input = ($scope, input) => $input_content($scope, input.content);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/components/custom-tag.marko", $template, $walks, $setup, $input);
+var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
 
 // template.marko
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
 var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
 var import_registry = require_registry();
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
 (0, import_registry.r)(_marko_componentType, () => _marko_template);
 const _marko_component = {};
 _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
@@ -50,7 +44,12 @@ _marko_template._ = (0, import_renderer.default)(function(input, out, _component
 	}, null, null, _componentDef, "0");
 }, {
 	t: _marko_componentType,
-	i: true,
-	d: true
+	i: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// components/tags-counter.marko
+var import_vdom = require_vdom();
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/components/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("__tests__/components/tags-counter.marko", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
@@ -1,0 +1,37 @@
+// components/tags-counter.marko
+var import_vdom = require_vdom();
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.c + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("b", $template, $walks, $setup);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,26 @@
+// components/tags-counter.marko
+var import_html = require_html();
+var tags_counter_default = _template("__tests__/components/tags-counter.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/components/tags-counter.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/components/tags-counter.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/html.bundle.js
@@ -1,0 +1,24 @@
+// components/tags-counter.marko
+var import_html = require_html();
+var tags_counter_default = _template("b", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "a", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true
+}, {});

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/render.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  <button
+    id="counter"
+  >
+    0
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <button
+    id="counter"
+  >
+    1
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/render.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  <button
+    id="counter"
+  >
+    0
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <button
+    id="counter"
+  >
+    1
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<div><button id=counter>0<!--Ms*1 #text/1--></button><!--Ms*1 #button/0--></div>
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/components/tags-counter.marko_0 1"
+  ];
+  M.s.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<div><button id=counter>0<!--Ms*1 b--></button><!--Ms*1 a--></div>
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [1, {
+    c: 0
+  }], "b0 1"];
+  M.s.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/components/tags-counter.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/components/tags-counter.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<button id="counter" onClick() { n++ }>${n}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
@@ -2,15 +2,19 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64733,
-        "brotli": 20275
+        "min": 64316,
+        "brotli": 20099
       },
       "files": {
-        "components/custom-tag.marko": 1076,
-        "template.marko": 1076,
+        "components/tags-counter.marko": 505,
+        "template.marko": 936,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }
     }
+  },
+  "html": {
+    "min": 374,
+    "brotli": 257
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/template.marko
@@ -1,0 +1,1 @@
+<div><tags-counter/></div>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function bump(document: Document) {
+  (document.querySelector("#counter") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, bump],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,47 @@
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// tags/tags-counter.marko
+var import_vdom = require_vdom();
+const $template$1 = "<button id=counter> </button>";
+const $walks$1 = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/tags/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup$1($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("__tests__/tags/tags-counter.marko", $template$1, $walks$1, $setup$1);
+
+// components/class-wrapper.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/components/class-wrapper.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+function $setup($scope) {
+	$dynamicTag($scope, _marko_template);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/dom.bundle.js
@@ -1,0 +1,37 @@
+// tags/tags-counter.marko
+var import_vdom = require_vdom();
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("c0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.c + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("c", $template, $walks, $setup);
+
+// components/class-wrapper.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "b", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,34 @@
+// tags/tags-counter.marko
+var import_html = require_html();
+var tags_counter_default = _template("__tests__/tags/tags-counter.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/tags/tags-counter.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/tags/tags-counter.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// components/class-wrapper.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "__tests__/components/class-wrapper.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+
+// template.marko
+s("__tests__/components/class-wrapper.marko", _marko_template, "preserve");
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_dynamic_tag($scope0_id, "#text/0", _marko_template, {}, 0, 0, 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/html.bundle.js
@@ -1,0 +1,31 @@
+// tags/tags-counter.marko
+var import_html = require_html();
+var tags_counter_default = _template("c", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "c0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+});
+
+// components/class-wrapper.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType = "b", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true
+}, {});
+
+// template.marko
+s("b", _marko_template, "preserve");
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_dynamic_tag(_scope_id(), "a", _marko_template, {}, 0, 0, 0);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/render.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  <button
+    id="counter"
+  >
+    0
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <button
+    id="counter"
+  >
+    1
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/render.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<div>
+  <button
+    id="counter"
+  >
+    0
+  </button>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <button
+    id="counter"
+  >
+    1
+  </button>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<!--M#_0-->
+<div><button id=counter>0<!--M_*3 #text/1--></button><!--M_*3 #button/0--></div>
+<!--M/-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      m5c: "_0",
+      m5i: {}
+    }, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/tags/tags-counter.marko_0 3"
+  ];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/components/class-wrapper.marko"
+    ]
+  });
+  M._.r.push("$compat_setScope 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/__snapshots__/writes.html
@@ -1,0 +1,21 @@
+<!--M#_0-->
+<div><button id=counter>0<!--M_*3 b--></button><!--M_*3 a--></div><!--M/-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    m5c: "_0",
+    m5i: {}
+  }, {
+    c: 0
+  }], "c0 3"];
+  M._.w();
+  $MC = (window.$MC || []).concat({
+    "p": "_",
+    "w": [
+      ["_0", 0, 2]
+    ],
+    "t": ["b"]
+  });
+  M._.r.push("$C_s 2");
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/components/class-wrapper.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/components/class-wrapper.marko
@@ -1,0 +1,1 @@
+<div><tags-counter/></div>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/sizes.json
@@ -2,15 +2,19 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64733,
-        "brotli": 20275
+        "min": 64316,
+        "brotli": 20061
       },
       "files": {
-        "components/custom-tag.marko": 1076,
-        "template.marko": 1076,
+        "tags/tags-counter.marko": 499,
+        "components/class-wrapper.marko": 952,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }
     }
+  },
+  "html": {
+    "min": 507,
+    "brotli": 335
   }
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/tags/tags-counter.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/tags/tags-counter.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<button id="counter" onClick() { n++ }>${n}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/template.marko
@@ -1,0 +1,2 @@
+// use tags
+<class-wrapper/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function bump(document: Document) {
+  (document.querySelector("#counter") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, bump],
+};


### PR DESCRIPTION
`getClassHydrationMode` only detected Class-API interactivity via `meta.component`. A Tags template records its own interactivity on `program.extra.isInteractive`, which never reached the class translator, so `classHydration` stayed undefined for an inert Class component wrapping a stateful Tags child.

That left the child dead after SSR — the boundary is deleted in optimize DOM (`dynamic-tag.ts`), compat registration is skipped in HTML, and the entry-graph walk in `add-dependencies.js` never visits the child, so no hydrate entry ships.

`getClassHydrationMode` now also reads the file's `program.extra.isInteractive`, the same way this file already probes `extra.featureType` for children. Nothing is added to `metadata.marko`.

Two fixtures, both red without the fix: a Tags page rendering an inert Class wrapper around a stateful Tags grandchild, and an inert Class page rendering a stateful Tags child. `custom-tag-parameters-from-args` was the same bug — its page entry now ships the hydrate entries its siblings already had.