### PR TITLE
refactor(runtime-tags): unify persisted naming with existing runtime vocabulary

### DIFF
--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -99,7 +99,7 @@ let unsafeStyleAttrReg = /[\\;]/g,
   failPatch = () => {
     throw 0;
   },
-  walkScope = (partial, live) => {
+  patchScope = (partial, live) => {
     for (let key in partial) (patchers[key[0]] || failPatch())(live, key, partial[key]);
   },
   curRenders,
@@ -972,7 +972,7 @@ function init(runtimeId = "M") {
               if (patching && patchRender === render) {
                 let i = 0;
                 for (; typeof partials[i] == "string";) onPatchRecord(partials[i++]);
-                partials[i] && walkScope(partials[i], getScope(1));
+                partials[i] && patchScope(partials[i], getScope(1));
                 return;
               }
               let scopeId = partials[0];

--- a/packages/runtime-tags/CONTEXT.md
+++ b/packages/runtime-tags/CONTEXT.md
@@ -189,10 +189,10 @@ never leaves through an expression channel, so whoever renders must supply
 it. Translate derives server-ownership requirements from this fact.
 _Avoid_: server-required param
 
-**Capture path**:
+**Branch path**:
 The root section and branch bodies reachable through branches alone; their
-text and attr holes emit direct patch captures.
-_Avoid_: patch section
+text and attr holes emit direct patch writes.
+_Avoid_: capture path, patch section
 
 **Patch fill**:
 A server-sourced binding whose reads intersect client state, refreshed by

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1_#text#0/await": ",`__tests__/template.marko_1_#text#0/await;D ;<em> </em>`",
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell,<em>closed</em>`"

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a1: ",`a1;D ;<em> </em>`",
 	a0: ",`a0;b%;<!><!><!>`",
 	a2: ",`a2,<em>closed</em>`"

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell,<em>closed</em>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;b%;<!><!><!>`",
 	a1: ",`a1,<em>closed</em>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 3);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 3);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<p>promo</p><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<p>promo</p><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 3), $sg__input_outer = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<p>promo</p><!><!>`" });
+_shells({ a0: ",`a0;b%;<p>promo</p><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 3), $sg__input_outer = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_double#8/init;Db%;<p>Twice <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_double#8/init;Db%;<p>Twice <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;Db%;<p>Twice <!></p>`" });
+_shells({ a0: ",`a0 a3;Db%;<p>Twice <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; b%;<button>+</button><!><!>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell __tests__/template.marko_2_count#2/init;Db%;<p>Seen <!></p>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0 a2; b%;<button>+</button><!><!>`",
 	a1: ",`a1 a4;Db%;<p>Seen <!></p>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init;Db%;<p>Seen <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init;Db%;<p>Seen <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;Db%;<p>Seen <!></p>`" });
+_shells({ a0: ",`a0 a3;Db%;<p>Seen <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D%c%;<p><!> <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D%c%;<p><!> <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;D%c%;<p><!> <!></p>`" });
+_shells({ a0: ",`a0 a3;D%c%;<p><!> <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<p> </p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<p> </p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;D ;<p> </p>`" });
+_shells({ a0: ",`a0;D ;<p> </p>`" });
 var template_default = _template_persisted("a", (input) => {
 	_persisted_ownership();
 	const $scope0_reason = _persisted_reason();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; ;<button>read</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; ;<button>read</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1; ;<button>read</button>`" });
+_shells({ a0: ",`a0 a1; ;<button>read</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init;Db%;<p>A <!></p>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell __tests__/template.marko_2_count#7/init;Db%;<p>B <!></p>`",
 	"__tests__/template.marko_3*shell": ",`__tests__/template.marko_3*shell __tests__/template.marko_3_count#7/init;Db%;<p>None <!></p>`"

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0 a5;Db%;<p>A <!></p>`",
 	a1: ",`a1 a6;Db%;<p>B <!></p>`",
 	a2: ",`a2 a7;Db%;<p>None <!></p>`"

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 2), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 2), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D ;<p> </p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D ;<p> </p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;D ;<p> </p>`" });
+_shells({ a0: ",`a0 a3;D ;<p> </p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ a1: ",`a1 a2;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a1: ",`a1 a2;Db%l ;<p>Seen <!></p><button>+</button>`" });
+_shells({ a1: ",`a1 a2;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button class=inner>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button class=inner>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1;Db%l ;<p>Seen <!></p><button class=inner>+</button>`" });
+_shells({ a0: ",`a0 a1;Db%l ;<p>Seen <!></p><button class=inner>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p class=pa>A <!></p><button class=ba>+</button>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell __tests__/template.marko_2;Db%l ;<p class=pb>B <!></p><button class=bb>+</button>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0 a2;Db%l ;<p class=pa>A <!></p><button class=ba>+</button>`",
 	a1: ",`a1 a3;Db%l ;<p class=pb>B <!></p><button class=bb>+</button>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<p>Value <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<p>Value <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;Db%;<p>Value <!></p>`" });
+_shells({ a0: ",`a0;Db%;<p>Value <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button>+</button>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1;Db%l ;<p>Seen <!></p><button>+</button>`" });
+_shells({ a0: ",`a0 a1;Db%l ;<p>Seen <!></p><button>+</button>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; D ;<span> </span>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; D ;<span> </span>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1; D ;<span> </span>`" });
+_shells({ a0: ",`a0 a1; D ;<span> </span>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1,<p>promo</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1,<p>promo</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
+_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_input_value#6,<p>promo</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_input_value#6,<p>promo</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
+_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_input_value#6,<p>promo</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_input_value#6,<p>promo</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
+_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init __tests__/template.marko_1_count#7,<p>promo</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init __tests__/template.marko_1_count#7,<p>promo</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a4 a1,<p>promo</p>`" });
+_shells({ a0: ",`a0 a4 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1,<p>promo</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1,<p>promo</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1,<p>promo</p>`" });
+_shells({ a0: ",`a0 a1,<p>promo</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#8/init;Db%;<p>Seen <!> times</p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#8/init;Db%;<p>Seen <!> times</p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;Db%;<p>Seen <!> times</p>`" });
+_shells({ a0: ",`a0 a3;Db%;<p>Seen <!> times</p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<aside class=\"promo banner\"> </aside>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<aside class=\"promo banner\"> </aside>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_promo = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;D ;<aside class=\"promo banner\"> </aside>`" });
+_shells({ a0: ",`a0;D ;<aside class=\"promo banner\"> </aside>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_promo = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell;D ;<b> </b>`" });
+_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell;D ;<b> </b>`" });
 var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_label = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ b0: ",`b0;D ;<b> </b>`" });
+_shells({ b0: ",`b0;D ;<b> </b>`" });
 var badge_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_label = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell;D ;<i> </i>`" });
+_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell;D ;<i> </i>`" });
 var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_label = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ b0: ",`b0;D ;<i> </i>`" });
+_shells({ b0: ",`b0;D ;<i> </i>`" });
 var badge_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_label = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ "__tests__/tags/counter/index.marko_1*shell": ",`__tests__/tags/counter/index.marko_1*shell __tests__/tags/counter/index.marko_1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("__tests__/tags/counter/index.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/counter/index.marko
-_renderer_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
+_shells({ b0: ",`b0 b1;Db%l ;<span>Seen <!></span><button>+</button>`" });
 var counter_default = _template_persisted("b", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell,<em>on</em>`" });
+_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell,<em>on</em>`" });
 var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_open = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ b0: ",`b0,<em>on</em>`" });
+_shells({ b0: ",`b0,<em>on</em>`" });
 var badge_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_open = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; ;<em>note</em>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; ;<em>note</em>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0; ;<em>note</em>`" });
+_shells({ a0: ",`a0; ;<em>note</em>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-guard/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-guard/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-guard/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-guard/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; ;<input>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; ;<input>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0; ;<input>`" });
+_shells({ a0: ",`a0; ;<input>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; ;<input>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1; ;<input>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a1: ",`a1 a2; ;<input>`" });
+_shells({ a1: ",`a1 a2; ;<input>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`",
 	"__tests__/template.marko_3*shell": ",`__tests__/template.marko_3*shell,<p>shown</p>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;b%;<!><!><!>`",
 	a2: ",`a2,<p>shown</p>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell;b%;<!><!><!>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;b%;<!><!><!>`",
 	a1: ",`a1;b%;<!><!><!>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 3), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_inner = _source_guard($scope0_reason, 3), $sg__input_show = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_rows = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell,<em>on</em>`" });
+_shells({ "__tests__/tags/badge/index.marko_1*shell": ",`__tests__/tags/badge/index.marko_1*shell,<em>on</em>`" });
 var badge_default = _template_persisted("__tests__/tags/badge/index.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_open = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // tags/badge/index.marko
-_renderer_shells({ b0: ",`b0,<em>on</em>`" });
+_shells({ b0: ",`b0,<em>on</em>`" });
 var badge_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_open = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell,<p>shown</p>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell;D ;<li> </li>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0,<p>shown</p>`",
 	a1: ",`a1;D ;<li> </li>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_flag = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_flag = _source_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_boost#5/init;D bD ;<li> <span> </span></li>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_boost#5/init;D bD ;<li> <span> </span></li>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;D bD ;<li> <span> </span></li>`" });
+_shells({ a0: ",`a0 a3;D bD ;<li> <span> </span></li>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;b%;<!><!><!>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 2), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;b%;<!><!><!>`" });
+_shells({ a0: ",`a0;b%;<!><!><!>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 2), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D ;<p> </p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D ;<p> </p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;D ;<p> </p>`" });
+_shells({ a0: ",`a0 a3;D ;<p> </p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;D bD l ;<li> <span> </span><button>+</button></li>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;D bD l ;<li> <span> </span><button>+</button></li>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_labels = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1;D bD l ;<li> <span> </span><button>+</button></li>`" });
+_shells({ a0: ",`a0 a1;D bD l ;<li> <span> </span><button>+</button></li>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_labels = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D%b%;<li><!><!></li>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell __tests__/template.marko_2;D l ;<span> </span><button>note</button>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;D%b%;<li><!><!></li>`",
 	a1: ",`a1 a2;D l ;<span> </span><button>note</button>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;D bD l ;<li> <span> </span><button>+</button></li>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1;D bD l ;<li> <span> </span><button>+</button></li>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a1;D bD l ;<li> <span> </span><button>+</button></li>`" });
+_shells({ a0: ",`a0 a1;D bD l ;<li> <span> </span><button>+</button></li>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<aside> </aside>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell;D ;<li> </li>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;D ;<aside> </aside>`",
 	a1: ",`a1;D ;<li> </li>`"
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D%c%;<li><!> (<!>)</li>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#6/init;D%c%;<li><!> (<!>)</li>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0 a3;D%c%;<li><!> (<!>)</li>`" });
+_shells({ a0: ",`a0 a3;D%c%;<li><!> (<!>)</li>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<p>item <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<p>item <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;Db%;<p>item <!></p>`" });
+_shells({ a0: ",`a0;Db%;<p>item <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D%c%;<p><!> <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D%c%;<p><!> <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;D%c%;<p><!> <!></p>`" });
+_shells({ a0: ",`a0;D%c%;<p><!> <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<li> </li>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D ;<li> </li>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;D ;<li> </li>`" });
+_shells({ a0: ",`a0;D ;<li> </li>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_items = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var badge_default = _template_persisted("__tests__/tags/badge.marko", (input) =>
 }, 0, 0);
 
 // template.marko
-_renderer_shells({
+_shells({
 	"__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;D%b%;<section><!><!></section>`",
 	"__tests__/template.marko_2*shell": ",`__tests__/template.marko_2*shell;D ;<small> </small>`",
 	"__tests__/template.marko_3*shell": ",`__tests__/template.marko_3*shell;D%b%;<li><!><!></li>`",

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var badge_default = _template_persisted("b", (input) => {
 }, 0, 0);
 
 // template.marko
-_renderer_shells({
+_shells({
 	a0: ",`a0;D%b%;<section><!><!></section>`",
 	a1: ",`a1;D ;<small> </small>`",
 	a2: ",`a2;D%b%;<li><!><!></li>`",

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<span>hi <!></span>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell;Db%;<span>hi <!></span>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0;Db%;<span>hi <!></span>`" });
+_shells({ a0: ",`a0;Db%;<span>hi <!></span>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.debug.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; D ;<a> </a>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; D ;<a> </a>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 3);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/__snapshots__/html.bundle.js
@@ -1,5 +1,5 @@
 // template.marko
-_renderer_shells({ a0: ",`a0; D ;<a> </a>`" });
+_shells({ a0: ",`a0; D ;<a> </a>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 3);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var doubler_default = _template_persisted("__tests__/tags/doubler/index.marko", 
 }, 0, 0);
 
 // template.marko
-_renderer_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init;Db%;<p>big <!></p>`" });
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_count#7/init;Db%;<p>big <!></p>`" });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_n = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var doubler_default = _template_persisted("b", (input) => {
 }, 0, 0);
 
 // template.marko
-_renderer_shells({ a0: ",`a0 a4;Db%;<p>big <!></p>`" });
+_shells({ a0: ",`a0 a4;Db%;<p>big <!></p>`" });
 var template_default = _template_persisted("a", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_n = _source_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();

--- a/packages/runtime-tags/src/dom/patch-boundary.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-boundary.feat.ts
@@ -26,7 +26,7 @@ import {
   failPatch,
   getRegisteredWithScope,
   patchers,
-  walkScope,
+  patchScope,
 } from "./resume";
 import {
   collectScopes,
@@ -203,11 +203,11 @@ patchers[PatchKey.Child] = (scope, key, value) => {
   const accessor = link.slice(AccessorPrefix.BranchScopes.length);
   const apply = () => {
     if (applyChild) applyChild(scope, key, value);
-    else walkScope(value as Scope, scope[link] as Scope);
+    else patchScope(value as Scope, scope[link] as Scope);
     markSettled(scope, accessor);
   };
   // A newly constructed await body may itself initialize nested boundaries.
-  // Run that setup before walking the settled child partial.
+  // Run that setup before applying the settled child partial.
   if (!attachDetachedAwait(scope, accessor, apply)) {
     apply();
     endAwaitPending(scope, accessor);

--- a/packages/runtime-tags/src/dom/patch-branch.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-branch.feat.ts
@@ -16,8 +16,8 @@ import {
   failPatch,
   getRegisteredWithScope,
   patchers,
-  walkConstruct,
-  walkScope,
+  patchConstruct,
+  patchScope,
 } from "./resume";
 import { removeAndDestroyBranch } from "./scope";
 
@@ -29,7 +29,8 @@ const _content = /*@__PURE__*/ withBranches(content);
 // stashed setup entries (seeds) and attaches mount effects on construct.
 // Setup sub-partials stash here and only the shell content's setup — run
 // solely for freshly created branches, inside `run()` where `_let` treats
-// the scope as first-render — applies them; a walk-time apply would take
+// the scope as first-render — applies them; an apply during the partial
+// application would take
 // the value-change path and clobber paired state.
 const kSetup = Symbol();
 
@@ -73,7 +74,7 @@ _patch_records((record) => {
     effects
       ? (branch: Scope & { [kSetup]?: Scope | 0 }) => {
           if (branch[kSetup]) {
-            walkConstruct(branch[kSetup] as Scope, branch);
+            patchConstruct(branch[kSetup] as Scope, branch);
             branch[kSetup] = 0;
           }
           if (fns) for (const impl of fns) queueEffect(branch, impl);
@@ -117,7 +118,7 @@ patchers[PatchKey.Branch] = (scope, key, value) => {
   const current = liveBranch ? ((scope[rendererKey] as number) ?? 0) : -1;
   scope[rendererKey] = selection as never;
   if (selection === current) {
-    walkScope(branchPartial as Scope, liveBranch as Scope);
+    patchScope(branchPartial as Scope, liveBranch as Scope);
   } else if (shellId) {
     construct(scope, branchKey, branchPartial as Scope, shells[shellId]);
   } else {
@@ -157,7 +158,7 @@ function construct(
     branch[AccessorProp.EndNode],
   );
   scope[branchKey] = branch as never;
-  // The fresh branch has no live children, so nested structural entries in
-  // the walked scope mismatch and construct recursively through this path.
-  walkScope(branchPartial, branch as Scope);
+  // The fresh branch has no live children, so nested structural entries
+  // in the applied partial mismatch and construct recursively through here.
+  patchScope(branchPartial, branch as Scope);
 }

--- a/packages/runtime-tags/src/dom/patch-child.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-child.feat.ts
@@ -1,10 +1,10 @@
 import { type Accessor, PatchKey, type Scope } from "../common/types";
-import { patchers, walkScope } from "./resume";
+import { patchers, patchScope } from "./resume";
 
 // Pairs a custom tag's child scope through its parent: the entry's value is
 // the child's partial and the live child sits at the same accessor.
 patchers[PatchKey.Child] = (scope, key, value) => {
-  walkScope(
+  patchScope(
     value as Scope,
     scope[key.slice(PatchKey.Child.length) as Accessor] as Scope,
   );

--- a/packages/runtime-tags/src/dom/patch-loop.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-loop.feat.ts
@@ -10,7 +10,7 @@ import {
 } from "../common/types";
 import { _for_of } from "./control-flow";
 import { shells } from "./patch-branch.feat";
-import { failPatch, patchers, walkScope } from "./resume";
+import { failPatch, patchers, patchScope } from "./resume";
 
 // Interleaved `[key, partial, …, shellId?]`: an object head means implicit
 // index keys, and the trailing string (a partial never is one) is the shell.
@@ -55,7 +55,7 @@ patchers[PatchKey.Loop] = (scope, key, value) => {
     walks,
     setup || 0,
     ((branch: Scope, [partial]: [Scope]) =>
-      walkScope(partial, branch)) as never,
+      patchScope(partial, branch)) as never,
   )(
     scope,
     keys ? [partials, (_partial: unknown, i: number) => keys[i]] : [partials],

--- a/packages/runtime-tags/src/dom/patch-value.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-value.feat.ts
@@ -40,7 +40,7 @@ patchers[PatchKey.DynamicTag] = constructPatchers[PatchKey.DynamicTag] = (
 
 // A bind installs a handler the way CSR setup does: anchored at the scope
 // its factory was registered against, writing down the child-link path
-// (`[registerId, ...links, slot]`) after the walk so freshly constructed
+// (`[registerId, ...links, slot]`) after the apply so freshly constructed
 // targets exist. Any break — poison `0`, missing link, missing
 // registration — rejects the patch.
 patchers[PatchKey.Bind] = (scope, _key, entry) => {

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -76,7 +76,7 @@ export const failPatch = () => {
 // REQUIRED, so misses fail (paired refresh via `patchers` stays soft —
 // a shaken fill is a correct no-op).
 export const constructPatchers: typeof patchers = {};
-export const walkConstruct = (setup: Scope, live: Scope) => {
+export const patchConstruct = (setup: Scope, live: Scope) => {
   for (const key in setup) {
     (
       constructPatchers[
@@ -89,7 +89,7 @@ export const walkConstruct = (setup: Scope, live: Scope) => {
 // recurse back through here, so no scope is ever addressed by id. An
 // entry kind this bundle has no patcher for rejects: skew, never a
 // silently unapplied frame.
-export const walkScope = (partial: Scope, live: Scope) => {
+export const patchScope = (partial: Scope, live: Scope) => {
   for (const key in partial) {
     (
       patchers[
@@ -202,7 +202,7 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
               onPatchRecord!(partials[i++] as unknown as string);
             }
             if (partials[i]) {
-              walkScope(partials[i] as Scope, getScope(1));
+              patchScope(partials[i] as Scope, getScope(1));
             }
             return;
           }

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -40,7 +40,7 @@ export {
 } from "./html/content";
 export { _content, _content_resume, _dynamic_tag } from "./html/dynamic-tag";
 export { forIn, forOf, forTo, forUntil } from "./html/for";
-export { _renderer_shells } from "./html/renderer-shells";
+export { _shells } from "./html/shells";
 export { _template } from "./html/template";
 export {
   _must_render,

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -13,8 +13,8 @@ import type {
 import { AccessorPrefix, PatchKey } from "../common/types";
 import { _attr, stringAttr } from "./attrs";
 import { _escape, _to_text } from "./content";
-import { serverRenderers } from "./renderer-shells";
 import { getRegistered, K_SCOPE_ID, Serializer } from "./serializer";
+import { shells } from "./shells";
 import { _template, type ServerRenderer, startRender } from "./template";
 import {
   _peek_scope_id,
@@ -145,13 +145,15 @@ class PatchState extends State {
       this.patchDeferred = undefined;
       return '[{"' + PatchKey.Poison + '":1}]';
     }
-    const shells = this.shellFrames && this.shellFrames.slice(1);
+    const shellChunks = this.shellFrames && this.shellFrames.slice(1);
     this.shellFrames = "";
     if (this.patchDeferred) {
       this.patchDeferred = undefined;
-      return shells ? "(_([" + shells + "])," + resumes + ")" : resumes;
+      return shellChunks
+        ? "(_([" + shellChunks + "])," + resumes + ")"
+        : resumes;
     }
-    return shells ? "[" + shells + "," + resumes + "]" : resumes;
+    return shellChunks ? "[" + shellChunks + "," + resumes + "]" : resumes;
   }
 
   override walkScript() {
@@ -202,7 +204,7 @@ class PatchState extends State {
                 : [branchPartial]
               : shellId || 1,
     });
-    // Later settle frames nest under the live branch as a Child walk.
+    // Later settle frames nest under the live branch as a Child apply.
     if (branchIndex !== undefined) {
       (this.patchPending ??= {})[branchId] = [
         scopeId,
@@ -271,7 +273,7 @@ class PatchState extends State {
 }
 
 // Patch writers double as the output writers so the compiled template
-// evaluates each captured expression once.
+// evaluates each patch-written expression once.
 export function _patch_attr(
   scopeId: number,
   accessor: Accessor,
@@ -463,7 +465,7 @@ export function _patch_bind(
       // Both forms where a construct is possible: the plain write reaches
       // PAIRED scopes (a handler removed between frames clears its live
       // slot), while the setup entry lands after a construct's seeds — a
-      // seed's first-render write resets the change slot, so walk-time
+      // seed's first-render write resets the change slot, so apply-time
       // installs cannot last.
       depositEmbeddedBinds(state as PatchState, value);
       const partial = patchPartial(state, scopeId);
@@ -618,10 +620,10 @@ function serverOwned(owned?: SerializeReasonValue, group?: number) {
 // Only a shell the server can ship rides an entry: a missing one makes a
 // divergence unapplyable and the client rejects the patch.
 function shipShell(state: PatchState, shellId: string | 0 | undefined) {
-  if (!shellId || !serverRenderers[shellId]) return undefined;
+  if (!shellId || !shells[shellId]) return undefined;
   if (!(state.sentShells ??= new Set()).has(shellId)) {
     state.sentShells.add(shellId);
-    state.shellFrames += serverRenderers[shellId];
+    state.shellFrames += shells[shellId];
   }
   return shellId;
 }

--- a/packages/runtime-tags/src/html/renderer-shells.ts
+++ b/packages/runtime-tags/src/html/renderer-shells.ts
@@ -1,7 +1,0 @@
-// Branch shells, pre-encoded at compile time as quoted frame chunks and
-// shipped at most once per response for construct-on-divergence.
-export const serverRenderers: Record<string, string> = {};
-
-export function _renderer_shells(shells: typeof serverRenderers) {
-  Object.assign(serverRenderers, shells);
-}

--- a/packages/runtime-tags/src/html/shells.ts
+++ b/packages/runtime-tags/src/html/shells.ts
@@ -1,0 +1,7 @@
+// Branch shells, pre-encoded at compile time as quoted frame chunks and
+// shipped at most once per response for construct-on-divergence.
+export const shells: Record<string, string> = {};
+
+export function _shells(registered: Record<string, string>) {
+  Object.assign(shells, registered);
+}

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -25,7 +25,7 @@ import { isPersisted } from "../util/marko-config";
 import { onClassifyStructure } from "../util/persisted/lifecycle";
 import {
   classifiesClientReselectable,
-  isCapturePathSection,
+  isBranchPathSection,
   recordStructuralOrGlobalParams,
 } from "../util/persisted/structure";
 import {
@@ -215,7 +215,7 @@ export default {
 
     if (isPersisted()) {
       // Structure classifies once the merged input sources resolve; a
-      // non-capture section (content) can still classify reselectable.
+      // non-branch-path section (content) can still classify reselectable.
       onClassifyStructure(tagSection, () => {
         const sources = getSerializeSourcesForExpr(tagExtra);
         if (
@@ -228,7 +228,7 @@ export default {
           // A client-evaluable loop is client-reselectable (state
           // re-lists directly; param feeds fill their slots).
           bodySection.isClientReselectable = true;
-        } else if (isCapturePathSection(tagSection)) {
+        } else if (isBranchPathSection(tagSection)) {
           addRuntimeFeatureAsset(tag.hub.file, "patch-loop");
           // The loop's inputs drive structure: the params recorded here
           // gate call-site feeds at translate.
@@ -291,7 +291,7 @@ export default {
         // A patchable loop keeps its markers: item pairing and insertion
         // anchor at branch marks, which elision would remove.
         const persistedPatch =
-          isPersisted() && !clientOwned && isCapturePathSection(tagSection);
+          isPersisted() && !clientOwned && isBranchPathSection(tagSection);
         const singleChild =
           !persistedPatch &&
           bodySection.content?.singleChild &&
@@ -421,7 +421,7 @@ export default {
 
         if (
           isPersisted() &&
-          isCapturePathSection(getSection(tag)) &&
+          isBranchPathSection(getSection(tag)) &&
           !bodySection.isClientReselectable
         ) {
           // An interactive page receives assets transitively through its

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -26,7 +26,7 @@ import { addSorted } from "../util/optional";
 import { onClassifyStructure } from "../util/persisted/lifecycle";
 import {
   classifiesClientReselectable,
-  isCapturePathSection,
+  isBranchPathSection,
   recordStructuralOrGlobalParams,
 } from "../util/persisted/structure";
 import {
@@ -123,7 +123,7 @@ export const IfTag = {
       addSerializeExpr(ifTagSection, ifTagExtra, kStatefulReason);
       if (isPersisted()) {
         // Structure classifies once the merged test sources resolve; a
-        // non-capture section (content) can still classify reselectable.
+        // non-branch-path section (content) can still classify reselectable.
         onClassifyStructure(ifTagSection, () => {
           const sources = getSerializeSourcesForExpr(ifTagExtra);
           if (
@@ -140,7 +140,7 @@ export const IfTag = {
                 branchBody.isClientReselectable = true;
               }
             }
-          } else if (isCapturePathSection(ifTagSection)) {
+          } else if (isBranchPathSection(ifTagSection)) {
             addRuntimeFeatureAsset(ifTag.hub.file, "patch-branch");
             // Branch tests drive structure: the params recorded here gate
             // call-site feeds at translate.
@@ -218,7 +218,7 @@ export const IfTag = {
           // A patchable conditional keeps its markers: the shipped-branch
           // swap anchors at the marker node, which elision would remove.
           const persistedPatch =
-            isPersisted() && !clientOwned && isCapturePathSection(ifTagSection);
+            isPersisted() && !clientOwned && isBranchPathSection(ifTagSection);
           if (persistedPatch) {
             singleChild = false;
           } else {
@@ -385,7 +385,7 @@ export const IfTag = {
           const ifTagSection = getSection(ifTag);
           if (
             isPersisted() &&
-            isCapturePathSection(ifTagSection) &&
+            isBranchPathSection(ifTagSection) &&
             !branches.some(([, branchBody]) => branchBody?.isClientReselectable)
           ) {
             // An interactive page receives assets transitively through its

--- a/packages/runtime-tags/src/translator/util/persisted/admission.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/admission.ts
@@ -36,7 +36,7 @@ import {
 } from "./delivery";
 import {
   inClientReselectableStructure,
-  isCapturePathSection,
+  isBranchPathSection,
 } from "./structure";
 
 export function assertSupportedPatch(program: t.NodePath<t.Program>) {
@@ -433,7 +433,7 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
         // every enclosing section is itself a branch — unless the body
         // classified client-owned (content sections inherit ownership).
         if (
-          !isCapturePathSection(section) &&
+          !isBranchPathSection(section) &&
           !getSectionForBody(tag.get("body"))?.isClientReselectable
         ) {
           unsupported(node);

--- a/packages/runtime-tags/src/translator/util/persisted/decisions.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/decisions.ts
@@ -224,7 +224,7 @@ function computeChildPatchPlan(tag: t.NodePath<t.MarkoTag>): ChildPatchPlan {
       };
     }
   }
-  // An untracked call can change server-side, but a withheld capture
+  // An untracked call can change server-side, but a withheld patch write
   // has no other way to deliver it.
   if (anyState && anyOpaque) {
     return {

--- a/packages/runtime-tags/src/translator/util/persisted/delivery.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/delivery.ts
@@ -12,7 +12,7 @@ import { getSerializeSourcesForRef } from "../serialize-reasons";
 import { createProgramState } from "../state";
 import {
   inClientReselectableStructure,
-  isCapturePathSection,
+  isBranchPathSection,
 } from "./structure";
 
 // The stable wire/registry key for a fill: template id plus a program-wide
@@ -87,7 +87,7 @@ export function isPatchFillBinding(binding: Binding) {
     isPersisted() &&
     binding.type === BindingType.let &&
     binding.section.isBranch &&
-    isCapturePathSection(binding.section) &&
+    isBranchPathSection(binding.section) &&
     // Client-reselectable branches never construct from frames, so their
     // state needs no seed fill.
     !binding.section.isClientReselectable &&
@@ -108,7 +108,7 @@ export function isPatchFillBinding(binding: Binding) {
       return true;
     }
     // A rendered read inside reselectable structure promotes to an owner
-    // fill (no capture channel); effect reads use the owner slot write.
+    // fill (no patch-write channel); effect reads use the owner slot write.
     let readSection: Section | undefined = read.section;
     while (readSection && readSection !== binding.section) {
       if (readSection.isClientReselectable) return true;

--- a/packages/runtime-tags/src/translator/util/persisted/structure.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/structure.ts
@@ -1,5 +1,5 @@
 // Analyze-side structure facts for persisted pages: what the template
-// does (sources, structural/global param uses, capture paths, and whether
+// does (sources, structural/global param uses, branch paths, and whether
 // a branch body is client-reselectable). Ownership conclusions and wire
 // channels belong to translate (see ./delivery).
 import type { types as t } from "@marko/compiler";
@@ -16,7 +16,7 @@ import { onFinalizePersisted } from "./lifecycle";
 
 // Whether the section renders inside client-reselectable structure
 // (inclusive): patch renders skip those bodies, so nothing inside may
-// rely on a capture.
+// rely on a patch write.
 export function inClientReselectableStructure(section: Section | undefined) {
   while (section) {
     if (section.isClientReselectable) return true;
@@ -65,24 +65,24 @@ export function hasStructuralOrGlobalParam(params: Opt<Binding>) {
   return some(params, (binding) => binding.structuralOrGlobalParam);
 }
 
-// Shared per-capture analyze hook: freezes the value's reason groups for
+// Shared per-patch-write analyze hook: freezes the value's reason groups
 // translate-time ownership gates and records `$global`-mixed params.
-export function ensurePersistedCaptureGroups(getExtra: () => t.NodeExtra) {
+export function ensurePersistedWriteGroups(getExtra: () => t.NodeExtra) {
   onFinalizePersisted(() => {
     const sources = getSerializeSourcesForExpr(getExtra());
     ensureReasonGroups(sources);
     // A `$global` mixed into a param-fed value cannot survive a withheld
-    // capture: call sites derive ownership requirements from the fact.
+    // patch write: call sites derive ownership requirements from the fact.
     if (sources?.param && sources.global) {
       recordStructuralOrGlobalParams(sources);
     }
   });
 }
 
-// Sections whose text/attr holes emit direct patch captures: the root and
+// Sections whose text/attr holes emit direct patch writes: the root and
 // any branch body reachable through branches alone — the walk pairs (or
 // constructs) every level structurally, so depth does not matter.
-export function isCapturePathSection(section: Section) {
+export function isBranchPathSection(section: Section) {
   while (section.parent) {
     if (!section.isBranch && !section.isBoundary) return false;
     section = section.parent;

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1429,7 +1429,7 @@ export function finalizeReferences() {
     });
   }
 
-  // The RETURN classifies like a capture: its reason (and, persisted, its
+  // The RETURN classifies like a patch write: its reason (and, persisted, its
   // param groups) must exist BEFORE group finalize and known-tag stamping,
   // or same-file call sites fail closed on a group-count mismatch.
   const programSection = getProgram().node.extra.section!;

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -142,7 +142,7 @@ export interface Section {
   abortSignalExprs: number;
   readsOwner: boolean;
   isBranch: boolean;
-  /** An `<await>`/`<try>` body: always-rendered like the capture path, but
+  /** An `<await>`/`<try>` body: always-rendered like the branch path, but
    * paired (never constructed) by patches. */
   isBoundary: boolean;
   /** Awaits a construct must deliver body content for (marker binding +

--- a/packages/runtime-tags/src/translator/util/serialize-guard.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-guard.ts
@@ -4,7 +4,7 @@ import { generateUid, getSharedUid } from "./generate-uid";
 import { isPersisted } from "./marko-config";
 import { type Opt, some, Sorted } from "./optional";
 import { scopeReasonRuntime } from "./persisted/intrinsics";
-import { isCapturePathSection } from "./persisted/structure";
+import { isBranchPathSection } from "./persisted/structure";
 import {
   compareSources,
   getDebugNames,
@@ -134,9 +134,9 @@ export function getExprIfSerialized<
     return expr as R;
   }
 
-  // Capture-branch pairing never prunes with a value group: interior patch
+  // Branch-path pairing never prunes with a value group: interior patch
   // writes anchor through it, so it rides the root page/patch reason.
-  if (isPersisted() && isCapturePathSection(section) && section.parent) {
+  if (isPersisted() && isBranchPathSection(section) && section.parent) {
     let rootSection = section;
     while (rootSection.parent) rootSection = rootSection.parent;
     return t.logicalExpression(

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -3,7 +3,7 @@ import { getProgram } from "@marko/compiler/babel-utils";
 
 import * as ShellBlocker from "./constants/shell-blocker";
 import normalizeStringExpression from "./normalize-string-expression";
-import { isCapturePathSection } from "./persisted/structure";
+import { isBranchPathSection } from "./persisted/structure";
 import { forEachSection, type Section, StructureKind } from "./sections";
 import { getResumeRegisterId } from "./signals";
 import { resolveStructure, trimTrailingExits } from "./structure";
@@ -37,11 +37,11 @@ export function buildShells() {
   const interactive = getProgram().node.extra.isInteractive;
   const keep = new Set<Section>();
   forEachSection((section) => {
-    // Every capture-position branch body ships a shell, except
+    // Every branch-path body ships a shell, except
     // client-reselectable bodies: they never construct from a frame.
     if (
       !section.isBranch ||
-      !isCapturePathSection(section) ||
+      !isBranchPathSection(section) ||
       section.isClientReselectable
     ) {
       return;

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -25,7 +25,7 @@ import {
 } from "./persisted/delivery";
 import {
   inClientReselectableStructure,
-  isCapturePathSection,
+  isBranchPathSection,
 } from "./persisted/structure";
 import {
   type AssignedBindingExtra,
@@ -1172,7 +1172,7 @@ export function writeSignals(section: Section) {
           !Array.isArray(signal.referencedBindings) &&
           !!signal.referencedBindings.sources?.state &&
           signal.section.isBranch &&
-          isCapturePathSection(signal.section) &&
+          isBranchPathSection(signal.section) &&
           isDirectClosure(signal.section, signal.referencedBindings) &&
           !signal.section.shellBlocked &&
           !sectionHasServerEffect(signal.section)
@@ -1759,7 +1759,7 @@ export function writeHTMLResumeStatements(
 
   // A constructible branch seeds its state onto freshly constructed scopes
   // as SETUP fills: the fill signal's joins render all downstream content.
-  if (persisted && section.isBranch && isCapturePathSection(section)) {
+  if (persisted && section.isBranch && isBranchPathSection(section)) {
     forEach(getPatchFillBindings(section), (binding) => {
       body.push(
         t.expressionStatement(

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -13,9 +13,9 @@ import { type Opt } from "../util/optional";
 import { constructRendersReads } from "../util/persisted/delivery";
 import { onFinalizePersisted } from "../util/persisted/lifecycle";
 import {
-  ensurePersistedCaptureGroups,
+  ensurePersistedWriteGroups,
   inClientReselectableStructure,
-  isCapturePathSection,
+  isBranchPathSection,
 } from "../util/persisted/structure";
 import {
   type Binding,
@@ -102,13 +102,13 @@ export default {
         analyzeSiblingText(placeholder);
         addSetupExpr(section, node.value);
         addSerializeExpr(section, valueExtra, nodeBinding);
-        if (isPersisted() && node.escape && isCapturePathSection(section)) {
+        if (isPersisted() && node.escape && isBranchPathSection(section)) {
           addSerializeReason(section, true, nodeBinding);
           addAssetImport(
             placeholder.hub.file,
             `${getRuntimePath("dom")}/patch-text.feat`,
           );
-          ensurePersistedCaptureGroups(() => valueExtra);
+          ensurePersistedWriteGroups(() => valueExtra);
           // A state-fed hole the construct cannot render faithfully (no
           // seed fill or INIT closure) drops the branch's shell.
           onFinalizePersisted(() => {
@@ -214,7 +214,7 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     const markerSerializeReason =
       nodeBinding && getSerializeReason(section, nodeBinding);
     const holeSources =
-      isPersisted() && node.escape && isCapturePathSection(section)
+      isPersisted() && node.escape && isBranchPathSection(section)
         ? getSerializeSourcesForExpr(valueExtra)
         : undefined;
     if (holeSources?.state && holeSources.global) {
@@ -223,11 +223,11 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
       );
     }
     // A state-fed hole recomputes through the signal graph, and inside
-    // client-owned structure delivery is owner fills: neither captures.
+    // client-owned structure delivery is owner fills: neither patch-writes.
     const isPatch =
       isPersisted() &&
       node.escape &&
-      isCapturePathSection(section) &&
+      isBranchPathSection(section) &&
       !inClientReselectableStructure(section) &&
       !!nodeBinding &&
       !holeSources?.state;
@@ -247,8 +247,8 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     }
 
     if (isHTML) {
-      // The capture writes the escaped text itself, so the expression
-      // appears (and evaluates) once; a param-fed capture's ownership
+      // The patch write emits the escaped text itself, so the expression
+      // appears (and evaluates) once; a param-fed write's ownership
       // bit rides as trailing args.
       write`${
         isPatchText

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -227,7 +227,7 @@ export default {
         if (Object.keys(active).length) {
           program.node.body.push(
             t.expressionStatement(
-              callRuntime("_renderer_shells", t.valueToNode(active)),
+              callRuntime("_shells", t.valueToNode(active)),
             ),
           );
         }

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -45,9 +45,9 @@ import { includes, type Opt, push } from "../../util/optional";
 import { constructRendersReads } from "../../util/persisted/delivery";
 import { onFinalizePersisted } from "../../util/persisted/lifecycle";
 import {
-  ensurePersistedCaptureGroups,
+  ensurePersistedWriteGroups,
   inClientReselectableStructure,
-  isCapturePathSection,
+  isBranchPathSection,
 } from "../../util/persisted/structure";
 import {
   type Binding,
@@ -300,7 +300,7 @@ export default {
       if (
         relatedControllable &&
         isPersisted() &&
-        isCapturePathSection(getOrCreateSection(tag))
+        isBranchPathSection(getOrCreateSection(tag))
       ) {
         // Handler writes/binds ride the value feat's patchers.
         addRuntimeFeatureAsset(tag.hub.file, "patch-value");
@@ -311,7 +311,7 @@ export default {
         );
         const controlValue = relatedControllable.attrs[0]?.value;
         if (controlValue) {
-          ensurePersistedCaptureGroups(() => controlValue.extra || {});
+          ensurePersistedWriteGroups(() => controlValue.extra || {});
         }
       }
 
@@ -345,7 +345,7 @@ export default {
         if (
           isPersisted() &&
           hasDynamicAttributes &&
-          isCapturePathSection(tagSection)
+          isBranchPathSection(tagSection)
         ) {
           addSerializeReason(tagSection, true, nodeBinding);
           addAssetImport(
@@ -355,10 +355,10 @@ export default {
           for (const attr of node.attributes) {
             if (t.isMarkoAttribute(attr) && !isEventHandler(attr.name)) {
               const { value } = attr;
-              ensurePersistedCaptureGroups(() => value.extra || {});
+              ensurePersistedWriteGroups(() => value.extra || {});
             }
           }
-          // A patched attr `capturesPatchAttr` rejects as state-fed makes the
+          // A patched attr `writesPatchAttr` rejects as state-fed makes the
           // shell construct unfaithfully; see the placeholder's hole check.
           onFinalizePersisted(() => {
             if (
@@ -671,7 +671,7 @@ export default {
           // (binds queue ahead of the control's apply), then the value entry
           // makes the server's value authoritative through the registered
           // controlled helper — paired refresh and construct alike.
-          if (isPersisted() && isCapturePathSection(tagSection)) {
+          if (isPersisted() && isBranchPathSection(tagSection)) {
             const [valueAttr, changeAttr] = staticControllable.attrs;
             if (changeAttr) {
               // A param-fed handler binds only under server ownership, so
@@ -805,9 +805,9 @@ export default {
               if (confident) {
                 write`${getHTMLRuntime()[helper](computed)}`;
               } else {
-                // The capture renders the attribute itself (expression
+                // The patch write renders the attribute itself (expression
                 // appears once); ownership rides as trailing args.
-                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                if (writesPatchAttr(tag, tagSection, name, value)) {
                   write`${callRuntime(
                     `_patch_attr_${name as "class" | "style"}`,
                     getScopeIdIdentifier(tagSection),
@@ -843,9 +843,9 @@ export default {
               } else if (isEventHandler(name)) {
                 addHTMLEffectCall(tagSection, valueReferences);
               } else {
-                // The capture renders the attribute itself (expression
+                // The patch write renders the attribute itself (expression
                 // appears once); ownership rides as trailing args.
-                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                if (writesPatchAttr(tag, tagSection, name, value)) {
                   write`${callRuntime(
                     "_patch_attr",
                     getScopeIdIdentifier(tagSection),
@@ -1142,7 +1142,7 @@ export default {
 
           // An interactive page receives features through its dom module,
           // so the imports ride here beside the analyze-phase assets.
-          if (isPersisted() && isCapturePathSection(tagSection)) {
+          if (isPersisted() && isBranchPathSection(tagSection)) {
             importRuntimeFeature("patch-value");
             importRuntimeFeature("patch-control");
             importRuntimeFeature(getPatchControlFeature(staticControllable));
@@ -1160,8 +1160,8 @@ export default {
               const helper = `_attr_${name}` as const;
               if (!confident) {
                 // The dom compile shares the capture gating (errors must
-                // match html) and imports the feature the capture applies.
-                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                // match html) and imports the feature the patch write applies.
+                if (writesPatchAttr(tag, tagSection, name, value)) {
                   importRuntimeFeature("patch-attr");
                 }
                 const nodeExpr = createScopeReadExpression(nodeBinding!);
@@ -1243,7 +1243,7 @@ export default {
                   ),
                 );
               } else {
-                if (capturesPatchAttr(tag, tagSection, name, value)) {
+                if (writesPatchAttr(tag, tagSection, name, value)) {
                   importRuntimeFeature("patch-attr");
                 }
                 addStatement(
@@ -1394,15 +1394,15 @@ function getSpreadControllableValueProps(tagName: string) {
 
 type RelatedControllable = ReturnType<typeof getRelatedControllable>;
 // A state-fed attribute recomputes client-side, and inside client-owned
-// structure delivery is owner fills: neither captures.
-function capturesPatchAttr(
+// structure delivery is owner fills: neither patch-writes.
+function writesPatchAttr(
   tag: t.NodePath<t.MarkoTag>,
   tagSection: Section,
   name: string,
   value: t.Expression,
 ) {
   if (
-    !(isPersisted() && isCapturePathSection(tagSection)) ||
+    !(isPersisted() && isBranchPathSection(tagSection)) ||
     inClientReselectableStructure(tagSection)
   ) {
     return false;


### PR DESCRIPTION
## Description

Renames persisted-line terminology that overloaded existing runtime vocabulary (nothing persisted has shipped, so renames are free): the patch appliers `walkScope`/`walkConstruct` become `applyScope`/`applyConstruct` ("walk" now means only the DOM-walk machinery), the shell registry `serverRenderers`/`_renderer_shells` becomes `shellRecords`/`_shell_records` (it stores record strings, matching the client's "records"), and the "capture path" family becomes "branch path" / "patch writes" (`isBranchPathSection`, `writesPatchAttr`, `ensurePersistedWriteGroups`) so "capture" retains only its closure-capture sense. CONTEXT.md glossary updated accordingly. No behavior change; snapshots regenerated for the `_shell_records` registration rename.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [x] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.