### PR TITLE
build: let a mocha file argument scope the run

### DIFF
--- a/.mocharc.all.json
+++ b/.mocharc.all.json
@@ -1,0 +1,4 @@
+{
+  "extends": "./.mocharc.json",
+  "spec": ["packages/*/@(src|test)/**/*.test.@(js|ts)"]
+}

--- a/.mocharc.json
+++ b/.mocharc.json
@@ -8,6 +8,5 @@
     "max-old-space-size=8192",
     "max-semi-space-size=128"
   ],
-  "require": ["~ts"],
-  "spec": ["packages/*/@(src|test)/**/*.test.@(js|ts)"]
+  "require": ["~ts"]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,7 @@ All from repo root. Tests and tooling run directly from TS source (native Node t
 
 ```sh
 pnpm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run; bail: stops at first failure
+pnpm exec mocha <file.test.ts>                            # one file; `pnpm test -- <file>` still unions with the suite glob
 pnpm run test:parallel                                    # whole suite fanned across CPU cores (~3x faster than a serial pnpm test)
 pnpm run test:update -- --grep "..."                      # regenerate snapshots (review the diff!)
 pnpm run compile -- -o dom -d foo.marko                   # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)

--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -14,12 +14,6 @@ Two majors stay pinned because they are migrations, not refreshes. Babel is held
 
 `fixGuide(translator)` interpolates only the resolved cheatsheet path, so every thrown compile error gets the identical `Fix guide: READ <path> before writing a fix.` — verified: `<div` (EOF in open tag) and bare text at root produce byte-identical hints. `packages/runtime-tags/cheatsheet.md` is ~200 lines over 11 sections, and one label spans several causes (`Invalid attribute name.` covers both a bad attribute and unwrapped concise text), so a whole-file pointer cannot disambiguate. Pass the diagnostic (label/loc, or a hint the emitter attaches from its AST context) into `appendAgentFixGuide` and append a section anchor, e.g. `see 'Golden rules' #1 in <path>`. See also "Attach the agent fix-guide to `errorRecovery` diagnostics, not just thrown errors" — a separate coverage defect that wants the same diagnostic-keyed guide helper, so build it once. Re-verify: compile two differently-broken templates with `CLAUDECODE=1` and confirm the appended lines differ.
 
-## Document (or script) how to scope `npm test` to a single file
-
-`.mocharc.json` › `spec` | 2026-07-15 | impact:low | effort:low
-
-Positional file args are unioned with the configured `spec` glob rather than replacing it: with mocha 11.7.6, `mocha packages/runtime-tags/src/__tests__/serializer.test.ts` resolves `argv.spec` to `["…/serializer.test.ts", "packages/*/@(src|test)/**/*.test.@(js|ts)"]`, so the whole suite runs — silently, since the named file is included. `--spec <file>` merges the same way; only `--grep` or bypassing the config (`npx mocha --no-config --no-package --timeout 10000 --require ~ts <file>`) actually scopes a run. Add a `test:file` script that forwards to mocha without the default spec, or document the incantation in CLAUDE.md beside the existing `--grep` line. Re-verify by printing the resolved `argv.spec` from mocha's run-command handler.
-
 ## Serialize `Blob` and `File`, including inside `FormData`
 
 `packages/runtime-tags/src/html/serializer.ts` › `writeFormData` | 2026-07-23 | impact:med | effort:med

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
     "lint": "oxlint && oxfmt --check --with-node-modules .",
     "prepare": "husky && pnpm --filter @marko/compiler run build-babel-types",
     "report": "zcov report -r html && open ./coverage/index.html",
-    "test": "mocha",
+    "test": "mocha --config .mocharc.all.json",
     "test:parallel": "node scripts/test-parallel.js",
-    "test:update": "UPDATE_EXPECTATIONS=1 mocha",
+    "test:update": "UPDATE_EXPECTATIONS=1 mocha --config .mocharc.all.json",
     "test:update:parallel": "cross-env UPDATE_EXPECTATIONS=1 node scripts/test-parallel.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Mocha unions positional file args with a configured `spec` rather than replacing it, so `mocha packages/compiler/test/config.test.js` ran all 10771 tests — silently, since the named file is inside the glob. `--spec` merges the same way, and an `extends` config with `spec: []` cannot reset it.

Moves the suite glob out of `.mocharc.json` into a new `.mocharc.all.json` that extends it, and points `test` / `test:update` at that config. A bare file argument now scopes to that file; the full suite is unchanged. `test:parallel` was never affected — it uses `.mocharc.parallel.json` and its own glob.

Removes the `agent-feedback/dx.md` entry this implements.