### PR TITLE
test(runtime-tags): record head tag mutations

### DIFF
--- a/agent-feedback/dx.md
+++ b/agent-feedback/dx.md
@@ -14,12 +14,6 @@ Two majors stay pinned because they are migrations, not refreshes. Babel is held
 
 Neither type has a case in `writeUnknownObject`, and `writeFormData` aborts on any non-string entry ("`File`/`Blob` entries aren't serializable yet"), so a resumed form carrying an upload cannot be represented at all. Both hold binary content the existing `writeArrayBuffer`/`writeTypedArray` path already encodes and both rebuild from a constructor call (`new File([bytes], name, { type, lastModified })`); the work is reading the bytes and threading the async read through the boundary the way `writeReadableStream` does. Verify: `serializer.test.ts`'s "aborts on File/Blob values instead of dropping them" pins today's behavior, and a bare `new Blob(["hi"])` hits `throwUnserializable`.
 
-## Record `<style>`/`<title>`/`<link>` mutations in the render log; a dynamic `<style>` update snapshots as an empty step
-
-`packages/runtime-tags/src/__tests__/utils/get-node-info.ts` › `isIgnoredTag` | 2026-07-23 | impact:med | effort:med
-
-`isIgnoredTag` returns true for `T`, `LINK`, `TITLE`, `STYLE` and untyped/module `SCRIPT`, and `utils/track-mutations.ts` › `formatMutationRecord` drops any record whose target (or characterData parent) is ignored, so no committed `render*.md` contains a `<style`/`<title` change. `_style_rule_item` (`src/dom/dom.ts`) splices a CSS custom property into that `textContent`, yet `fixtures/style-tag-dynamic/__snapshots__/render-csr.debug.md` ends at the bare line ``# Update `{"color":"blue"}` `` — byte-identical to a no-op client update, with the path covered only by `assert` calls in `style-tag-dynamic-injection`'s steps. AGENTS.md tells reviewers to audit the mutation log, so this is a blind spot in the primary review artifact. Direction: ignore Marko-emitted asset/resume nodes (the `T` placeholder, resume `<script>`s, injected `<link>`s) rather than the element type, or always emit style/title text changes. Re-verify: read that snapshot and confirm the second step has no `## Change`.
-
 ## Raise the unresolvable-tag-name error during analyze; at translate its `<let>`/`<const>` hint is lost and only the first bad tag reports
 
 `packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts` › `tagNotFoundError` | 2026-07-23 | impact:med | effort:med

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/render.debug.md
@@ -1,1 +1,8 @@
 # Render `{"$global":{"cspNonce":"default-nonce","serializedGlobals":{"cspNonce":true}}}`
+
+# Update
+## Change
+```
+INSERT: style
+UPDATE: style[nonce] null => "default-nonce"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-nonce/__snapshots__/render.md
@@ -1,1 +1,8 @@
 # Render `{"$global":{"cspNonce":"default-nonce","serializedGlobals":{"cspNonce":true}}}`
+
+# Update
+## Change
+```
+INSERT: style
+UPDATE: style[nonce] null => "default-nonce"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/render.debug.md
@@ -4,13 +4,28 @@
 ```js
 document.querySelector("style").click();
 ```
-
-# Update
-```js
-document.querySelector("style").click();
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 0\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 1\n  }\n")
 ```
 
 # Update
 ```js
 document.querySelector("style").click();
+```
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 1\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 2\n  }\n")
+```
+
+# Update
+```js
+document.querySelector("style").click();
+```
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 2\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 3\n  }\n")
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style/__snapshots__/render.md
@@ -4,13 +4,28 @@
 ```js
 document.querySelector("style").click();
 ```
-
-# Update
-```js
-document.querySelector("style").click();
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 0\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 1\n  }\n")
 ```
 
 # Update
 ```js
 document.querySelector("style").click();
+```
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 1\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 2\n  }\n")
+```
+
+# Update
+```js
+document.querySelector("style").click();
+```
+## Change
+```
+REMOVE: style::text("\n  .test {\n    content: 2\n  }\n")
+INSERT: style::text("\n  .test {\n    content: 3\n  }\n")
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-comments-strings/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-comments-strings/__snapshots__/render-csr.debug.md
@@ -8,3 +8,15 @@
 ```
 
 # Update `{"color":"blue"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19comments-19strings-1btemplate-1amarko_0:green;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19comments-19strings-1btemplate-1amarko_0:blue;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/__snapshots__/render-csr.debug.md
@@ -18,6 +18,7 @@
 ```
 ## Change
 ```
+REMOVE: style
 REMOVE: div
 ```
 
@@ -34,5 +35,9 @@ REMOVE: div
 ```
 ## Change
 ```
-INSERT: .box
+INSERT: .cM_1, .box
+INSERT: .cM_1::text("--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19conditional-1btemplate-1amarko_0:blue;}")
+UPDATE: .cM_1[class] null => "cM_1"
+REMOVE: .cM_1::text("--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19conditional-1btemplate-1amarko_0:blue;}")
+INSERT: .cM_1::text(".cM_1~*{}")
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-injection/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-injection/__snapshots__/render-csr.debug.md
@@ -17,6 +17,18 @@ assert.equal(
 ```
 
 # Update `{"color":"red/* ("}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:red\\} :root \\7B  display: none \\} \\3C /style\\>\\3C script\\>alert(1)\\3C /script\\>;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:red\\/* ();}")
+```
 
 # Update
 ```js
@@ -28,6 +40,18 @@ assert.equal(
 ```
 
 # Update `{"color":"red; background: blue"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:red\\/* ();}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:red\\3B  background: blue;}")
+```
 
 # Update
 ```js
@@ -39,6 +63,18 @@ assert.equal(
 ```
 
 # Update `{"color":"green\\"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:red\\3B  background: blue;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:green\\\\;}")
+```
 
 # Update
 ```js
@@ -50,6 +86,18 @@ assert.equal(
 ```
 
 # Update `{"color":"green"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:green\\\\;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19injection-1btemplate-1amarko_0:green;}")
+```
 
 # Update
 ```js

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-multi/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-multi/__snapshots__/render-csr.debug.md
@@ -13,3 +13,22 @@
 ```
 
 # Update `{"color":"blue","width":"20px"}`
+```html
+<header
+  class="a"
+>
+  Header
+</header>
+<main
+  class="a"
+>
+  Main
+</main>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_0:green;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_1:10px;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_1:10px;}")
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_1:10px;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19multi-1btemplate-1amarko_1:20px;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-selectors/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-selectors/__snapshots__/render-csr.debug.md
@@ -8,3 +8,21 @@
 ```
 
 # Update `{"color":"blue","pad":8,"hover":"navy","wide":"teal"}`
+```html
+<div
+  class="card"
+>
+  Card
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:red;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:4;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:darkred;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:4;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:darkred;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:4;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:darkred;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:8;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:darkred;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:8;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:darkred;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:8;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:navy;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:8;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:navy;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:crimson;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_0:blue;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_1:8;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_2:navy;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19selectors-1btemplate-1amarko_3:teal;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-shorthand/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-shorthand/__snapshots__/render-csr.debug.md
@@ -8,3 +8,17 @@
 ```
 
 # Update `{"block":"3px","inline":"4px"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_0:1px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_1:2px;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_0:3px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_1:2px;}")
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_0:3px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_1:2px;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_0:3px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19shorthand-1btemplate-1amarko_1:4px;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-static-mix/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-static-mix/__snapshots__/render-csr.debug.md
@@ -8,3 +8,15 @@
 ```
 
 # Update `{"color":"blue"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19static-19mix-1btemplate-1amarko_1:8px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19static-19mix-1btemplate-1amarko_0:green;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19static-19mix-1btemplate-1amarko_1:8px;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19static-19mix-1btemplate-1amarko_0:blue;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-two-tags/__snapshots__/render-csr.debug.md
@@ -13,3 +13,22 @@
 ```
 
 # Update `{"a":"green","b":"purple"}`
+```html
+<div
+  class="a"
+>
+  A
+</div>
+<div
+  class="b"
+>
+  B
+</div>
+```
+## Change
+```
+REMOVE: .cM_1::text(".cM_1~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0:red;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1:blue;}")
+INSERT: .cM_1::text(".cM_1~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0:green;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1:blue;}")
+REMOVE: .cM_1::text(".cM_1~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0:green;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1:blue;}")
+INSERT: .cM_1::text(".cM_1~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_0:green;--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19two-19tags-1btemplate-1amarko_1:purple;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic/__snapshots__/render-csr.debug.md
@@ -8,3 +8,15 @@
 ```
 
 # Update `{"color":"blue"}`
+```html
+<div
+  class="content"
+>
+  Hello
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-1btemplate-1amarko_0:green;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-1btemplate-1amarko_0:blue;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-escapes/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-escapes/__snapshots__/render-csr.debug.md
@@ -8,3 +8,15 @@
 ```
 
 # Update `{"color":"blue"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19escapes-1btemplate-1amarko_0:green;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19escapes-1btemplate-1amarko_0:blue;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-unbalanced-closers/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-unbalanced-closers/__snapshots__/render-csr.debug.md
@@ -8,3 +8,15 @@
 ```
 
 # Update `{"color":"blue"}`
+```html
+<div
+  class="box"
+>
+  Hi
+</div>
+```
+## Change
+```
+REMOVE: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19unbalanced-19closers-1btemplate-1amarko_0:green;}")
+INSERT: .cM_0::text(".cM_0~*{--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19unbalanced-19closers-1btemplate-1amarko_0:blue;}")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.debug.md
@@ -9,3 +9,13 @@
 ```js
 document.querySelector("button").click();
 ```
+```html
+<button>
+  go
+</button>
+```
+## Change
+```
+REMOVE: title::text("back\\slash world")
+INSERT: title::text("back\\slash earth")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-only-tag-escape/__snapshots__/render.md
@@ -9,3 +9,13 @@
 ```js
 document.querySelector("button").click();
 ```
+```html
+<button>
+  go
+</button>
+```
+## Change
+```
+REMOVE: title::text("back\\slash world")
+INSERT: title::text("back\\slash earth")
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/__snapshots__/render.debug.md
@@ -22,6 +22,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 0")
+INSERT: title::text("Count is 1")
 REMOVE: div::text("Count is 0")
 INSERT: div::text("Count is 1")
 ```
@@ -40,6 +42,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 1")
+INSERT: title::text("Count is 2")
 REMOVE: div::text("Count is 1")
 INSERT: div::text("Count is 2")
 ```
@@ -58,6 +62,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 2")
+INSERT: title::text("Count is 3")
 REMOVE: div::text("Count is 2")
 INSERT: div::text("Count is 3")
 ```

--- a/packages/runtime-tags/src/__tests__/fixtures/title-counter/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/title-counter/__snapshots__/render.md
@@ -22,6 +22,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 0")
+INSERT: title::text("Count is 1")
 REMOVE: div::text("Count is 0")
 INSERT: div::text("Count is 1")
 ```
@@ -40,6 +42,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 1")
+INSERT: title::text("Count is 2")
 REMOVE: div::text("Count is 1")
 INSERT: div::text("Count is 2")
 ```
@@ -58,6 +62,8 @@ document.querySelector("button").click();
 ```
 ## Change
 ```
+REMOVE: title::text("Count is 2")
+INSERT: title::text("Count is 3")
 REMOVE: div::text("Count is 2")
 INSERT: div::text("Count is 3")
 ```

--- a/packages/runtime-tags/src/__tests__/utils/get-node-info.ts
+++ b/packages/runtime-tags/src/__tests__/utils/get-node-info.ts
@@ -118,14 +118,6 @@ export function getNodeSelector(
     : `${parentPath} > ${rhs}`;
 }
 
-export function getSanitizedNodes(nodeList: NodeList): Node[] {
-  const result: Node[] = [];
-  for (const node of nodeList) {
-    if (!isIgnoredNode(node)) result.push(node);
-  }
-  return result;
-}
-
 export function isIgnoredNode(node: Node) {
   return isMarkoComment(node) || isIgnoredTag(node) || isEmptyTextNode(node);
 }

--- a/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
+++ b/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
@@ -281,14 +281,14 @@ function formatMutationRecord(record: MutationRecord) {
   const { target, oldValue } = record;
 
   if (record.type === "characterData") {
-    if (nodeInfo.isIgnoredNode(target.parentNode!)) return;
+    if (isIgnoredMutationNode(target.parentNode!)) return;
 
     return `UPDATE: ${nodeInfo.getNodePath(target)} ${JSON.stringify(
       oldValue || "",
     )} => ${JSON.stringify(target.nodeValue || "")}`;
   }
 
-  if (nodeInfo.isIgnoredNode(target)) return;
+  if (isIgnoredMutationNode(target)) return;
 
   switch (record.type) {
     case "attributes": {
@@ -303,8 +303,12 @@ function formatMutationRecord(record: MutationRecord) {
 
     case "childList": {
       const { removedNodes, addedNodes, previousSibling } = record;
-      const removed = nodeInfo.getSanitizedNodes(removedNodes);
-      const added = nodeInfo.getSanitizedNodes(addedNodes);
+      const removed = Array.from(removedNodes).filter(
+        (node) => !isIgnoredMutationNode(node),
+      );
+      const added = Array.from(addedNodes).filter(
+        (node) => !isIgnoredMutationNode(node),
+      );
 
       if (!removed.length && !added.length) return;
 
@@ -324,6 +328,13 @@ function formatMutationRecord(record: MutationRecord) {
       return details.join("\n");
     }
   }
+}
+
+function isIgnoredMutationNode(node: Node) {
+  if (!nodeInfo.isIgnoredNode(node)) return false;
+  return !(
+    nodeInfo.isElement(node) && /^(?:LINK|STYLE|TITLE)$/i.test(node.tagName)
+  );
 }
 
 function getFunctionBody(rawSource: string) {


### PR DESCRIPTION
Record mutations to style, title, and link elements in render snapshots while continuing to filter Marko placeholders and resume scripts. This makes dynamic head and style updates visible in the primary fixture review artifact.