### PR TITLE
docs(agent-feedback): state that entries are work, not documentation

### DIFF
--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -6,7 +6,7 @@ Actionable observations that were **out of scope for the task that surfaced them
 
 While working on any task, record anything a future contributor should act on:
 
-- a suspected bug you couldn't pursue → `bugs.md`
+- a suspected bug left unpursued → `bugs.md`
 - duplication, dead code, inconsistency, refactor opportunities → `cleanup.md`
 - runtime speed or bundle size opportunities → `perf.md`
 - friction in builds, tests, tooling, or repo workflows → `dx.md`
@@ -14,16 +14,17 @@ While working on any task, record anything a future contributor should act on:
 
 ## Rules
 
-1. **Search the category file first.** If an entry already covers it, don't duplicate; append a corroborating sentence only if you have new information.
-2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering your analysis. Never reference "my earlier analysis" or conversation context.
+1. **Search the category file first.** If an entry already covers it, don't duplicate; append a corroborating sentence only when it adds new information.
+2. **Be self-contained.** Include enough detail (paths, symbols, reasoning) that someone can act without re-discovering the analysis behind it. Never reference "my earlier analysis" or conversation context.
 3. **Cite by stable symbol, not line number.** Line numbers rot with the next edit; anchor the primary citation to the nearest enclosing stable symbol (exported function, class, variable, or a heading for docs). A line number may appear in the body as a secondary hint.
 4. **Append to the end** of the category file.
-5. Entries are **removed when resolved** (delete, don't mark done; git history is the archive), in **the same PR as the fix** — never a follow-up PR. A partial fix rewrites the entry to what remains.
+5. Entries are **removed when resolved** (delete, don't mark done; git history is the archive), in **the same PR as the fix**, never a follow-up PR. A partial fix rewrites the entry to what remains.
 6. **Verify before recording.** A guess is not feedback.
+7. **An entry is work to do, not documentation.** State the defect and the check that proves it. Never describe what already works, and never narrate what a landed fix changed.
 
 ## Resolving a "won't fix" item
 
-When a maintainer has explicitly deemed an item "won't fix" / "not worth it", resolve it by adding a brief inline comment at the code site that captures the decision (so it is not re-filed), then remove the entry. Only on such an explicit call — never on your own initiative.
+When a maintainer has explicitly deemed an item "won't fix" / "not worth it", resolve it by adding a brief inline comment at the code site that captures the decision (so it is not re-filed), then remove the entry. Only on such an explicit call, never on an agent's own initiative.
 
 ## Entry format
 
@@ -32,7 +33,7 @@ When a maintainer has explicitly deemed an item "won't fix" / "not worth it", re
 
 `<primary/file/path.ts>` › `<nearestStableSymbol>` | 2026-07-02 | impact:<low|med|high> | effort:<low|med|high>
 
-<2–6 sentences: the problem, why it matters, and a concrete suggested direction,
+<2-6 sentences: the problem, why it matters, and a concrete suggested direction,
 ending with the check that re-verifies the claim (a command, input, or
 observation). Cut evidence beyond what a fixer needs to act; further detail is
 re-derived from the citation. Additional file paths inline as needed.>


### PR DESCRIPTION
Rule 5 says a partial fix "rewrites the entry to what remains" without saying the fixed part must disappear, which reads as an invitation to narrate what landed. An entry that opens by describing a shipped diagnostic turns the worklist into a changelog and rots as soon as the code moves.

States that an entry is work to do, and that a partial fix leaves only the remainder.