### PR TITLE
perf(runtime-tags): skip inert resume branch metadata

### DIFF
--- a/.changeset/skip-empty-resume-branch.md
+++ b/.changeset/skip-empty-resume-branch.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Avoid emitting closest-branch resume metadata for scopes that are not serialized.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -95,12 +95,6 @@ Parameter reason groups (`contentSection.paramReasonGroups`, known-tag.ts:246-31
 
 `analyzeAttrs` sets `attrExtra.invokeOnly` only when `getRootSection(templateExportAttr.binding.section) !== getProgram().node.extra.section`, so a local `<define>` never gets the treatment an equivalent cross-file tag does — same-program prop trees are mid-analysis with incomplete reads. `<define/Btn|input|><button onClick=input.onClick>x</button></define>` with `<let/count=0/><Btn onClick=() => count++ />${count}` therefore folds `$Btn_content__input_onClick(...)` into the `$count` signal body, re-pushing the handler and re-running its `_on` script on every state update; the identical `tags/btn.marko` version hoists it into `$setup` alone. A conservative post-analysis fixed point would let local handlers read persisted slots lazily, dropping the intersection, input update, closure propagation and owner state. Re-verify: compile both shapes with `node -r ~ts scripts/inspect-compiled-output.mts -o dom -d` and diff the `$count` bodies.
 
-## Skip `_resume_branch` for sections with no serialize reason
-
-`packages/runtime-tags/src/translator/util/signals.ts` › `writeHTMLResumeStatements` | 2026-07-13 | impact:low | effort:low
-
-`resumeClosestBranch` ignores `sectionSerializeReason`, so an inert section emits `_resume_branch(scopeId)` with no accompanying `_scope(...)` write — wasted bytes, plus a `ClosestBranchId`-only scope nothing resumes when nested under a branch. Gate it on the finalized section reason while preserving empty referenced owners and ready-channel descendants. Re-verify: `fixtures/html-style-injection/__snapshots__/html.bundle.js` must stop emitting `_resume_branch($scope0_id)` for a template whose only state is an unserialized `<let>`.
-
 ## Cache the handler `addTagsEvents` binds for a Class parent's `on-x`
 
 `packages/runtime-class/src/runtime/helpers/dynamic-tag.js` › `addTagsEvents` | 2026-07-13 | impact:low | effort:low

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.debug.js
@@ -21,5 +21,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let n = 0;
 	_html(`<div id=tags-api>${_escape(n)}</div>`);
 	_dynamic_tag($scope0_id, "#text/1", _marko_template, {}, 0, 0, 0);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-inline-script-tags-to-class/__snapshots__/html.bundle.js
@@ -16,5 +16,4 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	_html(`<div id=tags-api>${_escape(0)}</div>`);
 	_dynamic_tag($scope0_id, "b", _marko_template, {}, 0, 0, 0);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
@@ -34,5 +34,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	});
 	my_menu_default({ item: $item });
 	_html(`<div>${_escape(foo)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
@@ -34,5 +34,4 @@ var template_default = _template("a", (input) => {
 	});
 	my_menu_default({ item: $item });
 	_html(`<div>${_escape(foo)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/__snapshots__/html.bundle.debug.js
@@ -16,5 +16,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		const $scope3_id = _scope_id();
 		_html("loading...");
 	}, $scope0_id) }) });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-inert/__snapshots__/html.bundle.js
@@ -16,5 +16,4 @@ var template_default = _template("a", (input) => {
 		_scope_id();
 		_html("loading...");
 	}, $scope0_id) }) });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.bundle.debug.js
@@ -6,5 +6,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const y = x * 2;
 	const z = y * 3;
 	_html(`<div>${_escape(z)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-chain/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(`<div>${_escape(6)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.bundle.debug.js
@@ -8,5 +8,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		const $scope1_id = _scope_id();
 		_html(_escape(a + b));
 	}
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-converge-in-if/__snapshots__/html.bundle.js
@@ -1,8 +1,7 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_scope_id();
 	_html(_escape(0));
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.bundle.debug.js
@@ -25,5 +25,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_: _scope_with_id($scope0_id)
 		}, "__tests__/template.marko", "3:2", { num: "3:6" });
 	}, 0, $scope0_id, "#text/0", 1, 0, 0, 0, 1);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-scope-for/__snapshots__/html.bundle.js
@@ -25,5 +25,4 @@ var template_default = _template("a", (input) => {
 			_: _scope_with_id($scope0_id)
 		});
 	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.bundle.debug.js
@@ -8,5 +8,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	};
 	const { x, y } = z;
 	_html(`<div>${_escape(x)}</div>${_escape(y)}`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/const-tag-destructure/__snapshots__/html.bundle.js
@@ -1,11 +1,10 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	const { x, y } = {
 		x: 1,
 		y: 2
 	};
 	_html(`<div>${_escape(x)}</div>${_escape(y)}`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.bundle.debug.js
@@ -14,5 +14,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let x = "y";
 	child_default({ value: 3 });
 	child_default({ value: x });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-default-value/__snapshots__/html.bundle.js
@@ -10,9 +10,8 @@ var child_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	let x = "y";
 	child_default({ value: 3 });
 	child_default({ value: x });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,6 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	let x = 1;
 	_html("<span>child</span>");
 	const $return = x + 3;
-	_resume_branch($scope0_id);
 	return $return;
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-expression/__snapshots__/html.bundle.js
@@ -1,11 +1,9 @@
 // tags/child.marko
 var child_default = _template("b", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html("<span>child</span>");
-	const $return = 4;
-	_resume_branch($scope0_id);
-	return $return;
+	return 4;
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,6 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	let y = 2;
 	_html("<span>child</span>");
 	const $return = x + y;
-	_resume_branch($scope0_id);
 	return $return;
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-var-multiple/__snapshots__/html.bundle.js
@@ -1,11 +1,9 @@
 // tags/child.marko
 var child_default = _template("b", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html("<span>child</span>");
-	const $return = 3;
-	_resume_branch($scope0_id);
-	return $return;
+	return 3;
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.debug.js
@@ -27,5 +27,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html("</section>");
 	}
 	_html("</div>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var child_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	let items = ["a", "b"];
 	_html("<div>");
 	_scope_id();
@@ -24,5 +24,4 @@ var template_default = _template("a", (input) => {
 	});
 	_html("</section>");
 	_html("</div>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,6 @@ var store_default = _template("__tests__/tags/store.marko", (input) => {
 			list = [];
 		}, "__tests__/tags/store.marko_0/_return2", $scope0_id)
 	};
-	_resume_branch($scope0_id);
 	return $return;
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-stateful-upstream-alias/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var store_default = _template("b", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let list = input.value;
-	const $return = {
+	return {
 		list,
 		listChange: _resume(function(v) {
 			list = v;
@@ -12,8 +12,6 @@ var store_default = _template("b", (input) => {
 			list = [];
 		}, "b1", $scope0_id)
 	};
-	_resume_branch($scope0_id);
-	return $return;
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.debug.js
@@ -37,5 +37,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "4:4", { row_id: ["row.id", "4:8"] });
 	}, "id", $scope0_id, "#ul/0", 1, 0, 0, 0, 1);
 	_html("</ul>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-if-condition/__snapshots__/html.bundle.js
@@ -37,5 +37,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</ul>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.debug.js
@@ -28,5 +28,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "5:4", { row_id: ["row.id", "5:8"] });
 	}, "id", $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-keyed-selector-preset/__snapshots__/html.bundle.js
@@ -28,5 +28,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.debug.js
@@ -28,5 +28,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "9:4", { row_user_id: ["row.user.id", "9:8"] });
 	}, (item) => item.user.id, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-by-member/__snapshots__/html.bundle.js
@@ -28,5 +28,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, (item) => item.user.id, $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.debug.js
@@ -19,5 +19,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "5:4", { "#LoopKey": "5:15" });
 	}, 0, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-index/__snapshots__/html.bundle.js
@@ -19,5 +19,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.debug.js
@@ -28,5 +28,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "5:4", { row_id: ["row.id", "5:8"] });
 	}, "id", $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-property-path-reject/__snapshots__/html.bundle.js
@@ -28,5 +28,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, "id", $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.debug.js
@@ -14,5 +14,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, "__tests__/template.marko", "4:4", { "#LoopKey": "4:8" });
 	}, 0, $scope0_id, "#tbody/0", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-selector-to/__snapshots__/html.bundle.js
@@ -14,5 +14,4 @@ var template_default = _template("a", (input) => {
 		});
 	}, 0, $scope0_id, "a", 1, 0, 0, 0, 1);
 	_html("</tbody></table>");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.debug.js
@@ -41,5 +41,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		writeScope($scope3_id, {}, "__tests__/template.marko", "22:2");
 	}, 0, $scope0_id, "#text/2", 1, 0, 0, 0, 1);
 	_script($scope0_id, "__tests__/template.marko_0");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-many/__snapshots__/html.bundle.js
@@ -32,5 +32,4 @@ var template_default = _template("a", (input) => {
 		writeScope($scope3_id, {});
 	}, 0, $scope0_id, "c", 1, 0, 0, 0, 1);
 	_script($scope0_id, "a1");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.bundle.debug.js
@@ -47,5 +47,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		writeScope($scope3_id, {}, "__tests__/template.marko", "24:2");
 	}, 0, $scope0_id, "#text/2", 1, 0, 0, 0, 1);
 	_script($scope0_id, "__tests__/template.marko_0");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-dynamic-tag-var-many/__snapshots__/html.bundle.js
@@ -44,5 +44,4 @@ var template_default = _template("a", (input) => {
 		writeScope($scope3_id, {});
 	}, 0, $scope0_id, "c", 1, 0, 0, 0, 1);
 	_script($scope0_id, "a4");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.bundle.debug.js
@@ -28,5 +28,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		writeScope($scope3_id, {}, "__tests__/template.marko", "28:2");
 	}, 0, $scope0_id, "#text/2", 1, 0, 0, 0, 1);
 	_script($scope0_id, "__tests__/template.marko_0");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-native-tag-var-many/__snapshots__/html.bundle.js
@@ -28,5 +28,4 @@ var template_default = _template("a", (input) => {
 		writeScope($scope3_id, {});
 	}, 0, $scope0_id, "c", 1, 0, 0, 0, 1);
 	_script($scope0_id, "a1");
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/__snapshots__/html.bundle.debug.js
@@ -6,5 +6,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let close = "/script>";
 	let payload = "<img src=x onerror=alert(1)>";
 	_html(`<script${_attr_nonce()}>${_escape_script(`var x = '${_to_text(open)}${_to_text(close)}${_to_text(payload)}'`)}<\/script>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection-adjacent/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(`<script${_attr_nonce()}>${_escape_script(`var x = '${_to_text("<")}${_to_text("/script>")}${_to_text("<img src=x onerror=alert(1)>")}'`)}<\/script>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let injection = "<\/SCRIPT>";
 	_html(`<script${_attr_nonce()}>${_escape_script(`var x = '${_to_text(injection)}'`)}<\/script>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-script-injection/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(`<script${_attr_nonce()}>${_escape_script(`var x = '${_to_text("<\/SCRIPT>")}'`)}<\/script>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/__snapshots__/html.bundle.debug.js
@@ -5,5 +5,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let open = "<";
 	let close = "/style><img src=x onerror=alert(1)>";
 	_html(`<style${_attr_nonce()}>${_escape_style(`.a { color: red }${_to_text(open)}${_to_text(close)}`)}</style>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection-adjacent/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(`<style${_attr_nonce()}>${_escape_style(`.a { color: red }${_to_text("<")}${_to_text("/style><img src=x onerror=alert(1)>")}`)}</style>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let injection = "</STYLE>";
 	_html(`<style${_attr_nonce()}>${_escape_style(`.evil { content: '${_to_text(injection)}'; }`)}</style>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-style-injection/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(`<style${_attr_nonce()}>${_escape_style(`.evil { content: '${_to_text("</STYLE>")}'; }`)}</style>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.bundle.debug.js
@@ -18,5 +18,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let x = 1;
 	_dynamic_tag($scope0_id, "#text/0", x === 1 ? baz_default : foo_default, {}, 0, 0, 0);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-ternary/__snapshots__/html.bundle.js
@@ -15,7 +15,5 @@ var foo_default = _template("c", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
-	_dynamic_tag($scope0_id, "a", baz_default, {}, 0, 0, 0);
-	_resume_branch($scope0_id);
+	_dynamic_tag(_scope_id(), "a", baz_default, {}, 0, 0, 0);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,6 @@ var store_default = _template("__tests__/tags/store.marko", (input) => {
 			list = [];
 		}, "__tests__/tags/store.marko_0/_return2", $scope0_id)
 	};
-	_resume_branch($scope0_id);
 	return $return;
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-stateful-upstream-alias/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var store_default = _template("b", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let list = input.value;
-	const $return = {
+	return {
 		list,
 		listChange: _resume(function(v) {
 			list = v;
@@ -12,8 +12,6 @@ var store_default = _template("b", (input) => {
 			list = [];
 		}, "b1", $scope0_id)
 	};
-	_resume_branch($scope0_id);
-	return $return;
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.debug.js
@@ -35,5 +35,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_escape(x)}${_el_resume($scope4_id, "#text/0", _serialize_guard($scope4_reason, 1))}-${_sep($sg__y)}${_escape(y)}${_el_resume($scope4_id, "#text/1", $sg__y)}-${_sep($sg__z)}${_escape(z)}${_el_resume($scope4_id, "#text/2", $sg__z)}</div>`);
 		_serialize_if($scope4_reason, 0) && writeScope($scope4_id, {}, "__tests__/template.marko", "11:2");
 	}, $scope0_id) });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/param-rest-reads/__snapshots__/html.bundle.js
@@ -35,5 +35,4 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_escape(x)}${_el_resume($scope4_id, "a", _serialize_guard($scope4_reason, 1))}-${_sep($sg__y)}${_escape(y)}${_el_resume($scope4_id, "b", $sg__y)}-${_sep($sg__z)}${_escape(z)}${_el_resume($scope4_id, "c", $sg__z)}</div>`);
 		_serialize_if($scope4_reason, 0) && writeScope($scope4_id, {});
 	}, $scope0_id) });
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.bundle.debug.js
@@ -5,7 +5,6 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 	let x = 1;
 	_html("<span>child</span>");
 	const $return = x;
-	_resume_branch($scope0_id);
 	return $return;
 });
 

--- a/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-tag-no-var/__snapshots__/html.bundle.js
@@ -1,12 +1,10 @@
 // tags/child.marko
 var child_default = _template("b", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	let x = 1;
 	_html("<span>child</span>");
-	const $return = x;
-	_resume_branch($scope0_id);
-	return $return;
+	return x;
 });
 
 // template.marko

--- a/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/__snapshots__/html.bundle.debug.js
@@ -4,5 +4,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let x = { y: "hello" };
 	_html(_escape(x.y));
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/typescript-with-tag-variable/__snapshots__/html.bundle.js
@@ -1,7 +1,6 @@
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	_html(_escape({ y: "hello" }.y));
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.bundle.debug.js
@@ -13,5 +13,4 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html("<section>");
 	child_default({});
 	_html(`</section><div>${_escape(count)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/walk-over-child/__snapshots__/html.bundle.js
@@ -8,10 +8,9 @@ var child_default = _template("b", (input) => {
 // template.marko
 var template_default = _template("a", (input) => {
 	_scope_reason();
-	const $scope0_id = _scope_id();
+	_scope_id();
 	let count = 0;
 	_html("<section>");
 	child_default({});
 	_html(`</section><div>${_escape(count)}</div>`);
-	_resume_branch($scope0_id);
 }, 1);

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -1477,7 +1477,11 @@ export function writeHTMLResumeStatements(
     !section.isBranch &&
     (section.hasAbortSignal ||
       !!section.referencedClosures ||
-      !!find(section.bindings, (binding) => binding.type === BindingType.let));
+      (sectionSerializeReason &&
+        !!find(
+          section.bindings,
+          (binding) => binding.type === BindingType.let,
+        )));
 
   if (resumeClosestBranch) {
     body.push(


### PR DESCRIPTION
Avoid emitting closest-branch resume metadata for scopes whose only trigger is an unserialized let, eliminating useless server work and payload. Abort-signal and closure-bearing scopes still retain their branch links so lifecycle cleanup and ready-channel descendants continue to resume correctly.