### PR TITLE
perf(runtime-tags): skip empty template setups

### DIFF
--- a/.changeset/empty-program-setups.md
+++ b/.changeset/empty-program-setups.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid scheduling empty template setup functions in the browser runtime.

--- a/.sizes.json
+++ b/.sizes.json
@@ -44,16 +44,16 @@
     {
       "name": "comments",
       "user": {
-        "min": 645,
-        "brotli": 364
+        "min": 636,
+        "brotli": 359
       },
       "runtime": {
         "min": 6511,
         "brotli": 2876
       },
       "total": {
-        "min": 7156,
-        "brotli": 3240
+        "min": 7147,
+        "brotli": 3235
       }
     },
     {

--- a/.sizes/comments.csr/entry.js
+++ b/.sizes/comments.csr/entry.js
@@ -1,4 +1,4 @@
-// size: 645 (min) 364 (brotli)
+// size: 636 (min) 359 (brotli)
 //#region packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/tags/comments.marko
 const $template$1 = "<ul></ul>";
 const $if_content__comment_comments = /*@__PURE__*/ _if_closure(4, 0, ($scope) =>
@@ -60,7 +60,6 @@ const $input_path$1 = /*@__PURE__*/ _const(4, $for_content__input_path);
 //#region packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
-const $setup = () => {};
 const $input_comments = ($scope, input_comments) => $input_comments$1($scope.a, input_comments);
 const $input_path = ($scope, input_path) => $input_path$1($scope.a, input_path);
 const $input = ($scope, input) => {
@@ -69,5 +68,5 @@ const $input = ($scope, input) => {
 };
 //#endregion
 //#region entry
-/* @__PURE__ */ _template("b", $template, $walks, $setup, $input).mount();
+/* @__PURE__ */ _template("b", $template, $walks, 0, $input).mount();
 //#endregion

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -161,12 +161,6 @@ The closure `signal` is assigned only in the `pending.then((mod) => queueAsyncRe
 
 `Boundary.flush()` runs `flushSerializer` on every call, and `ServerRendered.#read`'s `onNext` calls it on each `boundary.endAsync()` even when the HTML write is deferred to the next `queueTick`. Each call appends its own `_=>[…]` closure to `state.resumes`, so N awaits settling in one chunk emit N payloads and the delta scope-id encoding in `writeScopesRoot` cannot span them — see `fixtures/async-reorder-nested-batched-resolve/__snapshots__/writes.html`, where one chunk pushes `_ => [5,…], _ => [7,…]`. Serialization cannot simply be skipped, since the serializer itself calls `boundary.startAsync()`; take `flush(write?)` and serialize only when `write` or `this.count === 0`, with `#read` passing through its existing `write` flag. Re-verify: that snapshot should regenerate with a single `_ =>` closure per chunk.
 
-## Pass `0` for an empty `$setup` in `_template`, and keep `setupEmpty` for dynamic tags
-
-`packages/runtime-tags/src/translator/visitors/program/dom.ts` › `translate.exit` | 2026-07-23 | impact:med | effort:low
-
-With no program setup signal, `program/dom.ts` emits `export const $setup = () => {};` and still passes that identifier as `_template`'s 4th argument, so `_content` stores a truthy `RendererProp.Setup` and `setupBranch` queues `queueRender(branch, emptyFn, -1)` for every branch built from the template (and `mount` calls it directly). Child-section `_content` args already go through `replaceNullishAndEmptyFunctionsWith0`; the program `_template` args do not, and `program/index.ts` carries the matching TODO. Separately, `visitors/tag/dynamic-tag.ts` calls `addSetupStatement` unconditionally, so any template containing a dynamic tag loses `domExports.setupEmpty` and its parents still emit `import { $setup as _wrap }` + `_wrap($scope.a)` for a function translate left empty. Re-verify: compile `<section class="wrap"><${input.content}/></section>` and a parent that uses it with `-o dom`; 19 committed `dom.bundle.js` snapshots still contain `$setup = () => {}`.
-
 ## Collapse an all-same `_set_serialize_reason` group object into a bare guard or bitmask
 
 `packages/runtime-tags/src/translator/util/known-tag.ts` › `knownTagTranslateHTML` | 2026-07-23 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-and-components-dir/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ var import_vdom = require_vdom();
 const $template = "<h1>Hello tags</h1>";
 const $walks = "b";
 const $setup = () => {};
-var hello_tags_default = /*@__PURE__*/ _template("__tests__/tags/hello-tags.marko", $template, "b", $setup);
+var hello_tags_default = /*@__PURE__*/ _template("__tests__/tags/hello-tags.marko", $template, "b");
 
 // components/hello-components.marko
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/ambiguous-tags-dir/__snapshots__/dom.bundle.debug.js
@@ -2,10 +2,10 @@
 const $template$1 = "<h1>Hello world</h1>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello.marko", $template$1, "b", $setup$1);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello.marko", $template$1, "b");
 
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)("b");
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/explicit/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/explicit/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<h1>Hello world</h1>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/__snapshots__/dom.bundle.debug.js
@@ -30,7 +30,7 @@ const $onchange = ($scope) => function() {
 	$scope.input_onChange?.();
 };
 _resume("__tests__/components/tags-child.marko_0/onchange", $onchange);
-var tags_child_default = /*@__PURE__*/ _template("__tests__/components/tags-child.marko", $template, "b%c", $setup, $input);
+var tags_child_default = /*@__PURE__*/ _template("__tests__/components/tags-child.marko", $template, "b%c", 0, $input);
 
 // template.marko
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/__snapshots__/dom.bundle.js
@@ -18,7 +18,6 @@ _marko_template$1.Component = (0, import_defineComponent.default)(_marko_compone
 // components/tags-child.marko
 const $template = "<!><!><!>";
 const $walks = "b%c";
-const $setup = () => {};
 _resume("b", _marko_template$1);
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
 const $input_onChange = /*@__PURE__*/ _const(3, ($scope) => $dynamicTag($scope, _marko_template$1, () => ({ "on-change": $onchange($scope) })));
@@ -27,7 +26,7 @@ const $onchange = ($scope) => function() {
 	$scope.d?.();
 };
 _resume("c0", $onchange);
-var tags_child_default = /*@__PURE__*/ _template("c", $template, "b%c", $setup, $input);
+var tags_child_default = /*@__PURE__*/ _template("c", $template, "b%c", 0, $input);
 
 // template.marko
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64532,
-        "brotli": 20079
+        "min": 64515,
+        "brotli": 20100
       },
       "files": {
         "components/class-child.marko": 975,
-        "components/tags-child.marko": 609,
+        "components/tags-child.marko": 579,
         "template.marko": 947
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-only-show/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-only-show/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<!>shown<!>";
 const $walks = "d";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "d", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "d");

--- a/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/assign-destructured-reduced/__snapshots__/dom.bundle.debug.js
@@ -13,7 +13,7 @@ const $input__script = _script("__tests__/tags/child.marko_0_input#1", ($scope) 
 	}
 });
 const $input = /*@__PURE__*/ _const("input", $input__script);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // template.marko
 const $template = "";

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/dom.bundle.debug.js
@@ -25,7 +25,7 @@ const $input_level = /*@__PURE__*/ _const("input_level", ($scope) => {
 	$input_level__closure($scope);
 });
 const $input = ($scope, input) => $input_level($scope, input.level);
-var recurse_default = /*@__PURE__*/ _template("__tests__/tags/recurse.marko", $template$1, "b%c", $setup$1, $input);
+var recurse_default = /*@__PURE__*/ _template("__tests__/tags/recurse.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/dom.bundle.debug.js
@@ -11,16 +11,14 @@ const $thing2 = ($scope, $thing) => {
 	$x$1($scope, $thing.x);
 	$content($scope, $thing.content);
 };
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag/index.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&`)($walks$1);
+const $setup = () => {};
 const $thing_content2 = /*@__PURE__*/ _content("__tests__/template.marko_2*content", "Goodbye");
 const $thing_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
-function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-}
 const $x = /*@__PURE__*/ _const("x", ($scope) => {
 	let $thing;
 	if ($scope.x) {
@@ -37,4 +35,4 @@ const $x = /*@__PURE__*/ _const("x", ($scope) => {
 	$thing2($scope["#childScope/0"], $thing);
 });
 const $input = ($scope, input) => $x($scope, input.x);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	$input_item($scope, input.item);
 	$input_other($scope, input.other);
 };
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
@@ -29,7 +29,6 @@ const $item_content = /*@__PURE__*/ _content_closures(/*@__PURE__*/ _content("__
 	}
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_other($scope["#childScope/0"], attrTag({ content: $other_content($scope) }));
 	let $item;
 	forIn({

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-tag-parent/__snapshots__/dom.bundle.debug.js
@@ -26,7 +26,7 @@ const $input_footer = ($scope, input_footer) => {
 	$input_footer_class($scope, input_footer?.class);
 	$input_footer_content($scope, input_footer?.content);
 };
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, 0, 1);
 const $input_item = ($scope, input_item) => $dynamicTag($scope, input_item, () => [1]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, "b%c", $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<button>Toggle</button>`)($template$1);
@@ -25,7 +25,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 }));
 function $setup($scope) {
 	_var($scope, "#childScope/0", $menuEl);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$x($scope, true);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/dom.bundle.debug.js
@@ -47,7 +47,7 @@ const $input = ($scope, input) => {
 	$input_col($scope, input.col);
 };
 const $input_list = ($scope, input_list) => $input_list_item($scope, input_list?.item);
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_content($
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-no-scope/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $
 const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " ", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $
 const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " ", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div> </div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $
 const $for = /*@__PURE__*/ _for_of("#text/0", "<button></button>", " ", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", $setup$1, $input);
+var my_menu_default = /*@__PURE__*/ _template("__tests__/tags/my-menu/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div> </div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_content($
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<button>Multiplier: <!></button>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-leading-comment/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__content($scope
 const $for = /*@__PURE__*/ _for_of("#text/0", "<div class=item><!></div>", "D%", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var box_default = /*@__PURE__*/ _template("__tests__/tags/box/index.marko", $template$1, "b%c", $setup$1, $input);
+var box_default = /*@__PURE__*/ _template("__tests__/tags/box/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input$1 = ($scope, input) => {
 };
 const $x = ($scope, x) => $x_value($scope, x?.value);
 const $y = ($scope, y) => $y_value($scope, y?.value);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag/index.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = $template$1;
@@ -26,4 +26,4 @@ const $cond = /*@__PURE__*/ _const("cond", ($scope) => {
 	$y($scope["#childScope/0"], $y$1);
 });
 const $input = ($scope, input) => $cond($scope, input.cond);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__s_a($scope, $p
 const $for = /*@__PURE__*/ _for_of("#text/0", " ", " ", 0, $for_content__$params);
 const $input_scope = ($scope, input_scope) => $for($scope, [input_scope]);
 const $input = ($scope, input) => $input_scope($scope, input.scope);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $input_item__script = _script("__tests__/tags/list.marko_0_input_item#3", ($scope) => _el_read($scope["#div/0"]).textContent = [...$scope.input_item].map((item) => item.label).join("|"));
 const $input_item = /*@__PURE__*/ _const("input_item", $input_item__script);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, " b", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-static-repeated/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_content($
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags/__snapshots__/dom.bundle.debug.js
@@ -6,14 +6,13 @@ const $input_foo_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_foo = $dynamicTag;
 const $input = ($scope, input) => $input_foo($scope, input.foo);
-var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, "b%c", $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/tags/hello/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $foo_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Foo!");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_foo($scope["#childScope/0"], attrTag({ content: $foo_content($scope) }));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-boolean/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-boolean/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<input checked>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-carriage-return/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div data-x=\"x&#13;y\"></div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class-svg/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $active = ($scope, active) => {
 	_attr_class($scope["#circle/1"], active ? "on" : "off");
 };
 const $input = ($scope, input) => $active($scope, input.active);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,7 @@ const $input$1 = ($scope, input) => {
 };
 const $input_test_class = /*@__PURE__*/ _const("input_test_class", $if_content__input_test_class);
 const $input_test_content = /*@__PURE__*/ _const("input_test_content", $if_content__input_test_content);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, $setup$1, $input$1);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<div class=a></div><div class="a b"></div><div class="a b c"></div><div></div><div class=base></div>${_w0}${_w1}<!><!>`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-escape/__snapshots__/dom.bundle.debug.js
@@ -16,4 +16,4 @@ const $input = ($scope, input) => {
 	$input_foo($scope, input.foo);
 	$input_bar($scope, input.bar);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-falsey/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-falsey/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div d=0 y=1></div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-object-prototype-names/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-object-prototype-names/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div class=box toString=a valueOf=b hasOwnProperty=c constructor=d>content</div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-spread-lone-nullish-input/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $attrs = /*@__PURE__*/ _const("attrs", ($scope) => {
 	$attrs__script($scope);
 });
 const $input = ($scope, input) => $attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,7 @@ const $input$1 = ($scope, input) => {
 };
 const $input_test_style = /*@__PURE__*/ _const("input_test_style", $if_content__input_test_style);
 const $input_test_content = /*@__PURE__*/ _const("input_test_content", $if_content__input_test_content);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, $setup$1, $input$1);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<div></div><div style=width:100px></div><div style="color: green"></div><div></div>${_w0}${_w1}${_w2}<!><!>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "<!>";
 const $walks$1 = "%b";
 const $setup$1 = () => {};
 const $input$1 = ($scope, input) => _text($scope["#text/0"], JSON.stringify(input));
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "<!>", "%b", $setup$1, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "<!>", "%b", 0, $input$1);
 
 // template.marko
 const $template = "<!>";
@@ -19,4 +19,4 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 		item: $item
 	});
 });
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-template-literal-escape/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_name = ($scope, input_name) => _attr($scope["#div/0"], "foo", `Hello ${input_name}`);
 const $input = ($scope, input) => $input_name($scope, input.name);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/dom.bundle.debug.js
@@ -12,4 +12,4 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_label($sc
 const $for = /*@__PURE__*/ _for_of("#ul/0", "<li><!></li>", "D%", $for_content__setup, $for_content__$params);
 const $input_items = ($scope, input_items) => $for($scope, [input_items]);
 const $input = ($scope, input) => $input_items($scope, input.items);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-nested-component/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = " b";
 const $setup$1 = () => {};
 const $input_x = /*@__PURE__*/ _const("input_x", ($scope) => _attr_input_value_default($scope, "#input/0", $scope.input_x));
 const $input = ($scope, input) => $input_x($scope, input.x);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = "<!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input = ($scope, input) => {
 	$onClick$1($scope, input.onClick);
 	$text($scope, input.text);
 };
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input = ($scope, input) => {
 	$text($scope, input.text);
 	$onClick$1($scope, input.onClick);
 };
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	$value2($scope, input.value);
 };
 const $value2 = ($scope, $value) => $text($scope, $value.text);
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/dom.bundle.debug.js
@@ -13,7 +13,7 @@ const $input = ($scope, input) => {
 	$onClick$1($scope, input.onClick);
 	$text($scope, input.text);
 };
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input = ($scope, input) => {
 	$onClick$1($scope, input.onClick);
 	$text($scope, input.text);
 };
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $input = ($scope, input) => {
 	$onClick$1($scope, input.onClick);
 	$content($scope, input.content);
 };
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
@@ -22,7 +22,6 @@ const $mybutton_content = /*@__PURE__*/ _content("__tests__/template.marko_1*con
 const $clickCount__closure = /*@__PURE__*/ _closure($mybutton_content__clickCount);
 const $clickCount = /*@__PURE__*/ _let("clickCount/1", $clickCount__closure);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content_direct($scope["#childScope/0"], $mybutton_content($scope));
 	$onClick$1($scope["#childScope/0"], $onClick($scope));
 	$clickCount($scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-dynamic-native-tag/__snapshots__/dom.bundle.debug.js
@@ -6,4 +6,4 @@ const $tagName_content = _content_resume("__tests__/template.marko_1*content", "
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $tagName_content);
 const $tagName = ($scope, tagName) => $dynamicTag($scope, tagName, () => ({ class: ["a", "b"] }));
 const $input = ($scope, input) => $tagName($scope, input.tagName);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-export/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-export/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "";
 const $walks$1 = "";
 const $setup$1 = () => {};
 const v = 123;
-var exporter_default = /*@__PURE__*/ _template("__tests__/exporter.marko", "", "", $setup$1);
+var exporter_default = /*@__PURE__*/ _template("__tests__/exporter.marko", "", "");
 
 // template.marko
 const $template = "<div> </div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/dom.bundle.debug.js
@@ -42,7 +42,7 @@ const $input$1 = ($scope, input) => {
 	$input_comments$1($scope, input.comments);
 	$input_path$1($scope, input.path);
 };
-var comments_default = /*@__PURE__*/ _template("__tests__/tags/comments.marko", $template$1, " b", $setup$1, $input$1);
+var comments_default = /*@__PURE__*/ _template("__tests__/tags/comments.marko", $template$1, " b", 0, $input$1);
 
 // template.marko
 const $template = $template$1;
@@ -54,4 +54,4 @@ const $input = ($scope, input) => {
 	$input_comments($scope, input.comments);
 	$input_path($scope, input.path);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-layout/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $content = $dynamicTag;
 const $input$1 = ($scope, input) => $content($scope, input.content);
-var layout_default = /*@__PURE__*/ _template("__tests__/tags/layout.marko", $template$1, "D%l", $setup$1, $input$1);
+var layout_default = /*@__PURE__*/ _template("__tests__/tags/layout.marko", $template$1, "D%l", 0, $input$1);
 
 // template.marko
 const $template = $template$1;
@@ -15,7 +15,6 @@ const $layout_content__input_name = /*@__PURE__*/ _closure_get("name", ($scope) 
 const $layout_content__setup = $layout_content__input_name;
 const $layout_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<h1>Hello <!></h1>", "Db%", $layout_content__setup);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content_direct($scope["#childScope/0"], $layout_content($scope));
 }
 const $input = ($scope, input) => $name($scope, input.name);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $name = ($scope, name) => _text($scope["#text/0"], name);
 const $input = ($scope, input) => $name($scope, input.name);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Push</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = ($scope, input) => {
 	$content($scope, input.content);
 	$value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D%l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D%l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>Inc</button>${_w0}`)($template$1);
@@ -23,7 +23,6 @@ const $child_content2 = _content_resume("__tests__/template.marko_2*content", "<
 const $child_content__y = /*@__PURE__*/ _closure_get("y", ($scope) => $value($scope["#childScope/0"], $scope._.y));
 const $child_content__setup = ($scope) => {
 	$child_content__y($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content($scope["#childScope/0"], $child_content2($scope));
 };
 const $child_content__$params = ($scope, $params2) => $child_content__outer($scope, $params2[0]);
@@ -36,7 +35,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$x($scope, +$scope.x + 1);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$content($scope["#childScope/1"], $child_content($scope));
 	$x($scope, 1);
 	$y($scope, 2);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<div><!></div>";
-const $setup = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0, 0, 0, 1);
 const $input_content__OR__input_value = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.d, () => [$scope.e]));
 const $content = /*@__PURE__*/ _const(3, $input_content__OR__input_value);
@@ -15,7 +14,6 @@ const $child_content2 = _content_resume("a0", "<div><!>.<!></div>", "D%c%", $chi
 const $child_content__y = /*@__PURE__*/ _closure_get(4, ($scope) => $value($scope.a, $scope._.d));
 const $child_content__setup = ($scope) => {
 	$child_content__y($scope);
-	/* @__PURE__ */ $setup($scope.a);
 	$content($scope.a, $child_content2($scope));
 };
 const $child_content__$params = ($scope, $params2) => $child_content__outer($scope, $params2[0]);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9534,
-        "brotli": 4134
+        "min": 9530,
+        "brotli": 4133
       },
       "files": {
-        "tags/child.marko": 432,
-        "template.marko": 1296
+        "tags/child.marko": 407,
+        "template.marko": 1261
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-custom-tag/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
@@ -23,7 +23,6 @@ const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*conten
 const $count__closure = /*@__PURE__*/ _closure($child_content__count);
 const $count = /*@__PURE__*/ _let("count/1", $count__closure);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content_direct($scope["#childScope/0"], $child_content($scope));
 	$count($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-dynamic-tag/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag$1 = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag$1;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	(({ content, ...attrs }) => $attrs($scope, attrs))(input);
 	$content($scope, input.content);
 };
-var FancyButton_default = /*@__PURE__*/ _template("__tests__/tags/FancyButton.marko", $template$1, $walks$1, $setup$1, $input);
+var FancyButton_default = /*@__PURE__*/ _template("__tests__/tags/FancyButton.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
@@ -28,7 +28,6 @@ const $clickCount = /*@__PURE__*/ _let("clickCount/1", ($scope) => {
 	$clickCount__closure($scope);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content_direct($scope["#childScope/0"], $FancyButton_content($scope));
 	$clickCount($scope, 0);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-computed-string-key/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var reveal_default = /*@__PURE__*/ _template("__tests__/tags/reveal/index.marko", $template$1, "D l", $setup$1, $input);
+var reveal_default = /*@__PURE__*/ _template("__tests__/tags/reveal/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<button>inc <!></button>${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-existing-change/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var reveal_default = /*@__PURE__*/ _template("__tests__/tags/reveal/index.marko", $template$1, "D l", $setup$1, $input);
+var reveal_default = /*@__PURE__*/ _template("__tests__/tags/reveal/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<button>inc <!></button>${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/circular-tag-var-function-serialize/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $input_valueChange__script = _script("__tests__/tags/child.marko_0_input_valueChange#2", ($scope) => $scope.input_valueChange(1));
 const $input_valueChange = /*@__PURE__*/ _const("input_valueChange", $input_valueChange__script);
 const $input = ($scope, input) => $input_valueChange($scope, input.valueChange);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // template.marko
 const $template = "<!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/dom.bundle.debug.js
@@ -23,7 +23,7 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$write$1($scope, input.write);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-deep/__snapshots__/dom.bundle.debug.js
@@ -23,7 +23,7 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$write$1($scope, input.write);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<button id=outer>Toggle Outer</button><button id=middle>Toggle Middle</button><button id=inner>Toggle Inner</button><pre></pre><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-if-shallow/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$signalReset($scope, 0);
 	$input__script($scope);
 });
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "d", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "d", 0, $input);
 
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/dom.bundle.debug.js
@@ -18,7 +18,7 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$write$1($scope, input.write);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,7 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$write$1($scope, input.write);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-deep/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,7 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$write$1($scope, input.write);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<button id=outer>Toggle Outer</button><button id=middle>Toggle Middle</button><button id=inner>Toggle Inner</button><pre></pre><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-if-shallow/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$signalReset($scope, 0);
 	$input__script($scope);
 });
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b", 0, $input);
 
 // template.marko
 const $template = "<button>Toggle</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/comments/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/comments/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div><!--abc--><!--[if lt IE 9]&gt;<script src=\"...\"&gt;<\/script&gt;<![endif]--></div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-static-non-registered-function/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "<div> </div>";
 const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input = ($scope, input) => _text($scope["#text/0"], input.format(input.value));
-var price_default = /*@__PURE__*/ _template("__tests__/tags/price.marko", $template$1, "D l", $setup$1, $input);
+var price_default = /*@__PURE__*/ _template("__tests__/tags/price.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-attr-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-attr-value/__snapshots__/dom.bundle.debug.js
@@ -38,4 +38,4 @@ const $input = ($scope, input) => {
 	$input_fallback($scope, input.fallback);
 	$input_s($scope, input.s);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__content($scope
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_section = ($scope, input_section) => $for($scope, [input_section]);
 const $input = ($scope, input) => $input_section($scope, input.section);
-var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", $setup$1, $input);
+var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__content($scope
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_section = ($scope, input_section) => $for($scope, [input_section]);
 const $input = ($scope, input) => $input_section($scope, input.section);
-var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", $setup$1, $input);
+var sections_default = /*@__PURE__*/ _template("__tests__/tags/sections.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-defaulted-input/__snapshots__/dom.bundle.debug.js
@@ -31,4 +31,4 @@ const $falsy_label = ($scope, falsy_label) => _text($scope["#text/2"], falsy_lab
 const $falsy_size = ($scope, falsy_size) => _text($scope["#text/3"], falsy_size);
 const $guarded_label = ($scope, guarded_label) => _text($scope["#text/4"], guarded_label);
 const $input = ($scope, input) => $input_opts($scope, input.opts);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/content-with-state/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-with-state/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content$1 = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content$1($scope, input.content);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", $setup$2, $input$1);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", 0, $input$1);
 
 // tags/outer.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
@@ -22,7 +22,6 @@ const $inner_content__setup = ($scope) => {
 };
 const $inner_content = /*@__PURE__*/ _content("__tests__/tags/outer.marko_1*content", "<button>click</button><!><!>", " b%", $inner_content__setup);
 function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input_content_direct($scope["#childScope/0"], $inner_content($scope));
 }
 const $input = ($scope, input) => $input_content($scope, input.content);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-spread/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	}, _controllable_input);
 	$input__script($scope);
 });
-var checkbox_default = /*@__PURE__*/ _template("__tests__/tags/checkbox.marko", $template$1, " b", $setup$1, $input);
+var checkbox_default = /*@__PURE__*/ _template("__tests__/tags/checkbox.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-value-spread/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	}, _controllable_input);
 	$input__script($scope);
 });
-var radio_default = /*@__PURE__*/ _template("__tests__/tags/radio.marko", $template$1, " b", $setup$1, $input);
+var radio_default = /*@__PURE__*/ _template("__tests__/tags/radio.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `${_w0}${_w1}${_w2}<span> </span>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-checked-values-spread/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	}, _controllable_input);
 	$input__script($scope);
 });
-var checkbox_default = /*@__PURE__*/ _template("__tests__/tags/checkbox.marko", $template$1, " b", $setup$1, $input);
+var checkbox_default = /*@__PURE__*/ _template("__tests__/tags/checkbox.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `${_w0}${_w1}${_w2}<span> </span>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-details-open-spread/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs($scope, "#details/0", $scope.input, _controllable_open);
 	$input__script($scope);
 });
-var my_details_default = /*@__PURE__*/ _template("__tests__/tags/my-details.marko", $template$1, " b", $setup$1, $input);
+var my_details_default = /*@__PURE__*/ _template("__tests__/tags/my-details.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-dialog-open-spread/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs_content($scope, "#dialog/0", $scope.input, _controllable_open);
 	$input__script($scope);
 });
-var my_dialog_default = /*@__PURE__*/ _template("__tests__/tags/my-dialog.marko", $template$1, " b", $setup$1, $input);
+var my_dialog_default = /*@__PURE__*/ _template("__tests__/tags/my-dialog.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-spread/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs($scope, "#input/0", $scope.input, _controllable_input);
 	$input__script($scope);
 });
-var my_input_default = /*@__PURE__*/ _template("__tests__/tags/my-input.marko", $template$1, " b", $setup$1, $input);
+var my_input_default = /*@__PURE__*/ _template("__tests__/tags/my-input.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-spread/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs_content($scope, "#select/0", $scope.input, _controllable_select);
 	$input__script($scope);
 });
-var my_select_default = /*@__PURE__*/ _template("__tests__/tags/my-select.marko", $template$1, " b", $setup$1, $input);
+var my_select_default = /*@__PURE__*/ _template("__tests__/tags/my-select.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-textarea-value-spread/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs($scope, "#textarea/0", $scope.input, _controllable_textarea);
 	$input__script($scope);
 });
-var my_textarea_default = /*@__PURE__*/ _template("__tests__/tags/my-textarea.marko", $template$1, " b", $setup$1, $input);
+var my_textarea_default = /*@__PURE__*/ _template("__tests__/tags/my-textarea.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<span> </span>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controlled-select-undefined-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controlled-select-undefined-value/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_sel = /*@__PURE__*/ _const("input_sel", ($scope) => _attr_select_value_default($scope, "#select/0", $scope.input_sel));
 const $input = ($scope, input) => $input_sel($scope, input.sel);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-from/__snapshots__/dom.bundle.debug.js
@@ -17,4 +17,4 @@ const $input = ($scope, input) => {
 	$input_to($scope, input.to);
 	$input_step($scope, input.step);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/create-and-clear-rows-loop-in/__snapshots__/dom.bundle.debug.js
@@ -13,4 +13,4 @@ const $input_children = ($scope, input_children) => {
 	$for2($scope, [input_children]);
 };
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cross-tag-closure/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var my_tag_default = /*@__PURE__*/ _template("__tests__/tags/my-tag.marko", $template$1, "b%c", $setup$1, $input);
+var my_tag_default = /*@__PURE__*/ _template("__tests__/tags/my-tag.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<!>${_w0}${_w1}<!>`)("", $template$1);
@@ -41,7 +41,6 @@ function $setup($scope) {
 	_var($scope, "#childScope/0", $count);
 	$setup$2($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], 0);
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input_content_direct($scope["#childScope/2"], $mytag_content($scope));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-child-analyze/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "Hello Frank";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $value = ($scope, value) => _text($scope["#text/0"], value);
 const $input_value = $value;
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "D l";
 const $setup$2 = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input$1 = ($scope, input) => $input_value($scope, input.value);
-var cell_default = /*@__PURE__*/ _template("__tests__/tags/cell/index.marko", $template$2, "D l", $setup$2, $input$1);
+var cell_default = /*@__PURE__*/ _template("__tests__/tags/cell/index.marko", $template$2, "D l", 0, $input$1);
 
 // tags/row/index.marko
 const $template$1 = /*@__PURE__*/ ((_w0, _w1) => `<div class=row>${_w0}${_w1}</div>`)($template$2, $template$2);
@@ -16,7 +16,7 @@ const $input = ($scope, input) => {
 	$input_name($scope, input.name);
 	$input_quantity($scope, input.quantity);
 };
-var row_default = /*@__PURE__*/ _template("__tests__/tags/row/index.marko", $template$1, $walks$1, $setup$1, $input);
+var row_default = /*@__PURE__*/ _template("__tests__/tags/row/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>add</button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-lazy-read/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $input_onPress__script = _script("__tests__/tags/press-button/index.marko_0_input_onPress#3", ($scope) => _on($scope["#button/0"], "click", $scope.input_onPress));
 const $input_onPress = /*@__PURE__*/ _const("input_onPress", $input_onPress__script);
 const $input = ($scope, input) => $input_onPress($scope, input.onPress);
-var press_button_default = /*@__PURE__*/ _template("__tests__/tags/press-button/index.marko", $template$1, " b", $setup$1, $input);
+var press_button_default = /*@__PURE__*/ _template("__tests__/tags/press-button/index.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button class=inc>inc</button>${_w0}<div class=log> </div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "<div class=result> </div>";
 const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input = ($scope, input) => _text($scope["#text/0"], input.get());
-var show_result_default = /*@__PURE__*/ _template("__tests__/tags/show-result/index.marko", $template$1, "D l", $setup$1, $input);
+var show_result_default = /*@__PURE__*/ _template("__tests__/tags/show-result/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button class=inc>inc</button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-render-body/__snapshots__/dom.bundle.debug.js
@@ -10,14 +10,13 @@ const $input = ($scope, input) => {
 	$name($scope, input.name);
 	$content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<!>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&b`)($walks$1);
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "This is the body content");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content_direct($scope["#childScope/0"], $child_content($scope));
 	$name($scope["#childScope/0"], "World");
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-template/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "b%c";
 const $setup$1 = () => {};
 const $input_name = ($scope, input_name) => _text($scope["#text/0"], input_name);
 const $input = ($scope, input) => $input_name($scope, input.name);
-var hello_default = /*@__PURE__*/ _template("__tests__/hello.marko", $template$1, "b%c", $setup$1, $input);
+var hello_default = /*@__PURE__*/ _template("__tests__/hello.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $input_thing = ($scope, input_thing) => {
 	$input_thing_selected($scope, input_thing?.selected);
 	$input_thing_content($scope, input_thing?.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>Toggle</button>`)($template$1);
@@ -26,7 +26,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$selected($scope, !$scope.selected);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$selected($scope, false);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-unreferenced-with-body/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<span>only this</span>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $name = /*@__PURE__*/ _const("name", ($scope) => {
 	$name__script($scope);
 });
 const $input = ($scope, input) => $name($scope, input.name);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<div></div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-member-intersection/__snapshots__/dom.bundle.debug.js
@@ -12,4 +12,4 @@ const $input = ($scope, input) => {
 	$input_a($scope, input.a);
 	$b($scope, input.b);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	(({ content, ...rest }) => $rest($scope, rest))(input);
 	$input_content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
@@ -24,7 +24,6 @@ const $child_content__setup = $child_content__value;
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
 const $value = /*@__PURE__*/ _const("value");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { content: $child_content($scope) });
 	$value($scope, 1);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
@@ -25,7 +25,6 @@ const $child_content__setup = $child_content__value;
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
 const $value = /*@__PURE__*/ _const("value");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { content: $child_content($scope) });
 	$value($scope, 1);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/dom.bundle.debug.js
@@ -13,7 +13,7 @@ const $input = ($scope, input) => {
 	(({ value, valueChange, ...rest }) => $rest($scope, rest))(input);
 	$valueChange2($scope, input.valueChange);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	(({ content, ...rest }) => $rest($scope, rest))(input);
 	$content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
@@ -24,7 +24,6 @@ const $child_content__setup = $child_content__value;
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
 const $value = /*@__PURE__*/ _const("value");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$content_direct($scope["#childScope/0"], $child_content($scope));
 	$rest($scope["#childScope/0"], {});
 	$value($scope, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,7 @@ const $_return = ($scope) => function(v) {
 };
 _resume("__tests__/tags/store.marko_0/_return2", $_return2);
 _resume("__tests__/tags/store.marko_0/_return", $_return);
-var store_default = /*@__PURE__*/ _template("__tests__/tags/store.marko", "", "", $setup$1, $input);
+var store_default = /*@__PURE__*/ _template("__tests__/tags/store.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>Clear</button><ul></ul>`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/doctype/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/doctype/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<!><html><head><title>Title of the document</title></head><body>The content of the document......</body></html>";
 const $walks = "c";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "c", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "c");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closure-with-function/__snapshots__/dom.bundle.debug.js
@@ -31,4 +31,4 @@ const $bar = ($scope) => function(test) {
 	return $scope.input_c + test;
 };
 _resume("__tests__/template.marko_0/bar", $bar);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-closures/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, "D%l", $setup$1, $input);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, "D%l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button></button>${_w0}<div></div>`)($template$1);
@@ -37,7 +37,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 	$c($scope, 4);
 }));
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input_content_direct($scope["#childScope/1"], $customtag_content($scope));
 	$b($scope, 2);
 	$c($scope, 3);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "Db%l";
 const $setup$1 = () => {};
 const $input_ = ($scope, input_0) => _text($scope["#text/0"], input_0);
 const $input = ($scope, input) => $input_($scope, input[0]);
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, $setup$1, $input);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<!><!><button></button>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // tags/custom-tag.marko
 const $template = "<div>tag <!></div>";
 const $walks = "Db%l";
-const $setup = () => {};
 const $input_ = ($scope, input_0) => _text($scope.a, input_0);
 const $input = ($scope, input) => $input_($scope, input[0]);
-var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
+var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, 0, $input);
 
 // template.marko
 const $x_content = _content_resume("a0", "Fallback Body");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-null-fallback/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9642,
-        "brotli": 4129
+        "min": 9631,
+        "brotli": 4125
       },
       "files": {
-        "tags/custom-tag.marko": 347,
+        "tags/custom-tag.marko": 317,
         "template.marko": 436
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_text($scope["#text/0"], $scope.input);
 	_return($scope, $scope.input);
 });
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, $setup$1, $input);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<button>Count: <!></button><!><div>Parent: <!></div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/__snapshots__/dom.bundle.js
@@ -1,12 +1,11 @@
 // tags/custom-tag.marko
 const $template = "<div>Child: <!></div>";
 const $walks = "Db%l";
-const $setup = () => {};
 const $input = /*@__PURE__*/ _const(2, ($scope) => {
 	_text($scope.a, $scope.c);
 	_return($scope, $scope.c);
 });
-var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
+var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, 0, $input);
 
 // template.marko
 const tags = [custom_tag_default];

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args-tag-var/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9800,
-        "brotli": 4191
+        "min": 9795,
+        "brotli": 4187
       },
       "files": {
-        "tags/custom-tag.marko": 339,
+        "tags/custom-tag.marko": 309,
         "template.marko": 451
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "<div> </div>";
 const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input = ($scope, input) => _text($scope["#text/0"], JSON.stringify(input));
-var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, "D l", $setup$1, $input);
+var custom_tag_default = /*@__PURE__*/ _template("__tests__/tags/custom-tag.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Count: <!></button><!><!><!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/__snapshots__/dom.bundle.js
@@ -1,9 +1,8 @@
 // tags/custom-tag.marko
 const $template = "<div> </div>";
 const $walks = "D l";
-const $setup = () => {};
 const $input = ($scope, input) => _text($scope.a, JSON.stringify(input));
-var custom_tag_default = /*@__PURE__*/ _template("b", $template, "D l", $setup, $input);
+var custom_tag_default = /*@__PURE__*/ _template("b", $template, "D l", 0, $input);
 
 // template.marko
 const tags = [custom_tag_default];

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-args/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9536,
-        "brotli": 4090
+        "min": 9531,
+        "brotli": 4091
       },
       "files": {
-        "tags/custom-tag.marko": 289,
+        "tags/custom-tag.marko": 259,
         "template.marko": 386
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/__snapshots__/dom.bundle.debug.js
@@ -6,16 +6,13 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$1, "b%c", $setup$1, $input);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<button id=toggle>toggle</button><!><!>";
 const $walks = " b%c";
 const $inner_content = /*@__PURE__*/ _content("__tests__/template.marko_2*content", "shown content");
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	$input_content_direct($scope["#childScope/0"], $inner_content($scope));
-};
+const $if_content__setup = ($scope) => $input_content_direct($scope["#childScope/0"], $inner_content($scope));
 const $if = /*@__PURE__*/ _if("#text/1", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $show = /*@__PURE__*/ _let("show/2", ($scope) => $if($scope, $scope.show ? 0 : 1));
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/__snapshots__/dom.bundle.js
@@ -1,14 +1,10 @@
 // tags/inner.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content(0);
 
 // template.marko
 const $inner_content = /*@__PURE__*/ _content("a0", "shown content");
-const $if_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup($scope.a);
-	$input_content_direct($scope.a, $inner_content($scope));
-};
+const $if_content__setup = ($scope) => $input_content_direct($scope.a, $inner_content($scope));
 const $if = /*@__PURE__*/ _if(1, /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $show = /*@__PURE__*/ _let(2, ($scope) => $if($scope, $scope.c ? 0 : 1));
 const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-conditional/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 6444,
-        "brotli": 2932
+        "min": 6438,
+        "brotli": 2927
       },
       "files": {
-        "tags/inner.marko": 165,
-        "template.marko": 594
+        "tags/inner.marko": 140,
+        "template.marko": 553
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-default/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-default/__snapshots__/dom.bundle.debug.js
@@ -5,16 +5,14 @@ const $setup$1 = () => {};
 const $input_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input = $dynamicTag;
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D%l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D%l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)("D%l", "D%l");
 const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], {});
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$input($scope["#childScope/1"], { content: $child_content($scope) });
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "Db%l";
 const $setup$1 = () => {};
 const $id = ($scope, id) => _text($scope["#text/0"], id);
 const $input = ($scope, input) => $id($scope, input.id);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<button></button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/__snapshots__/dom.bundle.js
@@ -1,10 +1,9 @@
 // tags/child.marko
 const $template = "<div>Id is <!></div>";
 const $walks = "Db%l";
-const $setup = () => {};
 const $id = ($scope, id) => _text($scope.a, id);
 const $input = ($scope, input) => $id($scope, input.id);
-var child_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("b", $template, $walks, 0, $input);
 
 // template.marko
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(1);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-native/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9558,
-        "brotli": 4099
+        "min": 9547,
+        "brotli": 4093
       },
       "files": {
-        "tags/child.marko": 321,
+        "tags/child.marko": 291,
         "template.marko": 360
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "Db%l";
 const $setup$2 = () => {};
 const $value$1 = ($scope, value) => _text($scope["#text/0"], value);
 const $input$1 = ($scope, input) => $value$1($scope, input.value);
-var child1_default = /*@__PURE__*/ _template("__tests__/tags/child1.marko", $template$2, $walks$2, $setup$2, $input$1);
+var child1_default = /*@__PURE__*/ _template("__tests__/tags/child1.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/child2.marko
 const $template$1 = "<div>Child 2 has <!></div>";
@@ -12,7 +12,7 @@ const $walks$1 = "Db%l";
 const $setup$1 = () => {};
 const $value = ($scope, value) => _text($scope["#text/0"], value);
 const $input = ($scope, input) => $value($scope, input.value);
-var child2_default = /*@__PURE__*/ _template("__tests__/tags/child2.marko", $template$1, $walks$1, $setup$1, $input);
+var child2_default = /*@__PURE__*/ _template("__tests__/tags/child2.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<!><!><button></button>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/__snapshots__/dom.bundle.js
@@ -1,18 +1,16 @@
 // tags/child1.marko
 const $template$1 = "<div>Child 1 has <!></div>";
 const $walks$1 = "Db%l";
-const $setup$1 = () => {};
 const $value$1 = ($scope, value) => _text($scope.a, value);
 const $input$1 = ($scope, input) => $value$1($scope, input.value);
-var child1_default = /*@__PURE__*/ _template("b", $template$1, $walks$1, $setup$1, $input$1);
+var child1_default = /*@__PURE__*/ _template("b", $template$1, $walks$1, 0, $input$1);
 
 // tags/child2.marko
 const $template = "<div>Child 2 has <!></div>";
 const $walks = "Db%l";
-const $setup = () => {};
 const $value = ($scope, value) => _text($scope.a, value);
 const $input = ($scope, input) => $value($scope, input.value);
-var child2_default = /*@__PURE__*/ _template("c", $template, $walks, $setup, $input);
+var child2_default = /*@__PURE__*/ _template("c", $template, $walks, 0, $input);
 
 // template.marko
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-custom-tags/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 14617,
-        "brotli": 5665
+        "min": 14595,
+        "brotli": 5649
       },
       "files": {
-        "tags/child1.marko": 364,
-        "tags/child2.marko": 344,
+        "tags/child1.marko": 330,
+        "tags/child2.marko": 314,
         "template.marko": 440
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
@@ -12,22 +12,18 @@ const $input = ($scope, input) => {
 	(({ as, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
 	$inputAs($scope, input.as);
 };
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", $setup$1, $input);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `<div>${_w0}</div><div>${_w1}</div><div>${_w2}</div><div>${_w3}</div>`)($template$1, $template$1, $template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `D/${_w0}&lD/${_w1}&lD/${_w2}&lD/${_w3}&l`)("b%c", "b%c", "b%c", "b%c");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$inputAs($scope["#childScope/0"]);
 	$htmlInput($scope["#childScope/0"], {});
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$inputAs($scope["#childScope/1"]);
 	$htmlInput($scope["#childScope/1"], {});
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$inputAs($scope["#childScope/2"]);
 	$htmlInput($scope["#childScope/2"], {});
-	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
 	$inputAs($scope["#childScope/3"]);
 	$htmlInput($scope["#childScope/3"], {});
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-name/__snapshots__/dom.bundle.debug.js
@@ -12,7 +12,7 @@ const $input$2 = ($scope, input) => {
 	$other$2($scope, input.other);
 	$content$2($scope, input.content);
 };
-var tag_a_default = /*@__PURE__*/ _template("__tests__/tags/tag-a/index.marko", $template$2, $walks$2, $setup$2, $input$2);
+var tag_a_default = /*@__PURE__*/ _template("__tests__/tags/tag-a/index.marko", $template$2, $walks$2, 0, $input$2);
 
 // tags/tag-b/index.marko
 const $template$1 = "<div>B <!></div>";
@@ -28,7 +28,7 @@ const $input$1 = ($scope, input) => {
 	$other$1($scope, input.other);
 	$content$1($scope, input.content);
 };
-var tag_b_default = /*@__PURE__*/ _template("__tests__/tags/tag-b/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+var tag_b_default = /*@__PURE__*/ _template("__tests__/tags/tag-b/index.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = "<!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-native/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<!><p class=par>paragraph</p><!>";
 const $walks = "d";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "d", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "d");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
@@ -10,16 +10,13 @@ const $showdivnull_content = _content_resume("__tests__/tags/child.marko_1*conte
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $showdivnull_content);
 const $show$1 = ($scope, show) => $dynamicTag($scope, show ? "div" : null);
 const $input = ($scope, input) => $show$1($scope, input.show);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=s>S</button><!><!>";
 const $walks = "b b b%c";
 const $if_content__show = /*@__PURE__*/ _if_closure("#text/2", 0, ($scope) => $show$1($scope["#childScope/0"], $scope._.show));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__show;
 const $if = /*@__PURE__*/ _if("#text/2", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $outer = /*@__PURE__*/ _let("outer/3", ($scope) => $if($scope, $scope.outer ? 0 : 1));
 const $show = /*@__PURE__*/ _let("show/4", $if_content__show);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/dom.bundle.js
@@ -1,6 +1,5 @@
 // tags/child.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0, _content_resume("b0", 0, 0, _script("b1", ($scope) => _lifecycle($scope, { onDestroy: function() {
 	document.getElementById("ref").textContent = "dyn destroyed";
 } }))));
@@ -8,11 +7,7 @@ const $show$1 = ($scope, show) => $dynamicTag($scope, show ? "div" : null);
 
 // template.marko
 const $if_content__show = /*@__PURE__*/ _if_closure(2, 0, ($scope) => $show$1($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__show._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /*@__PURE__*/ _if(2, /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /*@__PURE__*/ _if(2, /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__show);
 const $outer = /*@__PURE__*/ _let(3, ($scope) => $if($scope, $scope.d ? 0 : 1));
 const $show = /*@__PURE__*/ _let(4, $if_content__show);
 const $setup__script = _script("a0", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9481,
-        "brotli": 4089
+        "min": 9467,
+        "brotli": 4081
       },
       "files": {
-        "tags/child.marko": 393,
-        "template.marko": 734
+        "tags/child.marko": 368,
+        "template.marko": 624
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
@@ -17,15 +17,13 @@ const $input = ($scope, input) => {
 	$inputAs($scope, input.as);
 	$foo($scope, input.foo);
 };
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", $setup$1, $input);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>${_w0}</div><div>${_w1}</div>`)($template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `D/${_w0}&lD/${_w1}&l`)("b%c", "b%c");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], { id: "foo" });
-	/* @__PURE__ */ $setup$1($scope["#childScope/1"]);
 	$foo($scope["#childScope/1"], "bar");
 	const $wrapper_input_spread = { id: "foo" };
 	$inputAs($scope["#childScope/1"], $wrapper_input_spread.as);

--- a/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/empty-child-template/__snapshots__/dom.bundle.debug.js
@@ -2,10 +2,10 @@
 const $template$1 = "";
 const $walks$1 = "";
 const $setup$1 = () => {};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div>${_w0}</div>`)("");
 const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}&l`)("");
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks);

--- a/packages/runtime-tags/src/__tests__/fixtures/entities/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/entities/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "Hello John &amp; Suzy Invalid Entity: &b ; Valid Numeric Entity: &#34; Valid Hexadecimal Entity: &#x00A2;";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-comment-object-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_value = /*@__PURE__*/ _const("input_value", ($scope) => _text($scope["#comment/0"], $scope.input_value));
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-own-body-read-before-return/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-custom-tag-own-body-read-before-return/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, () => $r);
 const $r = _var_resume("__tests__/tags/child.marko_0_r#5/var", /*@__PURE__*/ _const("r", ($scope) => _return($scope, $scope.r)));
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b1c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b1c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div> </div>`)($template$1);
@@ -24,7 +24,6 @@ const $x = _var_resume("__tests__/template.marko_0_x#3/var", /*@__PURE__*/ _cons
 }));
 function $setup($scope) {
 	_var($scope, "#childScope/0", $x);
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $child_content($scope));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-content/__snapshots__/dom.bundle.debug.js
@@ -6,4 +6,4 @@ const $input_tag_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_tag = $dynamicTag;
 const $input = ($scope, input) => $input_tag($scope, input.tag);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-number/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-dynamic-tag-number/__snapshots__/dom.bundle.debug.js
@@ -6,4 +6,4 @@ const $input_tag_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_tag = $dynamicTag;
 const $input = ($scope, input) => $input_tag($scope, input.tag);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-exclusive-checked-value-spread/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
 	$input_attrs__script($scope);
 });
 const $input = ($scope, input) => $input_attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-duplicate/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-duplicate/__snapshots__/dom.bundle.debug.js
@@ -12,4 +12,4 @@ const $for = /*@__PURE__*/ _for_of("#text/0", "<button> </button>", " D ", $for_
 const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, () => "dup"]));
 const $input_items = $items;
 const $input = ($scope, input) => $input_items($scope, input.items);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-object/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-object/__snapshots__/dom.bundle.debug.js
@@ -12,4 +12,4 @@ const $for = /*@__PURE__*/ _for_of("#text/0", "<button> </button>", " D ", $for_
 const $items = /*@__PURE__*/ _let("items/4", ($scope) => $for($scope, [$scope.items, (item) => item]));
 const $input_items = $items;
 const $input = ($scope, input) => $input_items($scope, input.items);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-static/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-static/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_id($scope
 const $for = /*@__PURE__*/ _for_of("#text/0", " ", " ", 0, $for_content__$params);
 const $input_items = ($scope, input_items) => $for($scope, [input_items, (item) => item]);
 const $input = ($scope, input) => $input_items($scope, input.items);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-from-non-number/__snapshots__/dom.bundle.debug.js
@@ -10,4 +10,4 @@ const $input_from = ($scope, input_from) => $for($scope, [
 	1
 ]);
 const $input = ($scope, input) => $input_from($scope, input.from);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-of-non-iterable/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $for_content__$params = ($scope, $params2) => $for_content__item($scope, $
 const $for = /*@__PURE__*/ _for_of("#text/0", "<li> </li>", "D ", 0, $for_content__$params);
 const $input_value = ($scope, input_value) => $for($scope, [input_value]);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-to-non-finite/__snapshots__/dom.bundle.debug.js
@@ -10,4 +10,4 @@ const $input_to = ($scope, input_to) => $for($scope, [
 	1
 ]);
 const $input = ($scope, input) => $input_to($scope, input.to);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-until-non-finite/__snapshots__/dom.bundle.debug.js
@@ -10,4 +10,4 @@ const $input_until = ($scope, input_until) => $for($scope, [
 	1
 ]);
 const $input = ($scope, input) => $input_until($scope, input.until);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-multi-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
@@ -16,4 +16,4 @@ const $input = ($scope, input) => {
 	$input_attrs($scope, input.attrs);
 	$input_more($scope, input.more);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-function-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_handler = ($scope, input_handler) => _attr($scope["#div/0"], "title", input_handler);
 const $input = ($scope, input) => $input_handler($scope, input.handler);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-object-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _attr($scope["#div/0"], "title", input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-promise-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _attr($scope["#div/0"], "title", input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-attr-symbol-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _attr($scope["#div/0"], "title", input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-event-handler-not-function/__snapshots__/dom.bundle.debug.js
@@ -5,4 +5,4 @@ const $setup = () => {};
 const $input_onClick__script = _script("__tests__/template.marko_0_input_onClick#3", ($scope) => _on($scope["#button/0"], "click", $scope.input_onClick));
 const $input_onClick = /*@__PURE__*/ _const("input_onClick", $input_onClick__script);
 const $input = ($scope, input) => $input_onClick($scope, input.onClick);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-spread-react-attribute/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
 	$input_attrs__script($scope);
 });
 const $input = ($scope, input) => $input_attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-native-tag-lowercase-event-handler-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_handler = ($scope, input_handler) => _attr($scope["#button/0"], "onclick", input_handler);
 const $input = ($scope, input) => $input_handler($scope, input.handler);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-change-handler-not-controllable/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
 	$input_attrs__script($scope);
 });
 const $input = ($scope, input) => $input_attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-checked-with-value-change/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-checked-with-value-change/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
 	$input_attrs__script($scope);
 });
 const $input = ($scope, input) => $input_attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-spread-invalid-attr-name/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-spread-invalid-attr-name/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_attrs = /*@__PURE__*/ _const("input_attrs", ($scope) => {
 	$input_attrs__script($scope);
 });
 const $input = ($scope, input) => $input_attrs($scope, input.attrs);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-text-object-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D l", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by-conditional/__snapshots__/dom.bundle.debug.js
@@ -12,4 +12,4 @@ const $input = ($scope, input) => {
 	$input_items($scope, input.items);
 	$input_useKey($scope, input.useKey);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-of-member-signal-collapse/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-of-member-signal-collapse/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#ul/0", "<li><!> (<!>)</li>", "D%c%", 0, $for_content__$params);
 const $input_users = ($scope, input_users) => $for($scope, [input_users]);
 const $input = ($scope, input) => $input_users($scope, input.users);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-grow-shrink/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-insert-middle/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-mixed/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-replace/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-reverse/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-rotate/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $for_content__$params = ($scope, $params2) => {
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", " D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-reorder-swap/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $for_content__$params = ($scope, $params2) => $for_content__child_text($sc
 const $for = /*@__PURE__*/ _for_of("#div/0", "<span> </span>", "D ", 0, $for_content__$params);
 const $input_children = ($scope, input_children) => $for($scope, [input_children, "id"]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $count$1 = ($scope, count) => $for($scope, [
 	1
 ]);
 const $input = ($scope, input) => $count$1($scope, input.count);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, "b%c", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<button id=o>O</button><button id=c>C</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $count$1 = ($scope, count) => $for($scope, [
 	1
 ]);
 const $input = ($scope, input) => $count$1($scope, input.count);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=a>A</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/for-text-constructor/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-text-constructor/__snapshots__/dom.bundle.debug.js
@@ -5,4 +5,4 @@ const $setup = () => {};
 const $for = /*@__PURE__*/ _for_of("#div/0", "constructor");
 const $input_words = ($scope, input_words) => $for($scope, [input_words]);
 const $input = ($scope, input) => $input_words($scope, input.words);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hello-dynamic/__snapshots__/dom.bundle.debug.js
@@ -11,4 +11,4 @@ const $input = ($scope, input) => {
 	$input_name($scope, input.name);
 	$input_missing($scope, input.missing);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input_what_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_what = $dynamicTag;
 const $input = ($scope, input) => $input_what($scope, input.what);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$1, "b%c", $setup$1, $input);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
@@ -34,7 +34,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	}
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_what($scope["#childScope/0"], attrTag({ content: $what_content($scope) }));
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input_content = ($scope, input_content) => {
 	$dynamicTag2$1($scope, input_content);
 };
 const $input$1 = ($scope, input) => $input_content($scope, input.content);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$2, $walks$2, $setup$2, $input$1);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/child.marko
 const $template$1 = "<div></div>";
@@ -38,10 +38,7 @@ const $thing_content2__setup = ($scope) => {
 	$setup$1($scope["#childScope/0"]);
 };
 const $thing_content2 = /*@__PURE__*/ _content("__tests__/template.marko_3*content", $template$1, /*@__PURE__*/ ((_w0) => `0${_w0}&`)(" b"), $thing_content2__setup, 0, "ClosureScopes:3");
-const $inputshowThingnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-	$input_content($scope["#childScope/0"], $thing_content2($scope));
-};
+const $inputshowThingnull_content__setup = ($scope) => $input_content($scope["#childScope/0"], $thing_content2($scope));
 const $inputshowThingnull_content = _content_resume("__tests__/template.marko_2*content", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$2), $inputshowThingnull_content__setup, 0, "ClosureScopes:2");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml#2/hoist", "setHtml", "ClosureScopes:1");
 const $thing_content__setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));
@@ -58,7 +55,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	$setHtml3_getter($scope)()("Hoist from dynamic tag");
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $thing_content($scope));
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // tags/thing.marko
 const $template$1 = "<!><!><!><!>";
 const $walks = "b%b%c";
-const $setup$1 = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
 const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(1);
 const $input_content = ($scope, input_content) => {
@@ -32,10 +31,7 @@ const $thing_content2__setup = ($scope) => {
 	$setup($scope.a);
 };
 const $thing_content2 = /*@__PURE__*/ _content("a2", $template, /*@__PURE__*/ ((_w0) => `0${_w0}&`)(" b"), $thing_content2__setup, 0, "B3");
-const $inputshowThingnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope.a);
-	$input_content($scope.a, $thing_content2($scope));
-};
+const $inputshowThingnull_content__setup = ($scope) => $input_content($scope.a, $thing_content2($scope));
 const $inputshowThingnull_content = _content_resume("a3", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks), $inputshowThingnull_content__setup, 0, "B2");
 const $setHtml_getter = _hoist_resume("a0", 2, "B1");
 const $setup__script = _script("a5", ($scope) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-from-dynamic/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9356,
+        "min": 9350,
         "brotli": 4004
       },
       "files": {
-        "tags/thing.marko": 360,
+        "tags/thing.marko": 333,
         "tags/child.marko": 234,
-        "template.marko": 1484
+        "template.marko": 1441
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-minimum-scope/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_value = /*@__PURE__*/ _const("input_value", ($scope) => _return($sc
 const $input = ($scope, input) => $input_value($scope, input.value);
 const $_return = ($scope) => () => $scope.input_value;
 _resume("__tests__/tags/child.marko_0/_return", $_return);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // template.marko
 const $template = "<pre id=root></pre><pre id=outer></pre><pre id=inner></pre><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "";
 const $setup$2 = () => {};
 const $input__script = _script("__tests__/tags/child.marko_0_input#1", ($scope) => $scope.input.action());
 const $input = /*@__PURE__*/ _const("input", $input__script);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$2, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // tags/source.marko
 const $template$1 = "<div></div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$2 = () => {};
 const $input_value__script = _script("__tests__/tags/thing.marko_0_input_value#2", ($scope) => $scope.input_value);
 const $input_value = /*@__PURE__*/ _const("input_value", $input_value__script);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", $setup$2, $input);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", 0, $input);
 
 // tags/child.marko
 const $template$1 = "<div></div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $setup$1 = () => {};
 const $input_value__script = _script("__tests__/tags/thing.marko_0_input_value#2", ($scope) => $scope.input_value);
 const $input_value = /*@__PURE__*/ _const("input_value", $input_value__script);
 const $input$1 = ($scope, input) => $input_value($scope, input.value);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", $setup$1, $input$1);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!><!>${_w0}<!><!><!><!>`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
@@ -19,7 +19,7 @@ const $input_content = ($scope, input_content) => {
 	$dynamicTag2$1($scope, input_content);
 };
 const $input$1 = ($scope, input) => $input_content($scope, input.content);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$1, $walks$1, $setup$1, $input$1);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!><!><!>`)($template$1);
@@ -34,10 +34,7 @@ const $thing_content2__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, () 
 const $thing_content2__setHtml = _var_resume("__tests__/template.marko_3_setHtml2#2/var", /*@__PURE__*/ _const("setHtml2", ($scope) => _assert_hoist($scope.setHtml2)));
 const $thing_content2__setup = ($scope) => $thing_content2__dynamicTag($scope, 1 && child_default);
 const $thing_content2 = /*@__PURE__*/ _content("__tests__/template.marko_3*content", "<!><!><!>", "b1", $thing_content2__setup, 0, "ClosureScopes:3");
-const $inputshowThingnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
-	$input_content($scope["#childScope/0"], $thing_content2($scope));
-};
+const $inputshowThingnull_content__setup = ($scope) => $input_content($scope["#childScope/0"], $thing_content2($scope));
 const $inputshowThingnull_content = _content_resume("__tests__/template.marko_2*content", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1), $inputshowThingnull_content__setup, 0, "ClosureScopes:2");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml#2/hoist", "setHtml", "ClosureScopes:1");
 const $thing_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, () => $thing_content__setHtml);
@@ -52,7 +49,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	$setHtml3_getter($scope)()("Hoist from dynamic tag");
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $thing_content($scope));
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/__snapshots__/dom.bundle.js
@@ -1,17 +1,16 @@
 // tags/child.marko
 const $template$1 = "<div></div>";
 const $walks$1 = " b";
-function $setup$1($scope) {
+function $setup($scope) {
 	_return($scope, $_return($scope));
 }
 const $_return = ($scope) => () => (html) => $scope.a.innerHTML = html;
 _resume("b0", $_return);
-var child_default = /*@__PURE__*/ _template("b", $template$1, " b", $setup$1);
+var child_default = /*@__PURE__*/ _template("b", $template$1, " b", $setup);
 
 // tags/thing.marko
 const $template = "<!><!><!><!>";
 const $walks = "b%b%c";
-const $setup = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
 const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(1);
 const $input_content = ($scope, input_content) => {
@@ -30,10 +29,7 @@ const $thing_content2__dynamicTag = /*@__PURE__*/ _dynamic_tag(0, 0, () => $thin
 const $thing_content2__setHtml = _var_resume("a3", /*@__PURE__*/ _const(2));
 const $thing_content2__setup = ($scope) => $thing_content2__dynamicTag($scope, child_default);
 const $thing_content2 = /*@__PURE__*/ _content("a4", "<!><!><!>", "b1", $thing_content2__setup, 0, "B3");
-const $inputshowThingnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup($scope.a);
-	$input_content($scope.a, $thing_content2($scope));
-};
+const $inputshowThingnull_content__setup = ($scope) => $input_content($scope.a, $thing_content2($scope));
 const $inputshowThingnull_content = _content_resume("a5", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks), $inputshowThingnull_content__setup, 0, "B2");
 const $setHtml_getter = _hoist_resume("a0", 2, "B1");
 const $thing_content__setHtml = _var_resume("a1", /*@__PURE__*/ _const(2));

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-from-dynamic/sizes.json
@@ -2,13 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10116,
-        "brotli": 4284
+        "min": 10110,
+        "brotli": 4280
       },
       "files": {
-        "tags/child.marko": 340,
-        "tags/thing.marko": 356,
-        "template.marko": 1724
+        "tags/child.marko": 336,
+        "tags/thing.marko": 331,
+        "template.marko": 1683
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $setup$1 = () => {};
 const $input_value__script = _script("__tests__/tags/thing.marko_0_input_value#2", ($scope) => $scope.input_value);
 const $input_value = /*@__PURE__*/ _const("input_value", $input_value__script);
 const $input$1 = ($scope, input) => $input_value($scope, input.value);
-var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", $setup$1, $input$1);
+var thing_default = /*@__PURE__*/ _template("__tests__/tags/thing.marko", "", "", 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!><!>${_w0}<!><!><!><!>`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-in-function/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input_fn = ($scope, input_fn) => _text($scope["#text/0"], typeof input_fn);
 const $input = ($scope, input) => $input_fn($scope, input.fn);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input_content = ($scope, input_content) => {
 	$dynamicTag2$1($scope, input_content);
 };
 const $input$1 = ($scope, input) => $input_content($scope, input.content);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!><!><!>`)($template$1);
@@ -25,7 +25,6 @@ const $inputshowChildnull_content__setup__script = _script("__tests__/template.m
 	}
 });
 const $inputshowChildnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $child_content2($scope));
 	$inputshowChildnull_content__setup__script($scope);
 };
@@ -47,7 +46,6 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => {
 	}
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $child_content($scope));
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/__snapshots__/dom.bundle.js
@@ -1,7 +1,6 @@
 // tags/child.marko
 const $template = "<!><!><!><!>";
 const $walks = "b%b%c";
-const $setup = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
 const $dynamicTag2 = /*@__PURE__*/ _dynamic_tag(1);
 const $input_content = ($scope, input_content) => {
@@ -19,7 +18,6 @@ const $inputshowChildnull_content__setup__script = _script("a6", ($scope) => {
 	for (const el of $inputshowChildnull_content__$el2_getter($scope)) el.classList.add("inner");
 });
 const $inputshowChildnull_content__setup = ($scope) => {
-	/* @__PURE__ */ $setup($scope.a);
 	$input_content($scope.a, $child_content2($scope));
 	$inputshowChildnull_content__setup__script($scope);
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-from-dynamic/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9173,
-        "brotli": 3921
+        "min": 9169,
+        "brotli": 3920
       },
       "files": {
-        "tags/child.marko": 356,
-        "template.marko": 1321
+        "tags/child.marko": 331,
+        "template.marko": 1286
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "";
 const $setup$1 = () => {};
 const $input__script = _script("__tests__/tags/child.marko_0_input#1", ($scope) => $scope.input.action());
 const $input = /*@__PURE__*/ _const("input", $input__script);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}<div></div>${_w1}`)("", "");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "";
 const $setup$1 = () => {};
 const $input__script = _script("__tests__/tags/child.marko_0_input#1", ($scope) => $scope.input.value().innerHTML = "mounted");
 const $input = /*@__PURE__*/ _const("input", $input__script);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}<div></div>${_w1}`)("", "");

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = " b";
 const $setup$2 = () => {};
 const $input__script = _script("__tests__/tags/child.marko_0_input#2", ($scope) => _el_read($scope["#div/0"]).innerHTML = $scope.input.y());
 const $input = /*@__PURE__*/ _const("input", $input__script);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input);
 
 // tags/source.marko
 const $template$1 = "";

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-static-unsafe/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-static-unsafe/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div><!--a --&gt; b--><span>after</span></div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/html-entity/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-entity/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<div>&lt;div&gt;</div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/if-flatten-else-if-space-syntax/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-flatten-else-if-space-syntax/__snapshots__/dom.bundle.debug.js
@@ -9,4 +9,4 @@ const $input = ($scope, input) => {
 	$input_a($scope, input.a);
 	$input_b($scope, input.b);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D l", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $n$1 = /*@__PURE__*/ _const("n", ($scope) => {
 	$if_content__input_n($scope);
 });
 const $input = ($scope, input) => $n$1($scope, input.n);
-var leaf_default = /*@__PURE__*/ _template("__tests__/tags/leaf.marko", $template$1, "b%c", $setup$1, $input);
+var leaf_default = /*@__PURE__*/ _template("__tests__/tags/leaf.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<button id=o>O</button><button id=n>N</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,7 @@ const $if_content__setup$1 = ($scope) => {
 const $if$1 = /*@__PURE__*/ _if("#text/0", $template$2, /*@__PURE__*/ ((_w0) => `/${_w0}&`)("b"), $if_content__setup$1);
 const $show$1 = ($scope, show) => $if$1($scope, show ? 0 : 1);
 const $input = ($scope, input) => $show$1($scope, input.show);
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", $setup$1, $input);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=s>S</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $if_content__setup$1 = $if_content__setup__script;
 const $if$1 = /*@__PURE__*/ _if("#text/0", "<p>inner</p>", 0, $if_content__setup$1);
 const $show$1 = ($scope, show) => $if$1($scope, show ? 0 : 1);
 const $input = ($scope, input) => $show$1($scope, input.show);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<div id=ref>init</div><button id=o>O</button><button id=s>S</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-tag/__snapshots__/dom.bundle.debug.js
@@ -19,4 +19,4 @@ const $input = ($scope, input) => {
 	$input_x($scope, input.x);
 	$input_y($scope, input.y);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-barrel-registered-function/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$3 = () => {};
 function gamma(message) {
 	return message + "-g";
 }
-var extras_default = /*@__PURE__*/ _template("__tests__/tags/extras.marko", "", "", $setup$3);
+var extras_default = /*@__PURE__*/ _template("__tests__/tags/extras.marko", "", "");
 
 // tags/handlers.marko
 const $template$2 = "";
@@ -17,13 +17,13 @@ function alpha(message) {
 function beta(message) {
 	return message + "-b";
 }
-var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "", $setup$2);
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "");
 
 // tags/barrel.marko
 const $template$1 = "";
 const $walks$1 = "";
 const $setup$1 = () => {};
-var barrel_default = /*@__PURE__*/ _template("__tests__/tags/barrel.marko", "", "", $setup$1);
+var barrel_default = /*@__PURE__*/ _template("__tests__/tags/barrel.marko", "", "");
 
 // tags/v:handlers.marko.register-beta.js
 _resume("__tests__/tags/handlers.marko_0/export/beta", beta);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-circular-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$2 = () => {};
 function bFn(message) {
 	return message + "-b";
 }
-var chain_b_default = /*@__PURE__*/ _template("__tests__/tags/chain-b.marko", $template$2, "b", $setup$2);
+var chain_b_default = /*@__PURE__*/ _template("__tests__/tags/chain-b.marko", $template$2, "b");
 
 // tags/chain-a.marko
 const $template$1 = "<div>a</div>";
@@ -14,7 +14,7 @@ const $setup$1 = () => {};
 function aFn(message) {
 	return message + "-a";
 }
-var chain_a_default = /*@__PURE__*/ _template("__tests__/tags/chain-a.marko", $template$1, "b", $setup$1);
+var chain_a_default = /*@__PURE__*/ _template("__tests__/tags/chain-a.marko", $template$1, "b");
 
 // tags/v:chain-b.marko.register-bFn.js
 _resume("__tests__/tags/chain-b.marko_0/export/bFn", bFn);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ function shout(message) {
 }
 const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", $template$1, "D l", $setup$1, $input);
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", $template$1, "D l", 0, $input);
 
 // tags/v:handlers.marko.register-shout.js
 _resume("__tests__/tags/handlers.marko_0/export/shout", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/__snapshots__/dom.bundle.js
@@ -1,13 +1,12 @@
 // tags/handlers.marko
 const $template = "<div> </div>";
 const $walks = "D l";
-const $setup = () => {};
 function shout(message) {
 	return message.toUpperCase() + "!";
 }
 const $input_message = ($scope, input_message) => _text($scope.a, input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var handlers_default = /*@__PURE__*/ _template("b", $template, "D l", $setup, $input);
+var handlers_default = /*@__PURE__*/ _template("b", $template, "D l", 0, $input);
 
 // tags/v:handlers.marko.register-shout.js
 _resume("b0", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-function-specifiers/sizes.json
@@ -2,11 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9608,
-        "brotli": 4110
+        "min": 9591,
+        "brotli": 4109
       },
       "files": {
-        "tags/handlers.marko": 431,
+        "tags/handlers.marko": 401,
         "tags/v:handlers.marko.register-shout.js": 85,
         "template.marko": 350
       }

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ function shout(message) {
 }
 const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", $setup$1, $input);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>add</button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ function shout(message) {
 }
 const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", $setup$2, $input);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", 0, $input);
 
 // tags/v:greeting.marko.register-shout.js
 _resume("__tests__/tags/greeting.marko_0/export/shout", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-tag-input/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$2 = () => {};
 function shout(message) {
 	return message.toUpperCase() + "!";
 }
-var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "", $setup$2);
+var handlers_default = /*@__PURE__*/ _template("__tests__/tags/handlers.marko", "", "");
 
 // tags/press.marko
 const $template$1 = "<button>press</button><div> </div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ function shout(message) {
 }
 const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", $setup$1, $input);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$1, "D l", 0, $input);
 
 // tags/v:greeting.marko.register-shout.js
 _resume("__tests__/tags/greeting.marko_0/export/shout", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/dom.bundle.debug.js
@@ -7,13 +7,13 @@ function shout(message) {
 }
 const $input_message = ($scope, input_message) => _text($scope["#text/0"], input_message);
 const $input = ($scope, input) => $input_message($scope, input.message);
-var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", $setup$2, $input);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/greeting.marko", $template$2, "D l", 0, $input);
 
 // tags/greetings.marko
 const $template$1 = "<div>greetings</div>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var greetings_default = /*@__PURE__*/ _template("__tests__/tags/greetings.marko", $template$1, "b", $setup$1);
+var greetings_default = /*@__PURE__*/ _template("__tests__/tags/greetings.marko", $template$1, "b");
 
 // tags/v:greeting.marko.register-shout.js
 _resume("__tests__/tags/greeting.marko_0/export/shout", shout);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-shorthand/__snapshots__/dom.bundle.debug.js
@@ -2,10 +2,10 @@
 const $template$1 = "<div></div>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$1, "b", $setup$1);
+var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$1, "b");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<!>${_w0}${_w1}<!>`)($template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `b/${_w0}&/${_w1}&b`)("b", "b");
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/dom.bundle.debug.js
@@ -2,13 +2,13 @@
 const $template$2 = "<div>baz</div>";
 const $walks$2 = "b";
 const $setup$2 = () => {};
-var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$2, "b", $setup$2);
+var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$2, "b");
 
 // tags/foo.marko
 const $template$1 = "<div>foo</div>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var foo_default = /*@__PURE__*/ _template("__tests__/tags/foo.marko", $template$1, "b", $setup$1);
+var foo_default = /*@__PURE__*/ _template("__tests__/tags/foo.marko", $template$1, "b");
 
 // template.marko
 const $template = "<!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const b = "b";
 const $template$1 = "<div></div>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$1, "b", $setup$1);
+var baz_default = /*@__PURE__*/ _template("__tests__/tags/baz.marko", $template$1, "b");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<!>${_w0}${_w1}${_w2}<!>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = ($scope, input) => {
 	$input_content($scope, input.content);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
@@ -19,7 +19,6 @@ const $child_content__x = ($scope, x) => _text($scope["#text/0"], x);
 const $child_content__$params = ($scope, $params2) => $child_content__x($scope, $params2[0]);
 const $child_content = _content_resume("__tests__/template.marko_1*content", " ", " ", 0, $child_content__$params);
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_content($scope["#childScope/0"], $child_content($scope));
 	$input_value($scope["#childScope/0"], "Hi");
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/input-destructure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-destructure/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input = ($scope, input) => {
 	$a($scope, input.a);
 	$b($scope, input.b);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-integer-reference/__snapshots__/dom.bundle.debug.js
@@ -8,4 +8,4 @@ const $input_value = ($scope, input_value) => {
 };
 const $input_value_ = ($scope, input_value_0) => _text($scope["#text/1"], input_value_0);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$input__script($scope);
 });
 const $input_value = ($scope, input_value) => _text($scope["#text/1"], input_value);
-var my_input_default = /*@__PURE__*/ _template("__tests__/tags/my-input.marko", $template$1, $walks$1, $setup$1, $input);
+var my_input_default = /*@__PURE__*/ _template("__tests__/tags/my-input.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $doubled__OR__tripled = ($scope) => {
 };
 const $input_n = /*@__PURE__*/ _const("input_n", $doubled__OR__tripled);
 const $input = ($scope, input) => $input_n($scope, input.n);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>inc</button>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_a$1($scope, input.a);
 	$input_b$1($scope, input.b);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, $setup$1, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $Child_content__walks = "D lD l", $Child_content__template = "<div> </div><div> </div>";

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -22,7 +22,7 @@ const $input = ($scope, input) => {
 	(({ button, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
 	$buttons($scope, input.button);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input = ($scope, input) => {
 	(({ first, ...rest }) => $rest($scope, rest))(input);
 	$first($scope, input.first);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>inc <!></button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input_stuff = ($scope, input_stuff) => {
 };
 const $input_stuff_other = ($scope, input_stuff_other) => $input_stuff_other_y($scope, input_stuff_other?.y);
 const $input_stuff_cond = ($scope, input_stuff_cond) => $input_stuff_cond_a($scope, input_stuff_cond?.a);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner/index.marko", $template$2, $walks$2, $setup$2, $input$1);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner/index.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/child/index.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<h1> </h1>${_w0}`)($template$2);
@@ -28,7 +28,7 @@ const $input = ($scope, input) => {
 	(({ title, ...rest }) => $rest($scope, rest))(input);
 	$title($scope, input.title);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input_a = ($scope, input_a) => _text($scope["#text/0"], input_a);
 const $input = ($scope, input) => $input_a($scope, input.a);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>inc <!></button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$2 = () => {};
 const $input_data_val = ($scope, input_data_val) => _text($scope["#text/0"], input_data_val);
 const $input$1 = ($scope, input) => $input_data($scope, input.data);
 const $input_data = ($scope, input_data) => $input_data_val($scope, input_data?.val);
-var leaf_default = /*@__PURE__*/ _template("__tests__/tags/leaf.marko", $template$2, $walks$2, $setup$2, $input$1);
+var leaf_default = /*@__PURE__*/ _template("__tests__/tags/leaf.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/mid.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<p><!> <!></p>${_w0}`)($template$2);
@@ -22,7 +22,7 @@ const $group2 = ($scope, $group) => {
 	(({ keep, ...rest }) => $rest($scope, rest))($group);
 	$keep($scope, $group.keep);
 };
-var mid_default = /*@__PURE__*/ _template("__tests__/tags/mid.marko", $template$1, $walks$1, $setup$1, $input);
+var mid_default = /*@__PURE__*/ _template("__tests__/tags/mid.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>inc <!></button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$1 = "D l";
 const $setup$1 = () => {};
 const $input_a = ($scope, input_a) => _text($scope["#text/0"], input_a);
 const $input = ($scope, input) => $input_a($scope, input.a);
-var child_b_default = /*@__PURE__*/ _template("__tests__/tags/child-b/index.marko", $template$1, "D l", $setup$1, $input);
+var child_b_default = /*@__PURE__*/ _template("__tests__/tags/child-b/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>inc <!></button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input$2 = ($scope, input) => {
 	$input_b$1($scope, input.b);
 	$input_c($scope, input.c);
 };
-var child_a_default = /*@__PURE__*/ _template("__tests__/tags/child-a/index.marko", $template$2, $walks$2, $setup$2, $input$2);
+var child_a_default = /*@__PURE__*/ _template("__tests__/tags/child-a/index.marko", $template$2, $walks$2, 0, $input$2);
 
 // tags/child-c/index.marko
 const $template$1 = "<div><!> <!></div>";
@@ -22,7 +22,7 @@ const $input$1 = ($scope, input) => {
 	$input_a($scope, input.a);
 	$input_b($scope, input.b);
 };
-var child_c_default = /*@__PURE__*/ _template("__tests__/tags/child-c/index.marko", $template$1, $walks$1, $setup$1, $input$1);
+var child_c_default = /*@__PURE__*/ _template("__tests__/tags/child-c/index.marko", $template$1, $walks$1, 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<button>inc <!></button>${_w0}${_w1}${_w2}`)($template$2, $template$2, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input = ($scope, input) => {
 	$input_label($scope, input.label);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, 0, $input);
 
 // template.marko
 const $template = "<button>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input = ($scope, input) => {
 	$input_label($scope, input.label);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, 0, $input);
 
 // template.marko
 const $template = "<button class=toggle>Toggle</button><button class=inc>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/__snapshots__/dom.bundle.js
@@ -22,11 +22,10 @@ const $setup__script = _script("b2", ($scope) => {
 // child.marko
 const $template = "<div><!>: <!></div>";
 const $walks = "D%c%l";
-const $setup = () => {};
 const $input_label = ($scope, input_label) => _text($scope.a, input_label);
 const $input_value = ($scope, input_value) => _text($scope.b, input_value);
 const $input = ($scope, input) => {
 	$input_label($scope, input.label);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("a", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("a", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic-placeholder/sizes.json
@@ -9,8 +9,8 @@
       "brotli": 780
     },
     "child.mjs": {
-      "min": 221,
-      "brotli": 150
+      "min": 212,
+      "brotli": 143
     },
     "shared": {
       "min": 11221,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input = ($scope, input) => {
 	$input_label($scope, input.label);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, 0, $input);
 
 // template.marko
 const $template = "<button class=toggle>Toggle</button><button class=inc>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/__snapshots__/dom.bundle.js
@@ -19,11 +19,10 @@ const $setup__script = _script("b0", ($scope) => {
 // child.marko
 const $template = "<div><!>: <!></div>";
 const $walks = "D%c%l";
-const $setup = () => {};
 const $input_label = ($scope, input_label) => _text($scope.a, input_label);
 const $input_value = ($scope, input_value) => _text($scope.b, input_value);
 const $input = ($scope, input) => {
 	$input_label($scope, input.label);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("a", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("a", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-dynamic/sizes.json
@@ -9,8 +9,8 @@
       "brotli": 741
     },
     "child.mjs": {
-      "min": 221,
-      "brotli": 150
+      "min": 212,
+      "brotli": 143
     },
     "shared": {
       "min": 10879,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-input-chunk-load-error/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button id=toggle>toggle</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<!><!><button>Inc</button>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button class=toggle>Toggle</button><button class=inc>Inc</button><!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/dom.bundle.js
@@ -20,7 +20,6 @@ const $setup__script = _script("b0", ($scope) => {
 // child.marko
 const $template = "<span> </span>";
 const $walks = "D l";
-const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope.a, input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("a", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("a", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/sizes.json
@@ -9,8 +9,8 @@
       "brotli": 773
     },
     "child.mjs": {
-      "min": 199,
-      "brotli": 134
+      "min": 190,
+      "brotli": 132
     },
     "shared": {
       "min": 10937,

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button id=inc>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<!><!><button>click</button>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks = "D l";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);
 
 // template.marko
 const $template = "<button>Inc</button><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/dom.bundle.debug.js
@@ -26,7 +26,7 @@ const $walks = "Db%l";
 const $setup = () => {};
 const $value = ($scope, value) => _text($scope["#text/0"], value);
 const $input = ($scope, input) => $value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, 0, $input);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,7 @@ const $_return = ($scope) => function(v) {
 };
 _resume("__tests__/tags/store.marko_0/_return2", $_return2);
 _resume("__tests__/tags/store.marko_0/_return", $_return);
-var store_default = /*@__PURE__*/ _template("__tests__/tags/store.marko", "", "", $setup$1, $input);
+var store_default = /*@__PURE__*/ _template("__tests__/tags/store.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>Clear</button><ul></ul>`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = ($scope, input) => {
 	$input_value($scope, input.value);
 	$input_valueChange($scope, input.valueChange);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>clear</button>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input = ($scope, input) => {
 	$initial$1($scope, input.initial);
 	$onValue$1($scope, input.onValue);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<button>inc</button>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/local-closure-script/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $for_content__$params = ($scope, $params2) => $for_content__item_content($
 const $for = /*@__PURE__*/ _for_of("#text/0", "<!><!><!>", "b%", 0, $for_content__$params);
 const $input_item = ($scope, input_item) => $for($scope, [input_item]);
 const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", $setup$1, $input);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list/index.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/migrate-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/migrate-input/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = "E m";
 const $setup = () => {};
 const $input_x = ($scope, input_x) => _text($scope["#text/0"], input_x);
 const $input = ($scope, input) => $input_x($scope, input.x);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "E m", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "E m", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/dom.bundle.debug.js
@@ -9,4 +9,4 @@ const $children = ($scope, children) => $for($scope, [children, function(c) {
 	return c.id;
 }]);
 const $input = ($scope, input) => $children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/dom.bundle.debug.js
@@ -9,4 +9,4 @@ const $input_children = ($scope, input_children) => $for($scope, [input_children
 	return c.id;
 }]);
 const $input = ($scope, input) => $input_children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
@@ -18,7 +18,7 @@ const $input = ($scope, input) => {
 	$input_content($scope, input.content);
 };
 const $input_content = /*@__PURE__*/ _const("input_content", $for_content__input_content);
-var my_for_default = /*@__PURE__*/ _template("__tests__/tags/my-for.marko", $template$1, "b%c", $setup$1, $input);
+var my_for_default = /*@__PURE__*/ _template("__tests__/tags/my-for.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-name/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-name/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<!><span></span><div></div><div></div>";
 const $walks = "e";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "e", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "e");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-ref-effect-child/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $el__script = _script("__tests__/tags/hello-setter.marko_0_el#2", ($scope) => $scope.el().textContent = "hello");
 const $el = /*@__PURE__*/ _const("el", $el__script);
 const $input = ($scope, input) => $el($scope, input.el);
-var hello_setter_default = /*@__PURE__*/ _template("__tests__/tags/hello-setter.marko", "", "", $setup$1, $input);
+var hello_setter_default = /*@__PURE__*/ _template("__tests__/tags/hello-setter.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div></div>${_w0}`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/dom.bundle.debug.js
@@ -6,30 +6,27 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content($scope, input.content);
-var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo.marko", $template$2, "D%l", $setup$2, $input$1);
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo.marko", $template$2, "D%l", 0, $input$1);
 
 // tags/my-box.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<div></div>${_w0}`)($template$2);
 const $walks$1 = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D%l");
+const $setup$1 = () => {};
 const $input_head__script = _script("__tests__/tags/my-box.marko_0_input_head#4", ($scope) => _attrs_script($scope, "#div/0"));
 const $input_head = /*@__PURE__*/ _const("input_head", ($scope) => {
 	_attrs_content($scope, "#div/0", $scope.input_head);
 	$input_head_content($scope, $scope.input_head?.content);
 	$input_head__script($scope);
 });
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/1"]);
-}
 const $input_head_content = ($scope, input_head_content) => $input_content($scope["#childScope/1"], input_head_content);
 const $input = ($scope, input) => $input_head($scope, input.head);
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, $setup$1, $input);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
 const $head_content = _content_resume("__tests__/template.marko_1*content", "Hello");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input_head($scope["#childScope/0"], attrTag({
 		class: "h",
 		content: $head_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input = ($scope, input) => {
 	$input_head($scope, input.head);
 	$input_foot($scope, input.foot);
 };
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, $setup$1, $input);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/dom.bundle.debug.js
@@ -6,29 +6,26 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content$1 = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content$1($scope, input.content);
-var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo.marko", $template$2, "D%l", $setup$2, $input$1);
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo.marko", $template$2, "D%l", 0, $input$1);
 
 // tags/my-box.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<div></div>${_w0}`)($template$2);
 const $walks$1 = /*@__PURE__*/ ((_w0) => ` b/${_w0}&`)("D%l");
+const $setup$1 = () => {};
 const $input__script = _script("__tests__/tags/my-box.marko_0_input#3", ($scope) => _attrs_script($scope, "#div/0"));
 const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs_content($scope, "#div/0", $scope.input);
 	$input_content($scope, $scope.input.content);
 	$input__script($scope);
 });
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/1"]);
-}
 const $input_content = ($scope, input_content) => $input_content$1($scope["#childScope/1"], input_content);
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, $setup$1, $input);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
 const $mybox_content = _content_resume("__tests__/template.marko_1*content", "Hello");
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$input($scope["#childScope/0"], {
 		class: "x",
 		content: $mybox_content($scope)

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/dom.bundle.debug.js
@@ -7,16 +7,13 @@ const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_data_content = $dynamicTag;
 const $input$1 = ($scope, input) => $input_data($scope, input.data);
 const $input_data = ($scope, input_data) => $input_data_content($scope, input_data?.content);
-var render_input_default = /*@__PURE__*/ _template("__tests__/tags/render-input.marko", $template$2, "b%c", $setup$2, $input$1);
+var render_input_default = /*@__PURE__*/ _template("__tests__/tags/render-input.marko", $template$2, "b%c", 0, $input$1);
 
 // tags/my-box.marko
 const $template$1 = "<div></div><button type=button class=toggle>toggle</button><div class=echo></div>";
 const $walks$1 = " b b b";
 const $if_content__input = /*@__PURE__*/ _if_closure("#div/2", 0, ($scope) => $input_data($scope["#childScope/0"], $scope._.input));
-const $if_content__setup = ($scope) => {
-	$if_content__input._($scope);
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-};
+const $if_content__setup = $if_content__input;
 const $if = /*@__PURE__*/ _if("#div/2", /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
 const $show = /*@__PURE__*/ _let("show/5", ($scope) => $if($scope, $scope.show ? 0 : 1));
 const $setup__script = _script("__tests__/tags/my-box.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/dom.bundle.js
@@ -1,17 +1,12 @@
 // tags/render-input.marko
 const $template = "<!><!><!>";
-const $setup = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
 const $input_data_content = $dynamicTag;
 const $input_data = ($scope, input_data) => $input_data_content($scope, input_data?.content);
 
 // tags/my-box.marko
 const $if_content__input = /*@__PURE__*/ _if_closure(2, 0, ($scope) => $input_data($scope.a, $scope._.e));
-const $if_content__setup = ($scope) => {
-	$if_content__input._($scope);
-	/* @__PURE__ */ $setup($scope.a);
-};
-const $if = /*@__PURE__*/ _if(2, /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__setup);
+const $if = /*@__PURE__*/ _if(2, /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template), /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c"), $if_content__input);
 const $show = /*@__PURE__*/ _let(5, ($scope) => $if($scope, $scope.f ? 0 : 1));
 const $setup__script = _script("b0", ($scope) => _on($scope.b, "click", function() {
 	$show($scope, !$scope.f);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9131,
-        "brotli": 3954
+        "min": 9111,
+        "brotli": 3942
       },
       "files": {
-        "tags/render-input.marko": 289,
-        "tags/my-box.marko": 685,
+        "tags/render-input.marko": 264,
+        "tags/my-box.marko": 575,
         "template.marko": 100
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-stateful/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs_content($scope, "#div/0", $scope.input);
 	$input__script($scope);
 });
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, " b", $setup$1, $input);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-void/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs($scope, "#img/0", $scope.input);
 	$input__script($scope);
 });
-var my_img_default = /*@__PURE__*/ _template("__tests__/tags/my-img.marko", $template$1, " b", $setup$1, $input);
+var my_img_default = /*@__PURE__*/ _template("__tests__/tags/my-img.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "";
 const $setup$2 = () => {};
 const $input_value = /*@__PURE__*/ _const("input_value", ($scope) => _return($scope, $scope.input_value));
 const $input$2 = ($scope, input) => $input_value($scope, input.value);
-var my_const_default = /*@__PURE__*/ _template("__tests__/tags/my-const.marko", "", "", $setup$2, $input$2);
+var my_const_default = /*@__PURE__*/ _template("__tests__/tags/my-const.marko", "", "", 0, $input$2);
 
 // tags/child.marko
 const $template$1 = "";

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-subtree/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "";
 const $setup$2 = () => {};
 const $input_value = /*@__PURE__*/ _const("input_value", ($scope) => _return($scope, $scope.input_value));
 const $input$2 = ($scope, input) => $input_value($scope, input.value);
-var my_const_default = /*@__PURE__*/ _template("__tests__/tags/my-const.marko", "", "", $setup$2, $input$2);
+var my_const_default = /*@__PURE__*/ _template("__tests__/tags/my-const.marko", "", "", 0, $input$2);
 
 // tags/child.marko
 const $template$1 = "";
@@ -37,4 +37,4 @@ const $output_getter = _el("__tests__/template.marko_0_#div#0", "#div/0");
 const $if = /*@__PURE__*/ _if("#text/1", $template$1, /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1), $if_content__setup);
 const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
 const $input = ($scope, input) => $input_show($scope, input.show);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/dom.bundle.debug.js
@@ -9,7 +9,7 @@ const $input_content = ($scope, input_content) => $dynamicTag($scope, input_cont
 	3
 ]);
 const $input = ($scope, input) => $input_content($scope, input.content);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<!><!><!>${_w0}${_w1}<!>`)($template$1, $template$1);
@@ -53,9 +53,7 @@ const $list = /*@__PURE__*/ _let("list/4", ($scope) => {
 	$for2($scope, [$scope.list]);
 });
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input_content($scope["#childScope/2"], $child_content($scope));
-	/* @__PURE__ */ $setup$1($scope["#childScope/3"]);
 	$input_content($scope["#childScope/3"], $child_content2($scope));
 	$list($scope, ["a", "b"]);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-static-empty/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $input_x = ($scope, input_x) => {
 	_text($scope["#text/1"], input_x);
 };
 const $input = ($scope, input) => $input_x($scope, input.x);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/pure-signal-resume-function/__snapshots__/dom.bundle.debug.js
@@ -7,7 +7,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs_content($scope, "#button/0", $scope.input);
 	$input__script($scope);
 });
-var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, " b", $setup$1, $input);
+var my_button_default = /*@__PURE__*/ _template("__tests__/tags/my-button.marko", $template$1, " b", 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/dom.bundle.debug.js
@@ -9,4 +9,4 @@ const $children = ($scope, children) => $for($scope, [children, function(c) {
 	return c.id;
 }]);
 const $input = ($scope, input) => $children($scope, input.children);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/render-effect/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/render-effect/__snapshots__/dom.bundle.debug.js
@@ -3,7 +3,7 @@ const $template$1 = "";
 const $walks$1 = "";
 const $setup$1 = () => {};
 const $input = /*@__PURE__*/ _const("input", ($scope) => _return($scope, $scope.input.value()));
-var render_effect_default = /*@__PURE__*/ _template("__tests__/tags/render-effect.marko", "", "", $setup$1, $input);
+var render_effect_default = /*@__PURE__*/ _template("__tests__/tags/render-effect.marko", "", "", 0, $input);
 
 // template.marko
 const $template = "";

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-alias-nested-scope/__snapshots__/dom.bundle.debug.js
@@ -21,4 +21,4 @@ const $value = ($scope, value) => {
 const $input = ($scope, input) => $value($scope, input.value);
 const $rest = /*@__PURE__*/ _const("rest", $if_content__rest);
 const $input_value_foo = /*@__PURE__*/ _const("foo", $if_content__input_value_foo);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input = ($scope, input) => {
 	$skip($scope, input.skip);
 	$input_label($scope, input.label);
 };
-var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, $walks$1, $setup$1, $input);
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<main>${_w0}<button>+</button></main>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$1 = () => {};
 const $input_label = ($scope, rest_label) => _text($scope["#text/0"], rest_label);
 const $input2 = ($scope, input) => $input_label($scope, input?.label);
 const $input = $input2;
-var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, "D l", $setup$1, $input);
+var echo_default = /*@__PURE__*/ _template("__tests__/tags/echo/index.marko", $template$1, "D l", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<main>${_w0}<button>+</button></main>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/dom.bundle.debug.js
@@ -19,7 +19,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$if_content__input($scope);
 });
 const $input_item = /*@__PURE__*/ _const("input_item", $if_content__input_item);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", $setup$1, $input);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = "<button id=show>show</button><button id=clear>clear</button><div></div><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $setter = ($scope) => function() {
 	$scope.input_valueChange(1);
 };
 _resume("__tests__/tags/setter.marko_0/setter", $setter);
-var setter_default = /*@__PURE__*/ _template("__tests__/tags/setter.marko", "", "", $setup$1, $input);
+var setter_default = /*@__PURE__*/ _template("__tests__/tags/setter.marko", "", "", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<div> </div>`)("");

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-bind-type-casting/__snapshots__/dom.bundle.debug.js
@@ -21,7 +21,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content = $dynamicTag;
 const $input = ($scope, input) => $input_content($scope, input.content);
-var my_tag_default = /*@__PURE__*/ _template("__tests__/tags/my-tag.marko", $template$1, "b%c", $setup$1, $input);
+var my_tag_default = /*@__PURE__*/ _template("__tests__/tags/my-tag.marko", $template$1, "b%c", 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `<!>${_w0}${_w1}<!>`)("", $template$1);
@@ -41,7 +41,6 @@ function $setup($scope) {
 	_var($scope, "#childScope/0", $count);
 	$setup$2($scope["#childScope/0"]);
 	$input_value($scope["#childScope/0"], 0);
-	/* @__PURE__ */ $setup$1($scope["#childScope/2"]);
 	$input_content_direct($scope["#childScope/2"], $mytag_content($scope));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/same-source-alias-pattern-and-identifier/__snapshots__/dom.bundle.debug.js
@@ -9,4 +9,4 @@ const $b = ($scope, b) => {
 const $input_a_b = ($scope, b) => _text($scope["#text/1"], b);
 const $input = ($scope, input) => $a2($scope, input.a);
 const $a2 = ($scope, $a) => $b($scope, $a.b);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/script-tag-empty/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "";
 const $walks = "";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", "", "", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", "", "");

--- a/packages/runtime-tags/src/__tests__/fixtures/select-uncontrolled-empty-option/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/select-uncontrolled-empty-option/__snapshots__/dom.bundle.debug.js
@@ -2,4 +2,4 @@
 const $template = "<select><option value=a>A</option><option value>None</option></select>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-attr-tag-effect/__snapshots__/dom.bundle.debug.js
@@ -5,7 +5,7 @@ const $setup$2 = () => {};
 const $input_option__script = _script("__tests__/tags/child.marko_0_input_option#3", ($scope) => _el_read($scope["#div/0"]).innerHTML = Object.keys($scope.input_option).join(","));
 const $input_option$1 = /*@__PURE__*/ _const("input_option", $input_option__script);
 const $input$1 = ($scope, input) => $input_option$1($scope, input.option);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -13,7 +13,7 @@ const $walks$1 = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
 const $setup$1 = () => {};
 const $input_option = ($scope, input_option) => $input_option$1($scope["#childScope/0"], input_option);
 const $input = ($scope, input) => $input_option($scope, input.option);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_class$1($scope, input.class);
 	$input_value$1($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -20,7 +20,7 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_value($scope, input.value);
 };
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div id=known>${_w0}</div><div id=dynamic><!></div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/dom.bundle.debug.js
@@ -15,7 +15,7 @@ const $input$1 = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_option($scope, input.option);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -28,7 +28,7 @@ const $input = ($scope, input) => {
 	$_class($scope, input.class);
 };
 const $rest = ($scope, rest) => $rest_option($scope, rest.option);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content-rest/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input$1 = ($scope, input) => {
 	(({ class: $class, ...rest }) => $rest$1($scope, rest))(input);
 	$input_class($scope, input.class);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -28,7 +28,7 @@ const $input = ($scope, input) => {
 	(({ class: $class2, ...rest }) => $rest($scope, rest))(input);
 	$_class($scope, input.class);
 };
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<div id=content-missing>${_w0}</div><div id=content-undefined>${_w1}</div><div id=content-set>${_w2}</div><div id=dynamic><!></div>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/dom.bundle.debug.js
@@ -10,14 +10,12 @@ const $input$1 = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, $walks$2, $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
 const $walks$1 = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$2);
-function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
-}
+const $setup$1 = () => {};
 const $_class = ($scope, _class) => $input_class($scope["#childScope/0"], _class);
 const $rest_content = ($scope, rest_content) => $input_content($scope["#childScope/0"], rest_content);
 const $input = ($scope, input) => {
@@ -25,7 +23,7 @@ const $input = ($scope, input) => {
 	$_class($scope, input.class);
 };
 const $rest = ($scope, rest) => $rest_content($scope, rest.content);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<div id=content-missing>${_w0}</div><div id=content-undefined>${_w1}</div><div id=content-set>${_w2}</div><div id=dynamic><!></div>`)($template$1, $template$1, $template$1);
@@ -35,13 +33,10 @@ const $Wrap_content = _content_resume("__tests__/template.marko_2*content", "Hel
 const $wrap_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello World");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/3", $Wrap_content);
 function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
 	$_class($scope["#childScope/0"], "foo");
 	$rest_content($scope["#childScope/0"]);
-	$setup$1($scope["#childScope/1"]);
 	$_class($scope["#childScope/1"], "foo");
 	$rest_content($scope["#childScope/1"], undefined);
-	$setup$1($scope["#childScope/2"]);
 	$rest_content($scope["#childScope/2"], $wrap_content($scope));
 	$_class($scope["#childScope/2"], "foo");
 	$dynamicTag($scope, Wrap, () => ({ class: "bar" }));

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_class$1($scope, input.class);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$2);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_class$1($scope, input.class);
 	$input_value$1($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$2);
@@ -26,7 +26,7 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_value($scope, input.value);
 };
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div id=known>${_w0}</div><div id=dynamic><!></div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/dom.bundle.debug.js
@@ -10,7 +10,7 @@ const $input$1 = ($scope, input) => {
 	$input_value($scope, input.value);
 	$input_a($scope, input.a);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -25,7 +25,7 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$input_value($scope["#childScope/0"], $child_input_spread.value);
 	$input_a($scope["#childScope/0"], $child_input_spread.a);
 });
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = $template$1;

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$2 = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$3, " b", $setup$3, $input$2);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$3, " b", 0, $input$2);
 
 // tags/wrap.marko
 const $template$2 = $template$3;
@@ -21,7 +21,7 @@ const $input$1 = ($scope, input) => {
 	$value($scope, input.value);
 };
 const $rest$1 = ($scope, rest) => $rest_class$1($scope, rest.class);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$2, $walks$2, $setup$2, $input$1);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/wrap-outer.marko
 const $template$1 = $template$2;

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-deopt/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input$1 = ($scope, input) => {
 	(({ class: $class, ...rest }) => $rest($scope, rest))(input);
 	$_class($scope, input.class);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b b", $setup$1, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b b", 0, $input$1);
 
 // template.marko
 const $template = $template$1;
@@ -30,4 +30,4 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	$_class($scope["#childScope/0"], $child_input_spread.class);
 	$rest($scope["#childScope/0"], (({ class: $class, ...rest }) => rest)($child_input_spread));
 });
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/dom.bundle.debug.js
@@ -17,7 +17,7 @@ const $for_content__$temp = ($scope, $temp) => {
 const $for = /*@__PURE__*/ _for_of("#text/0", "<span><!></span>", " D%", 0, $for_content__$params);
 const $foo = ($scope, foo) => $for($scope, [foo]);
 const $input$2 = ($scope, input) => $foo($scope, input.foo);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, "b%c", $setup$2, $input$2);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, "b%c", 0, $input$2);
 
 // tags/wrap.marko
 const $template$1 = " <!><!>";
@@ -41,7 +41,7 @@ const $input$1 = ($scope, input) => {
 };
 const $input_foo__closure = /*@__PURE__*/ _closure($_classspandiv_content__input_foo);
 const $input_foo = /*@__PURE__*/ _const("input_foo", $input_foo__closure);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, "b%c", $setup$1, $input$1);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, "b%c", 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `${_w0}<!>`)($template$1);
@@ -49,7 +49,6 @@ const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&b`)("b%c");
 const $desc_content2 = _content_resume("__tests__/template.marko_2*content", "Two");
 const $desc_content = _content_resume("__tests__/template.marko_1*content", "One");
 function $setup($scope) {
-	/* @__PURE__ */ $setup$1($scope["#childScope/0"]);
 	$input_foo($scope["#childScope/0"], attrTags(attrTag({
 		value: 1,
 		desc: attrTag({ content: $desc_content($scope) })

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input/__snapshots__/dom.bundle.debug.js
@@ -16,7 +16,7 @@ const $input$1 = ($scope, input) => {
 	(({ class: $class, ...rest }) => $rest($scope, rest))(input);
 	$_class($scope, input.class);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b b", $setup$1, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b b", 0, $input$1);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div id=known>${_w0}</div><div id=dynamic><!></div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_value($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -21,7 +21,7 @@ const $input = ($scope, input) => {
 	$value($scope, input.value);
 };
 const $rest = ($scope, rest) => $rest_class($scope, rest.class);
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2) => `<div id=value-missing>${_w0}</div><div id=value-undefined>${_w1}</div><div id=value-set>${_w2}</div><div id=dynamic><!></div>`)($template$1, $template$1, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/dom.bundle.debug.js
@@ -8,7 +8,7 @@ const $input$1 = ($scope, input) => {
 	$input_class$1($scope, input.class);
 	$input_value$1($scope, input.value);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", $setup$2, $input$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, " b", 0, $input$1);
 
 // tags/wrap.marko
 const $template$1 = $template$2;
@@ -20,7 +20,7 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_value($scope, input.value);
 };
-var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, $setup$1, $input);
+var wrap_default = /*@__PURE__*/ _template("__tests__/tags/wrap.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div id=known>${_w0}</div><div id=dynamic><!></div>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-trailing-native-tag-default-function/__snapshots__/dom.bundle.debug.js
@@ -15,4 +15,4 @@ function $onClick(_, el) {
 	el.textContent = "clicked";
 }
 _resume("__tests__/template.marko_0/onClick", $onClick);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
@@ -6,7 +6,7 @@ const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content$1 = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content$1($scope, input.content);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", $setup$2, $input$1);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", 0, $input$1);
 
 // tags/outer.marko
 const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
@@ -22,7 +22,6 @@ const $inner_content__setup = ($scope) => {
 };
 const $inner_content = /*@__PURE__*/ _content("__tests__/tags/outer.marko_1*content", "<button>click</button><!><!>", " b%", $inner_content__setup);
 function $setup$1($scope) {
-	/* @__PURE__ */ $setup$2($scope["#childScope/0"]);
 	$input_content_direct($scope["#childScope/0"], $inner_content($scope));
 }
 const $input = ($scope, input) => $input_content($scope, input.content);

--- a/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-server-only-tree/__snapshots__/dom.bundle.debug.js
@@ -2,13 +2,13 @@
 const $template$1 = "<div class=child>Child</div>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template$1, "b", $setup$1);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template$1, "b");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<div class=page>Page</div>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b");
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks);
 
 // page.css
 var page_default = ".page-global {\n  margin: 0;\n}\n";

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-concise/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template = "<div></div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");
 
 // v:template.marko.css
 var v_template_marko_default = "button {\n  background-color: yellow;\n}";

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-conditional/__snapshots__/dom.bundle.debug.js
@@ -14,7 +14,7 @@ const $input = ($scope, input) => {
 	$input_color($scope, input.color);
 };
 const $input_color = /*@__PURE__*/ _const("input_color", $if_content__input_color);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%c", 0, $input);
 
 // v:template.marko.css
 var v_template_marko_default = "\n    .box { color: var(--M_packages-1bruntime-19tags-1bsrc-1b__tests__-1bfixtures-1bstyle-19tag-19dynamic-19conditional-1btemplate-1amarko_0); }\n  ";

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-type/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-type/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template = "<div class=content>Hello</div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");
 
 // v:template.marko.less
 var v_template_marko_default = "\n  .content {\n    color: green;\n  }\n";

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template = "<div class=content>Hello</div>";
 const $walks = "b";
 const $setup = () => {};
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b");
 
 // v:template.marko.css
 var v_template_marko_default = "\n  .content {\n    color: green;\n  }\n";

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/__snapshots__/dom.bundle.debug.js
@@ -4,7 +4,7 @@ const $walks$2 = "Db%l";
 const $setup$2 = () => {};
 const $input_label$1 = ($scope, input_label) => _text($scope["#text/0"], input_label);
 const $input$1 = ($scope, input) => $input_label$1($scope, input.label);
-var a_default = /*@__PURE__*/ _template("__tests__/tags/a/index.marko", $template$2, $walks$2, $setup$2, $input$1);
+var a_default = /*@__PURE__*/ _template("__tests__/tags/a/index.marko", $template$2, $walks$2, 0, $input$1);
 
 // tags/b/index.marko
 const $template$1 = "<div>B <!></div>";
@@ -12,7 +12,7 @@ const $walks$1 = "Db%l";
 const $setup$1 = () => {};
 const $input_label = ($scope, input_label) => _text($scope["#text/0"], input_label);
 const $input = ($scope, input) => $input_label($scope, input.label);
-var b_default = /*@__PURE__*/ _template("__tests__/tags/b/index.marko", $template$1, $walks$1, $setup$1, $input);
+var b_default = /*@__PURE__*/ _template("__tests__/tags/b/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = "<button>toggle</button><!><!><!><!><!><!><!>";

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/__snapshots__/dom.bundle.js
@@ -1,18 +1,16 @@
 // tags/a/index.marko
 const $template$1 = "<div>A <!></div>";
 const $walks$1 = "Db%l";
-const $setup$1 = () => {};
 const $input_label$1 = ($scope, input_label) => _text($scope.a, input_label);
 const $input$1 = ($scope, input) => $input_label$1($scope, input.label);
-var a_default = /*@__PURE__*/ _template("b", $template$1, $walks$1, $setup$1, $input$1);
+var a_default = /*@__PURE__*/ _template("b", $template$1, $walks$1, 0, $input$1);
 
 // tags/b/index.marko
 const $template = "<div>B <!></div>";
 const $walks = "Db%l";
-const $setup = () => {};
 const $input_label = ($scope, input_label) => _text($scope.a, input_label);
 const $input = ($scope, input) => $input_label($scope, input.label);
-var b_default = /*@__PURE__*/ _template("c", $template, $walks, $setup, $input);
+var b_default = /*@__PURE__*/ _template("c", $template, $walks, 0, $input);
 
 // template.marko
 const localTag = a_default;

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-name-type-unions/sizes.json
@@ -2,12 +2,12 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9943,
-        "brotli": 4214
+        "min": 9921,
+        "brotli": 4210
       },
       "files": {
-        "tags/a/index.marko": 374,
-        "tags/b/index.marko": 354,
+        "tags/a/index.marko": 340,
+        "tags/b/index.marko": 324,
         "template.marko": 1075
       }
     }

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-resolution-priority/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template$1 = "<span></span>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var foo_default = /*@__PURE__*/ _template("__tests__/tags/foo.marko", $template$1, "b", $setup$1);
+var foo_default = /*@__PURE__*/ _template("__tests__/tags/foo.marko", $template$1, "b");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div></div>${_w0}<!><!>`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-nested-discovery/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template$2 = "<span class=icon-star>star</span>";
 const $walks$2 = "b";
 const $setup$2 = () => {};
-var icon_star_default = /*@__PURE__*/ _template("__tests__/tags/icons/icon-star.marko", $template$2, "b", $setup$2);
+var icon_star_default = /*@__PURE__*/ _template("__tests__/tags/icons/icon-star.marko", $template$2, "b");
 
 // tags/util/greeting.marko
 const $template$1 = "<p>Hello, <!>!</p>";
@@ -10,7 +10,7 @@ const $walks$1 = "Db%l";
 const $setup$1 = () => {};
 const $input_name = ($scope, input_name) => _text($scope["#text/0"], input_name);
 const $input = ($scope, input) => $input_name($scope, input.name);
-var greeting_default = /*@__PURE__*/ _template("__tests__/tags/util/greeting.marko", $template$1, $walks$1, $setup$1, $input);
+var greeting_default = /*@__PURE__*/ _template("__tests__/tags/util/greeting.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, $template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/dom.bundle.debug.js
@@ -11,7 +11,7 @@ const $input_depth = /*@__PURE__*/ _const("input_depth", ($scope) => {
 	$if_content__input_depth($scope);
 });
 const $input = ($scope, input) => $input_depth($scope, input.depth);
-var tree_default = /*@__PURE__*/ _template("__tests__/tags/tree/index.marko", $template$1, $walks$1, $setup$1, $input);
+var tree_default = /*@__PURE__*/ _template("__tests__/tags/tree/index.marko", $template$1, $walks$1, 0, $input);
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<button>inc <!></button>${_w0}`)($template$1);

--- a/packages/runtime-tags/src/__tests__/fixtures/text-escape-coverage/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/text-escape-coverage/__snapshots__/dom.bundle.debug.js
@@ -10,4 +10,4 @@ const $input = ($scope, input) => {
 	$input_b($scope, input.b);
 	$input_c($scope, input.c);
 };
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-spread/__snapshots__/dom.bundle.debug.js
@@ -7,4 +7,4 @@ const $input = /*@__PURE__*/ _const("input", ($scope) => {
 	_attrs($scope, "#textarea/0", $scope.input, _controllable_textarea);
 	$input__script($scope);
 });
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/textarea-value-template-escape/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/textarea-value-template-escape/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_name = /*@__PURE__*/ _const("input_name", ($scope) => _attr_input_value_default($scope, "#textarea/0", `[AB]${$scope.input_name}[!]`));
 const $input = ($scope, input) => $input_name($scope, input.name);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-first-child/__snapshots__/dom.bundle.debug.js
@@ -10,4 +10,4 @@ const $value = /*@__PURE__*/ _const("value", ($scope) => {
 	$if_content__input_value($scope);
 });
 const $input = ($scope, input) => $value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D%l", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D%l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/toggle-nested/__snapshots__/dom.bundle.debug.js
@@ -31,4 +31,4 @@ const $value2 = /*@__PURE__*/ _const("value2", ($scope) => {
 	$if_content__input_value2($scope);
 	$value2__closure($scope);
 });
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-coercion/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/uncontrolled-textarea-value-coercion/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_v = /*@__PURE__*/ _const("input_v", ($scope) => _attr_input_value_default($scope, "#textarea/0", $scope.input_v));
 const $input = ($scope, input) => $input_v($scope, input.v);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/update-attr/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-attr/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = " b";
 const $setup = () => {};
 const $input_value = ($scope, input_value) => _attr($scope["#div/0"], "b", input_value);
 const $input = ($scope, input) => $input_value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/update-html/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-html/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = "c%b";
 const $setup = () => {};
 const $value = ($scope, value) => _html($scope, value, "#text/0");
 const $input = ($scope, input) => $value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "c%b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "c%b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/update-text/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/update-text/__snapshots__/dom.bundle.debug.js
@@ -4,4 +4,4 @@ const $walks = "b%b";
 const $setup = () => {};
 const $value = ($scope, value) => _text($scope["#text/0"], value);
 const $input = ($scope, input) => $value($scope, input.value);
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%b", $setup, $input);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b%b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/dom.bundle.debug.js
@@ -2,7 +2,7 @@
 const $template$1 = "<span>Hello</span>";
 const $walks$1 = "b";
 const $setup$1 = () => {};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b", $setup$1);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "b");
 
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<section>${_w0}</section><div> </div>`)($template$1);

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -219,10 +219,12 @@ export default {
           callRuntime(
             "_template",
             t.stringLiteral(program.hub.file.metadata.marko.id),
-            templateIdentifier,
-            walksIdentifier,
-            setupIdentifier,
-            programInputSignal?.identifier,
+            ...replaceNullishAndEmptyFunctionsWith0([
+              templateIdentifier,
+              walksIdentifier,
+              domExports.setupEmpty ? undefined : setupIdentifier,
+              programInputSignal?.identifier,
+            ]),
           ),
         ),
       );

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -131,11 +131,9 @@ export default {
     enter(tag) {
       assertAttributesOrArgs(tag);
       const { node } = tag;
-      // Dynamic tags (and locally invoked define bodies) initialize their
-      // renderer with statements that can land in setup.
-      addSetupStatement(getOrCreateSection(tag));
       const definedBodySection = node.extra?.defineBodySection;
       if (definedBodySection) {
+        addSetupStatement(getOrCreateSection(tag));
         knownTagAnalyze(
           tag,
           definedBodySection,


### PR DESCRIPTION
Avoid passing no-op setup functions to template renderers so browser branches do not schedule empty setup work. Dynamic tags now track setup eligibility from their resolved references while locally defined tags remain conservative, allowing parents to skip truly empty child setup calls in both debug and optimized output.