### PR TITLE
perf(runtime-tags): streamline reference finalization

### DIFF
--- a/.changeset/swift-reference-finalization.md
+++ b/.changeset/swift-reference-finalization.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Reduce compile time for templates with many intersecting bindings.

--- a/agent-feedback/perf.md
+++ b/agent-feedback/perf.md
@@ -155,12 +155,6 @@ The closure `signal` is assigned only in the `pending.then((mod) => queueAsyncRe
 
 `knownTagTranslateHTML` falls back to an object literal `{0: g0, 1: g1, …}` whenever any group guard is a runtime expression, even when every group shares the same expression, and that literal is allocated on every render of the call site — one per row inside a `<for>`. Since `_serialize_if` treats `1` as "all groups" and a number as a bit-per-group mask, a shared 1|0 guard can be passed bare when `hasSkippedReasons` is false, or as `<bitmask> * guard` when groups were skipped. Gate it on the shared expression being normalized to 1|0 (a `_serialize_guard` call, an `||` chain of them, or a numeric literal), because `buildGuardExpr` can also hand back a raw `$scopeN_reason` whose value is itself a mask or object. Re-verify: `fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js` emits `_set_serialize_reason({0: $sg__input_x, 1: $sg__input_x, 2: $sg__input_x})`; across the committed html.bundle.js corpus 17 of 137 calls use the object form and 14 have identical values in every slot.
 
-## Reuse the `anchors` map for the intersection id loop in `finalizeReferences`
-
-`packages/runtime-tags/src/translator/util/references.ts` › `finalizeReferences` | 2026-07-23 | impact:low | effort:low
-
-The id-assignment loop tests `intersections[intersectionIndex].filter(isOwnedBinding).at(-1) === binding`, allocating a filtered array per owned binding, while the `anchors` map built ~30 lines above already holds each intersection's last owned binding; hoist `anchors` out of the `if (intersections.length)` block and the test becomes `anchors.get(intersection) === binding`. That removes an O(ownBindings × intersectionLength) walk (~640k element visits for 800 `<let>`s read in one expression). Same pass: `filter(bindings, isOwnedBinding)` is built twice and could be shared, and the name-collision check `find(section.bindings, ({ name }) => name === binding.name)` is an O(bindings²) scan a per-section `Set<string>` makes O(1). Re-verify: swap in the map lookup and run `pnpm run test:update -- --grep "runtime-tags/translator for-tag "` — snapshots must be unchanged, since the two expressions are equal by construction.
-
 ## Skip the `AbortController` when a section only uses `$signal` for cleanup
 
 `packages/runtime-tags/src/translator/visitors/referenced-identifier.ts` › `analyze` | 2026-07-29 | impact:med | effort:med

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -19,7 +19,6 @@ import {
   addSorted,
   concat,
   filter,
-  find,
   findSorted,
   forEach,
   includes,
@@ -1037,6 +1036,7 @@ export function finalizeReferences() {
     }
   }
 
+  const bindingNamesBySection = new Map<Section, Set<string>>();
   for (const binding of bindings) {
     if (binding.type !== BindingType.dom) {
       if (pruneBinding(binding)) {
@@ -1085,7 +1085,12 @@ export function finalizeReferences() {
         addOwnerSerializeReason(assignedSection, section, true);
       });
 
-      if (find(section.bindings, ({ name }) => name === binding.name)) {
+      let bindingNames = bindingNamesBySection.get(section);
+      if (!bindingNames) {
+        bindingNamesBySection.set(section, (bindingNames = new Set()));
+        forEach(section.bindings, ({ name }) => bindingNames!.add(name));
+      }
+      if (bindingNames.has(binding.name)) {
         binding.name = generateUid(name);
       }
     }
@@ -1121,10 +1126,9 @@ export function finalizeReferences() {
       }
     }
 
-    section.bindings = bindingUtil.add(
-      section.bindings,
-      getCanonicalBinding(binding),
-    );
+    const canonicalBinding = getCanonicalBinding(binding);
+    section.bindings = bindingUtil.add(section.bindings, canonicalBinding);
+    bindingNamesBySection.get(section)?.add(canonicalBinding.name);
 
     for (const exprExtra of binding.reads) {
       const { isEffect, section } = exprExtra;
@@ -1367,6 +1371,7 @@ export function finalizeReferences() {
   forEachSection((section) => {
     const { id, bindings } = section;
     const isOwnedBinding = ({ section }: Binding) => section.id === id;
+    const ownedBindings = filter(bindings, isOwnedBinding);
     const intersections = (intersectionsBySection.get(section) || []).filter(
       (intersection) => {
         const collapseSource = getCollapsibleIntersectionSource(
@@ -1379,20 +1384,21 @@ export function finalizeReferences() {
         return !collapseSource;
       },
     );
+    let anchors: Map<Intersection, Binding | undefined> | undefined;
     if (intersections.length) {
-      const anchors = new Map<Intersection, Binding | undefined>();
+      const sectionAnchors = (anchors = new Map());
       for (const intersection of intersections) {
         for (let i = intersection.length; i--;) {
           if (isOwnedBinding(intersection[i])) {
-            anchors.set(intersection, intersection[i]);
+            sectionAnchors.set(intersection, intersection[i]);
             break;
           }
         }
       }
 
       intersections.sort((a, b) => {
-        const aAnchor = anchors.get(a);
-        const bAnchor = anchors.get(b);
+        const aAnchor = sectionAnchors.get(a);
+        const bAnchor = sectionAnchors.get(b);
         return aAnchor
           ? bAnchor
             ? bindingUtil.compare(aAnchor, bAnchor)
@@ -1406,16 +1412,15 @@ export function finalizeReferences() {
     let intersectionIndex = 0;
     let nextId = 0;
     let intersection: Intersection;
-    forEach(filter(bindings, isOwnedBinding), (binding) => {
+    forEach(ownedBindings, (binding) => {
       binding.id = nextId++;
       // Reserved ids follow the binding's own; dom bindings never reserve
       // since their ids are the walker's dense indexes.
       nextId += binding.reserveSize;
       while (
         intersectionIndex < intersections.length &&
-        (intersection = intersections[intersectionIndex])
-          .filter(isOwnedBinding)
-          .at(-1) === binding
+        anchors!.get((intersection = intersections[intersectionIndex])) ===
+          binding
       ) {
         intersectionIndex++;
         intersectionMeta.set(intersection, {
@@ -1436,7 +1441,7 @@ export function finalizeReferences() {
 
     // Closure accessor ids trail the id space; `_closure_get` receives the
     // id directly, so unused reservations never reach the wire.
-    forEach(filter(bindings, isOwnedBinding), (binding) => {
+    forEach(ownedBindings, (binding) => {
       if (binding.closureSections) {
         closureAccessorIds.set(binding, nextId++);
       }


### PR DESCRIPTION
Reuses intersection anchors and owned-binding collections during reference finalization, and tracks binding names per section. This removes repeated quadratic scans from templates with large binding intersections without changing generated output.