### PR TITLE
feat(runtime-tags): persist lazy await resolution before and after its frame

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,27 @@
+// template.marko
+const $template = "<main><h1> </h1><!><button>Next</button></main>";
+const $walks = "E l%b l";
+const $await_content__value = ($scope, value) => _text($scope["#text/0"], value);
+const $await_content__$params = ($scope, $params2) => $await_content__value($scope, $params2[0]);
+const $placeholder_content = _content_resume("__tests__/template.marko_2*content", "loading");
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<em> </em>", "D ");
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0", $await_content__$params);
+const $try_content__n = /*@__PURE__*/ _closure_get("n", ($scope) => $try_content__await_promise($scope, resolveAfter("v" + $scope._.n, $scope._.n)));
+const $try_content__setup = ($scope) => {
+	$try_content__n($scope);
+	$await_content($scope);
+};
+const $n__closure = /*@__PURE__*/ _closure($try_content__n);
+const $n = /*@__PURE__*/ _let("n/6", $n__closure);
+const $try = /*@__PURE__*/ _try("#text/1", "<!><!><!>", "b%", $try_content__setup);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $input = ($scope, input) => $input_title($scope, input.title);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $await_content__value = ($scope, value) => _text($scope.a, value);
+const $await_content__$params = ($scope, $params2) => $await_content__value($scope, $params2[0]);
+const $placeholder_content = _content_resume("a0", "loading");
+const $try_content__await_promise = /*@__PURE__*/ _await_promise(0, $await_content__$params);
+const $try_content__n = /*@__PURE__*/ _closure_get(7, ($scope) => $try_content__await_promise($scope, resolveAfter("v" + $scope._.g, $scope._.g)));
+const $n = /*@__PURE__*/ _let(6, /* @__PURE__ */ _closure($try_content__n));
+const $setup__script = _script("a2", ($scope) => _on($scope.c, "click", function() {
+	$n($scope, +$scope.g + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const $n__closures = new Set();
+	let n = 0;
+	_html$1(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")}</h1>`);
+	_try$1($scope0_id, "#text/1", _content_resume$1("__tests__/template.marko_1*content", () => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _persisted_reason();
+		_await($scope1_id, "#text/0", resolveAfter("v" + n, n), (value) => {
+			const $scope3_id = _scope_id();
+			_html$1(`<em>${_escape(value)}${_el_resume($scope3_id, "#text/0")}</em>`);
+			writeScope($scope3_id, {}, "__tests__/template.marko", "8:6");
+		}, $scope1_reason || 0);
+		_subscribe($n__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "6:4"));
+		_resume_branch($scope1_id);
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume$1("__tests__/template.marko_2*content", () => {
+		const $scope2_reason = _persisted_reason();
+		const $scope2_id = _scope_id();
+		_html$1("loading");
+	}, $scope0_id) }) });
+	_html$1(`<button>Next</button>${_el_resume($scope0_id, "#button/2")}</main>`);
+	_script$1($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		n,
+		"ClosureScopes:n": $n__closures
+	}, "__tests__/template.marko", 0, { n: "3:6" });
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/html.bundle.js
@@ -1,0 +1,30 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const $n__closures = /* @__PURE__ */ new Set();
+	let n = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 0)}${_el_resume($scope0_id, "a")}</h1>`);
+	_try($scope0_id, "b", _content_resume("a1", () => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _persisted_reason();
+		_await($scope1_id, "a", resolveAfter("v0", n), (value) => {
+			const $scope3_id = _scope_id();
+			_html(`<em>${_escape(value)}${_el_resume($scope3_id, "a")}</em>`);
+			writeScope($scope3_id, {});
+		}, $scope1_reason || 0);
+		_subscribe($n__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
+		_resume_branch($scope1_id);
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a0", () => {
+		_persisted_reason();
+		_scope_id();
+		_html("loading");
+	}, $scope0_id) }) });
+	_html(`<button>Next</button>${_el_resume($scope0_id, "c")}</main>`);
+	_script($scope0_id, "a2");
+	$scope0_reason && writeScope($scope0_id, {
+		g: n,
+		h: $n__closures
+	});
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/patches.debug.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  "PatchText:#text/0": "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/patches.js
@@ -1,0 +1,4 @@
+// PATCH
+{
+  ta: "Store!"
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,119 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <em>
+    v0
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v0
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  loading
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + ::text("loading")
+REMOVE: main::text + em
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v1
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + em
+REMOVE: main > em + ::text("loading")
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  loading
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + ::text("loading")
+REMOVE: main::text + em
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v2
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + em
+REMOVE: main > em + ::text("loading")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/render-ssr.md
@@ -1,0 +1,119 @@
+# Render `{"title":"Store"}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <em>
+    v0
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+
+# Update `{"title":"Store!"}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v0
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  loading
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + ::text("loading")
+REMOVE: main::text + em
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v1
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + em
+REMOVE: main > em + ::text("loading")
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  loading
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + ::text("loading")
+REMOVE: main::text + em
+```
+
+# Update
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <em>
+    v2
+  </em>
+  <button>
+    Next
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > h1 + em
+REMOVE: main > em + ::text("loading")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/writes.debug.html
@@ -1,0 +1,20 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <!--M_[--><!--M_[--><em>v0<!--M_*3 #text/0--></em><!--M_]2 #text/0 3--><!--M_]1 #text/1 2--><button>Next</button><!--M_*1 #button/2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      n: 0,
+      "ClosureScopes:n": new Set([_(2)])
+    }, {
+      _: _(1),
+      "#BranchAccessor": "#text/1",
+      "#PlaceholderContent": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/template.marko_2*content"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/__snapshots__/writes.html
@@ -1,0 +1,16 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <!--M_[--><!--M_[--><em>v0<!--M_*3 a--></em><!--M_]2 a 3--><!--M_]1 b 2--><button>Next</button><!--M_*1 c-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: 0,
+    h: new Set([_(2)])
+  }, {
+    _: _(1),
+    C: "b",
+    Q: _(1, "a0")
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 10374,
+      "brotli": 4394
+    }
+  },
+  "html": {
+    "min": 501,
+    "brotli": 327
+  },
+  "patch": {
+    "min": 14,
+    "brotli": 18
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/template.marko
@@ -1,0 +1,13 @@
+import { resolveAfter } from "../../utils/resolve";
+
+<let/n=0/>
+<main>
+  <h1>${input.title}</h1>
+  <try>
+    <@placeholder>loading</@placeholder>
+    <await|value|=resolveAfter("v" + n, n)>
+      <em>${value}</em>
+    </await>
+  </try>
+  <button onClick() { n++ }>Next</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/test.ts
@@ -1,0 +1,21 @@
+import type { TestConfig } from "../../main.test";
+import { wait } from "../../utils/resolve";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A client-owned thenable re-resolves before and after a title patch;
+// the patch must not Pending/Child the live await.
+export const config: TestConfig = {
+  persisted: true,
+  equivalent: false,
+  steps: () => [
+    { title: "Store" },
+    click,
+    { title: "Store!" },
+    wait,
+    click,
+    wait,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,48 @@
+// template.marko
+const $template = "<main><h1> </h1><section><!></section><footer><!></footer><button>Count <!></button></main>";
+const $walks = "E lD%lD%l Db%m";
+const $await_content2__note = ($scope, note) => _text($scope["#text/0"], note);
+const $await_content2__$params = ($scope, $params3) => $await_content2__note($scope, $params3[0]);
+const $await_content__related = ($scope, related) => _text($scope["#text/0"], related);
+const $await_content__$params = ($scope, $params2) => $await_content__related($scope, $params2[0]);
+const $placeholder_content = _content_resume("__tests__/template.marko_2*content", "loading");
+const $await_content = /*@__PURE__*/ _await_content("#text/0", "<em> </em>", "D ");
+const $try_content__await_promise = /*@__PURE__*/ _await_promise("#text/0", $await_content__$params);
+const $try_content__input_related__OR__input_slow = /*@__PURE__*/ _or(1, ($scope) => $try_content__await_promise($scope, resolveAfter($scope._.input_related, $scope._.input_slow ? 1 : 0)));
+const $try_content__input_related = /*@__PURE__*/ _closure_get("input_related", $try_content__input_related__OR__input_slow);
+const $try_content__setup = ($scope) => {
+	$try_content__input_related($scope);
+	$try_content__input_slow($scope);
+	$await_content($scope);
+};
+const $try_content__input_slow = /*@__PURE__*/ _closure_get("input_slow", $try_content__input_related__OR__input_slow);
+const $count = /*@__PURE__*/ _let("count/12", ($scope) => _text($scope["#text/4"], $scope.count));
+const $try = /*@__PURE__*/ _try("#text/1", "<!><!><!>", "b%", $try_content__setup);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/3"], "click", function() {
+	$count($scope, +$scope.count + 1);
+}));
+function $setup($scope) {
+	$await_content2($scope);
+	$count($scope, 0);
+	$try($scope, { placeholder: attrTag({ content: $placeholder_content($scope) }) });
+	$setup__script($scope);
+}
+const $input_title = ($scope, input_title) => _text($scope["#text/0"], input_title);
+const $await_content2 = /*@__PURE__*/ _await_content("#text/2", "<span> </span>", "D ");
+const $await_promise = /*@__PURE__*/ _await_promise("#text/2", $await_content2__$params);
+const $input_slow__OR__input_note = /*@__PURE__*/ _or(11, ($scope) => $await_promise($scope, resolveAfter($scope.input_note, $scope.input_slow ? 2 : 0)));
+const $input_slow__closure = /*@__PURE__*/ _closure($try_content__input_slow);
+const $input_slow = /*@__PURE__*/ _const("input_slow", ($scope) => {
+	$input_slow__OR__input_note($scope);
+	$input_slow__closure($scope);
+});
+const $input_note = /*@__PURE__*/ _const("input_note", $input_slow__OR__input_note);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_related($scope, input.related);
+	$input_slow($scope, input.slow);
+	$input_note($scope, input.note);
+};
+const $input_related__closure = /*@__PURE__*/ _closure($try_content__input_related);
+const $input_related = /*@__PURE__*/ _const("input_related", $input_related__closure);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/dom.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+const $placeholder_content = _content_resume("a0", "loading");
+const $count = /*@__PURE__*/ _let(12, ($scope) => _text($scope.e, $scope.m));
+const $setup__script = _script("a2", ($scope) => _on($scope.d, "click", function() {
+	$count($scope, +$scope.m + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,46 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const $input_related__closures = new Set();
+	const $input_slow__closures = new Set();
+	let count = 0;
+	_html$1(`<main><h1>${_patch_text($scope0_id, "#text/0", input.title, $scope0_owned, 4)}${_el_resume($scope0_id, "#text/0")}</h1><section>`);
+	_try$1($scope0_id, "#text/1", _content_resume$1("__tests__/template.marko_1*content", () => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _persisted_reason();
+		_await($scope1_id, "#text/0", resolveAfter(input.related, input.slow ? 1 : 0), (related) => {
+			const $scope3_id = _scope_id();
+			_html$1(`<em>${_patch_text($scope3_id, "#text/0", related, $scope0_owned, 0)}${_el_resume($scope3_id, "#text/0")}</em>`);
+			writeScope($scope3_id, {}, "__tests__/template.marko", "9:8");
+		});
+		$scope0_reason && _subscribe(_source_if($scope0_reason, 6) && $input_slow__closures, _subscribe(_source_if($scope0_reason, 5) && $input_related__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "7:6")));
+		_resume_branch($scope1_id);
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume$1("__tests__/template.marko_2*content", () => {
+		const $scope2_reason = _persisted_reason();
+		const $scope2_id = _scope_id();
+		_html$1("loading");
+	}, $scope0_id) }) });
+	_html$1("</section><footer>");
+	_await($scope0_id, "#text/2", resolveAfter(input.note, input.slow ? 2 : 0), (note) => {
+		const $scope4_id = _scope_id();
+		_html$1(`<span>${_patch_text($scope4_id, "#text/0", note, $scope0_owned, 2)}${_el_resume($scope4_id, "#text/0")}</span>`);
+		writeScope($scope4_id, {}, "__tests__/template.marko", "15:6");
+	});
+	_html$1(`</footer><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "#text/4")}</button>${_el_resume($scope0_id, "#button/3")}</main>`);
+	_script$1($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, {
+		input_related: input.related,
+		input_slow: input.slow,
+		input_note: input.note,
+		count,
+		"ClosureScopes:input_related": $input_related__closures,
+		"ClosureScopes:input_slow": $input_slow__closures
+	}, "__tests__/template.marko", 0, {
+		input_related: ["input.related"],
+		input_slow: ["input.slow"],
+		input_note: ["input.note"],
+		count: "3:6"
+	});
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/html.bundle.js
@@ -1,0 +1,41 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const $input_related__closures = /* @__PURE__ */ new Set();
+	const $input_slow__closures = /* @__PURE__ */ new Set();
+	let count = 0;
+	_html(`<main><h1>${_patch_text($scope0_id, "a", input.title, $scope0_owned, 4)}${_el_resume($scope0_id, "a")}</h1><section>`);
+	_try($scope0_id, "b", _content_resume("a1", () => {
+		const $scope1_id = _scope_id();
+		_persisted_reason();
+		_await($scope1_id, "a", resolveAfter(input.related, input.slow ? 1 : 0), (related) => {
+			const $scope3_id = _scope_id();
+			_html(`<em>${_patch_text($scope3_id, "a", related, $scope0_owned, 0)}${_el_resume($scope3_id, "a")}</em>`);
+			writeScope($scope3_id, {});
+		});
+		$scope0_reason && _subscribe(_source_if($scope0_reason, 6) && $input_slow__closures, _subscribe(_source_if($scope0_reason, 5) && $input_related__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) })));
+		_resume_branch($scope1_id);
+	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a0", () => {
+		_persisted_reason();
+		_scope_id();
+		_html("loading");
+	}, $scope0_id) }) });
+	_html("</section><footer>");
+	_await($scope0_id, "c", resolveAfter(input.note, input.slow ? 2 : 0), (note) => {
+		const $scope4_id = _scope_id();
+		_html(`<span>${_patch_text($scope4_id, "a", note, $scope0_owned, 2)}${_el_resume($scope4_id, "a")}</span>`);
+		writeScope($scope4_id, {});
+	});
+	_html(`</footer><button>Count <!>${_escape(count)}${_el_resume($scope0_id, "e")}</button>${_el_resume($scope0_id, "d")}</main>`);
+	_script($scope0_id, "a2");
+	$scope0_reason && writeScope($scope0_id, {
+		i: input.related,
+		j: input.slow,
+		k: input.note,
+		m: count,
+		n: $input_related__closures,
+		o: $input_slow__closures
+	});
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/patches.debug.js
@@ -1,0 +1,20 @@
+// PATCH
+{
+  "PatchText:#text/0": "Store!",
+  "PatchChild:BranchScopes:#text/1": {
+    "PatchPending:#text/0": 1
+  },
+  "PatchPending:#text/2": 1
+}
+{
+  "PatchChild:BranchScopes:#text/1": {
+    "PatchChild:BranchScopes:#text/0": {
+      "PatchText:#text/0": "boots"
+    }
+  }
+}
+{
+  "PatchChild:BranchScopes:#text/2": {
+    "PatchText:#text/0": "backordered"
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/patches.js
@@ -1,0 +1,20 @@
+// PATCH
+{
+  ta: "Store!",
+  cAb: {
+    pa: 1
+  },
+  pc: 1
+}
+{
+  cAb: {
+    cAa: {
+      ta: "boots"
+    }
+  }
+}
+{
+  cAc: {
+    ta: "backordered"
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,199 @@
+# Render `{"title":"Store","related":"hats","note":"ready","slow":false}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <em>
+      hats
+    </em>
+  </section>
+  <footer>
+    <span>
+      ready
+    </span>
+  </footer>
+  <button>
+    Count 0
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <em>
+      hats
+    </em>
+  </section>
+  <footer>
+    <span>
+      ready
+    </span>
+  </footer>
+  <button>
+    Count 1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "0" => "1"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    loading
+  </section>
+  <footer />
+  <button>
+    Count 1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+INSERT: main > section::text("loading")
+REMOVE: main > section::text + em
+REMOVE: main > footer > span
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    loading
+  </section>
+  <footer />
+  <button>
+    Count 2
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "1" => "2"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer />
+  <button>
+    Count 2
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > section > em
+REMOVE: main > section > em + ::text("loading")
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer />
+  <button>
+    Count 3
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "2" => "3"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer>
+    <span>
+      backordered
+    </span>
+  </footer>
+  <button>
+    Count 3
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > footer > span
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer>
+    <span>
+      backordered
+    </span>
+  </footer>
+  <button>
+    Count 4
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "3" => "4"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/render-ssr.md
@@ -1,0 +1,199 @@
+# Render `{"title":"Store","related":"hats","note":"ready","slow":false}`
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <em>
+      hats
+    </em>
+  </section>
+  <footer>
+    <span>
+      ready
+    </span>
+  </footer>
+  <button>
+    Count 0
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store
+  </h1>
+  <section>
+    <em>
+      hats
+    </em>
+  </section>
+  <footer>
+    <span>
+      ready
+    </span>
+  </footer>
+  <button>
+    Count 1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "0" => "1"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    loading
+  </section>
+  <footer />
+  <button>
+    Count 1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > h1::text "Store" => "Store!"
+INSERT: main > section::text("loading")
+REMOVE: main > section::text + em
+REMOVE: main > footer > span
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    loading
+  </section>
+  <footer />
+  <button>
+    Count 2
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "1" => "2"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer />
+  <button>
+    Count 2
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > section > em
+REMOVE: main > section > em + ::text("loading")
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer />
+  <button>
+    Count 3
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "2" => "3"
+```
+
+# Update `{"title":"Store!","related":"boots","note":"backordered","slow":true}`
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer>
+    <span>
+      backordered
+    </span>
+  </footer>
+  <button>
+    Count 3
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > footer > span
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <h1>
+    Store!
+  </h1>
+  <section>
+    <em>
+      boots
+    </em>
+  </section>
+  <footer>
+    <span>
+      backordered
+    </span>
+  </footer>
+  <button>
+    Count 4
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > button::text@6 "3" => "4"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/writes.debug.html
@@ -1,0 +1,28 @@
+<main>
+  <h1>Store<!--M_*1 #text/0--></h1>
+  <section>
+    <!--M_[--><!--M_[--><em>hats<!--M_*3 #text/0--></em><!--M_]2 #text/0 3--><!--M_]1 #text/1 2-->
+  </section>
+  <footer><!--M_[--><span>ready<!--M_*4 #text/0--></span><!--M_]1 #text/2 4-->
+  </footer><button>Count <!>0<!--M_*1 #text/4--></button><!--M_*1 #button/3-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      input_related: "hats",
+      input_slow: !1,
+      input_note: "ready",
+      count: 0,
+      "ClosureScopes:input_related": new Set([_(2)]),
+      "ClosureScopes:input_slow": new Set([_(2)])
+    }, {
+      _: _(1),
+      "#BranchAccessor": "#text/1",
+      "#PlaceholderContent": _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/template.marko_2*content"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/__snapshots__/writes.html
@@ -1,0 +1,24 @@
+<main>
+  <h1>Store<!--M_*1 a--></h1>
+  <section>
+    <!--M_[--><!--M_[--><em>hats<!--M_*3 a--></em><!--M_]2 a 3--><!--M_]1 b 2-->
+  </section>
+  <footer><!--M_[--><span>ready<!--M_*4 a--></span><!--M_]1 c 4--></footer>
+  <button>Count <!>0<!--M_*1 e--></button><!--M_*1 d-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    i: "hats",
+    j: !1,
+    k: "ready",
+    m: 0,
+    n: new Set([_(2)]),
+    o: new Set([_(2)])
+  }, {
+    _: _(1),
+    C: "b",
+    Q: _(1, "a0")
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8420,
+      "brotli": 3656
+    }
+  },
+  "html": {
+    "min": 656,
+    "brotli": 381
+  },
+  "patch": {
+    "min": 80,
+    "brotli": 71
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/template.marko
@@ -1,0 +1,20 @@
+import { resolveAfter } from "../../utils/resolve";
+
+<let/count=0/>
+<main>
+  <h1>${input.title}</h1>
+  <section>
+    <try>
+      <@placeholder>loading</@placeholder>
+      <await|related|=resolveAfter(input.related, input.slow ? 1 : 0)>
+        <em>${related}</em>
+      </await>
+    </try>
+  </section>
+  <footer>
+    <await|note|=resolveAfter(input.note, input.slow ? 2 : 0)>
+      <span>${note}</span>
+    </await>
+  </footer>
+  <button onClick() { count++ }>Count ${count}</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/test.ts
@@ -1,0 +1,22 @@
+import type { TestConfig } from "../../main.test";
+import { navigate } from "../../utils/resolve";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// Thenables derived from input (not the nav promise) settle on different
+// ticks: prefix first, then each body, with a click between frames.
+export const config: TestConfig = {
+  persisted: true,
+  equivalent: false,
+  steps: () => [
+    { title: "Store", related: "hats", note: "ready", slow: false },
+    click,
+    navigate(
+      { title: "Store!", related: "boots", note: "backordered", slow: true },
+      click,
+    ),
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -24,8 +24,10 @@ import {
   type FlushType,
   isDestroy,
   isFlush,
+  isNavigate,
   isThrows,
   isWait,
+  type Navigate,
   resetResolveState,
   resolveAfter,
   type Throws,
@@ -46,6 +48,7 @@ type Step =
   | Flush
   | Destroy
   | Throws
+  | Navigate
   | ((document: Document) => unknown);
 type Steps = [Input, ...Step[]];
 export type TestConfig = {
@@ -407,11 +410,21 @@ function testFixtures(interop?: true) {
             await runSteps(steps, tracker, browser, run, {
               onFlush: hasFlush ? flushAndRun : undefined,
               onInput: persisted
-                ? async (input) => {
+                ? async (input, betweenFrames) => {
                     tracker.beginUpdate();
                     let applied = true;
                     const frames: string[] = [];
                     for await (const frame of template.renderPatch(input)) {
+                      if (frames.length && betweenFrames) {
+                        tracker.logUpdate(input);
+                        tracker.beginUpdate();
+                        await betweenFrames(browser.window.document);
+                        run();
+                        await browser.runAsyncScripts();
+                        run();
+                        tracker.logUpdate(betweenFrames);
+                        tracker.beginUpdate();
+                      }
                       frames.push(frame);
                       // A production caller navigates on the first failed
                       // frame; later frames must not mutate further.
@@ -608,7 +621,10 @@ async function runSteps(
   browser: ReturnType<typeof createBrowser>,
   run: () => void,
   opts: {
-    onInput?: (input: Input) => void | boolean | Promise<void | boolean>;
+    onInput?: (
+      input: Input,
+      betweenFrames?: (document: Document) => unknown,
+    ) => void | boolean | Promise<void | boolean>;
     onFlush?: () => Promise<void>;
     onDestroy?: () => void;
   },
@@ -651,7 +667,9 @@ async function runSteps(
         tracker.logUpdate(update);
       }
     } else if (opts.onInput) {
-      if ((await opts.onInput(update)) === false) break;
+      const input = isNavigate(update) ? update.navigateInput : update;
+      const between = isNavigate(update) ? update.betweenFrames : undefined;
+      if ((await opts.onInput(input, between)) === false) break;
     } else {
       // if new input is detected, stop testing
       // this will be covered by the client tests

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -96,6 +96,22 @@ export function isThrows(value: any): value is Throws {
   return typeof value === "function" && value.throws;
 }
 
+export type Navigate = {
+  navigateInput: Record<string, unknown>;
+  betweenFrames?: (document: Document) => unknown;
+};
+export function navigate(
+  input: Record<string, unknown>,
+  betweenFrames?: (document: Document) => unknown,
+): Navigate {
+  return { navigateInput: input, betweenFrames };
+}
+export function isNavigate(value: any): value is Navigate {
+  return (
+    typeof value === "object" && value !== null && "navigateInput" in value
+  );
+}
+
 export function resolveAfter<T>(value: T, id?: number) {
   const promise = getSharedPromise(id);
   return Object.assign(

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -995,6 +995,8 @@ export function _await<T>(
   const chunk = $chunk;
   const { boundary } = chunk;
   if (boundary.state.writesPatches) {
+    // serializeMarker 0: the client owns this await.
+    if (!resumeMarker) return;
     writePatch(scopeId, { [PatchKey.Pending + accessor]: 1 });
   }
   chunk.next = $chunk = chunk.fork(boundary, chunk.next);

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -33,7 +33,11 @@ import {
   setSectionParentIsOwner,
   startSection,
 } from "../util/sections";
-import { getSerializeGuard } from "../util/serialize-guard";
+import {
+  getSerializeGuard,
+  scopeReasonIdentifier,
+} from "../util/serialize-guard";
+import { getSerializeSourcesForExpr } from "../util/serialize-reasons";
 import { addSetupStatement } from "../util/setup-statements";
 import {
   addStatement,
@@ -169,6 +173,20 @@ export default {
         writer.flushInto(tag);
         writeHTMLResumeStatements(tagBody);
 
+        const valueSources = getSerializeSourcesForExpr(
+          valueAttr.value.extra || {},
+        );
+        // Client-owned thenables resolve via `_await_promise`; a patch
+        // must not Pending them (the body has no fills to Child).
+        const serializeGuard =
+          isPersisted() && !valueSources?.param && !valueSources?.global
+            ? t.logicalExpression(
+                "||",
+                scopeReasonIdentifier(section),
+                t.numericLiteral(0),
+              )
+            : getSerializeGuard(section, bodySection?.serializeReason, true);
+
         tag
           .replaceWith(
             t.expressionStatement(
@@ -181,7 +199,7 @@ export default {
                   node.body.params,
                   toFirstExpressionOrBlock(node.body.body),
                 ),
-                getSerializeGuard(section, bodySection?.serializeReason, true),
+                serializeGuard,
               ),
             ),
           )[0]


### PR DESCRIPTION
## Description

Thenables derived from input settle after the prefix frame, each body in resolution order. A client-owned `<await>` keeps resolving via `_await_promise`; a later patch no longer writes `Pending` for it (the body has no fills to `Child`).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.