### PR TITLE
feat(runtime-tags): delete the poison machinery

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,38 @@
+// template.marko
+const $template = "<main><!><button>show</button></main>";
+const $walks = "D%b l";
+const $if_content__api = /*@__PURE__*/ _fill_join("__tests__/template.marko0", "api", /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => _text($scope["#text/1"], [...$scope._.api].length)));
+const $if_content__setup = ($scope) => {
+	$if_content__api._($scope);
+	$if_content__api_label._($scope);
+};
+const $if_content__api_label = /*@__PURE__*/ _fill_join("__tests__/template.marko1", "api_label", /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => _text($scope["#text/0"], $scope._.api_label)));
+const $api2 = /*@__PURE__*/ _fill_const("__tests__/template.marko0", "api", ($scope) => {
+	$api_label($scope, $scope.api.label);
+	$if_content__api($scope);
+});
+const $input_title__OR__getTitle = ($scope) => {
+	$api2($scope, {
+		label: $scope.input_title,
+		[Symbol.iterator]: $api($scope)
+	});
+};
+const $input_title = /*@__PURE__*/ _const("input_title", $input_title__OR__getTitle);
+const $api_label = /*@__PURE__*/ _fill_const("__tests__/template.marko1", "api_label", $if_content__api_label);
+const $if = /*@__PURE__*/ _if("#text/0", "<p><!>:<!></p>", "D%c%", $if_content__setup);
+const $show = /*@__PURE__*/ _let("show/8", ($scope) => $if($scope, $scope.show ? 0 : 1));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/1"], "click", function() {
+	$show($scope, true);
+}));
+function $setup($scope) {
+	$show($scope, false);
+	$setup__script($scope);
+}
+const $input = ($scope, input) => $input_title($scope, input.title);
+const $getTitle = ($scope) => () => $scope.input_title;
+const $api = ($scope) => function* () {
+	yield $getTitle($scope);
+};
+_resume("__tests__/template.marko_0/getTitle", $getTitle);
+_resume("__tests__/template.marko_0/api", $api);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/dom.bundle.js
@@ -1,0 +1,18 @@
+// template.marko
+const $if_content__api = /*@__PURE__*/ _fill_join("a0", 6, /*@__PURE__*/ _if_closure(0, 0, ($scope) => _text($scope.b, [...$scope._.g].length)));
+const $if_content__setup = ($scope) => {
+	$if_content__api._($scope);
+	$if_content__api_label._($scope);
+};
+const $if_content__api_label = /*@__PURE__*/ _fill_join("a1", 7, /*@__PURE__*/ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.h)));
+const $if = /*@__PURE__*/ _if(0, "<p><!>:<!></p>", "D%c%", $if_content__setup);
+const $show = /*@__PURE__*/ _let(8, ($scope) => $if($scope, $scope.i ? 0 : 1));
+const $setup__script = _script("a2", ($scope) => _on($scope.b, "click", function() {
+	$show($scope, true);
+}));
+const $getTitle = ($scope) => () => $scope.e;
+const $api = ($scope) => function* () {
+	yield $getTitle($scope);
+};
+_resume("a0", $getTitle);
+_resume("a1", $api);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// template.marko
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const getTitle = _resume(() => input.title, "__tests__/template.marko_0/getTitle", $scope0_id);
+	const api = {
+		label: input.title,
+		[Symbol.iterator]: _resume(function* () {
+			yield getTitle;
+		}, "__tests__/template.marko_0/api", $scope0_id)
+	};
+	let show = false;
+	_html("<main>");
+	if ($scope0_reason) _if(() => {
+		if (show) {
+			const $scope1_id = _scope_id();
+			_html(`<p>${_escape(api.label)}${_el_resume($scope1_id, "#text/0")}:<!>${_escape([...api].length)}${_el_resume($scope1_id, "#text/1")}</p>`);
+			writeScope($scope1_id, {}, "__tests__/template.marko", "10:4");
+			return 0;
+		}
+	}, $scope0_id, "#text/0", 1, 1, 1, 0, 1);
+	_html(`<button>show</button>${_el_resume($scope0_id, "#button/1")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason ? writeScope($scope0_id, {
+		input_title: input.title,
+		getTitle,
+		api,
+		api_label: api.label
+	}, "__tests__/template.marko", 0, {
+		input_title: ["input.title"],
+		getTitle: "1:8",
+		api: "2:8",
+		api_label: ["api.label", "2:8"]
+	}) : (_owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", api), _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko1", api.label), _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "input_title", input.title), _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "getTitle", getTitle));
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/html.bundle.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	const getTitle = _resume(() => input.title, "a0", $scope0_id);
+	const api = {
+		label: input.title,
+		[Symbol.iterator]: _resume(function* () {
+			yield getTitle;
+		}, "a1", $scope0_id)
+	};
+	_html("<main>");
+	if ($scope0_reason) _if(() => {}, $scope0_id, "a", 1, 1, 1, 0, 1);
+	_html(`<button>show</button>${_el_resume($scope0_id, "b")}</main>`);
+	_script($scope0_id, "a2");
+	$scope0_reason ? writeScope($scope0_id, {
+		e: input.title,
+		f: getTitle,
+		g: api,
+		h: api.label
+	}) : (_owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", api), _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a1", api.label), _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "e", input.title), _owned_guard($scope0_owned, 0) && _patch_write($scope0_id, "f", getTitle));
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.debug.js
@@ -1,0 +1,13 @@
+// PATCH
+{
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko0": {
+    label: "b",
+    *[(_.a = [bindDeposit(1)], Symbol.iterator)]() {
+      yield* _.a
+    }
+  },
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko1": "b",
+  "PatchWrite:input_title": "b",
+  "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko_0/getTitle",
+  "PatchWrite:getTitle": bindDeposit(1)
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.js
@@ -1,0 +1,13 @@
+// PATCH
+{
+  va0: {
+    label: "b",
+    *[(_.a = [b(1)], Symbol.iterator)]() {
+      yield* _.a
+    }
+  },
+  va1: "b",
+  we: "b",
+  h1: "a0",
+  wf: b(1)
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/render.debug.md
@@ -1,0 +1,45 @@
+# Render `{"title":"a"}`
+```html
+<main>
+  <button>
+    show
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <p>
+    a:1
+  </p>
+  <button>
+    show
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > p
+UPDATE: main > p::text@2 "" => "1"
+UPDATE: main > p::text@0 "" => "a"
+```
+
+# Update `{"title":"b"}`
+```html
+<main>
+  <p>
+    b:1
+  </p>
+  <button>
+    show
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@0 "a" => "b"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/render.md
@@ -1,0 +1,45 @@
+# Render `{"title":"a"}`
+```html
+<main>
+  <button>
+    show
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <p>
+    a:1
+  </p>
+  <button>
+    show
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > p
+UPDATE: main > p::text@2 "" => "1"
+UPDATE: main > p::text@0 "" => "a"
+```
+
+# Update `{"title":"b"}`
+```html
+<main>
+  <p>
+    b:1
+  </p>
+  <button>
+    show
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@0 "a" => "b"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/writes.debug.html
@@ -1,0 +1,20 @@
+<main><!--M_|1 #text/0--><button>show</button><!--M_*1 #button/1--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      input_title: "a",
+      getTitle: _.b = _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko_0/getTitle"
+        ),
+      api: {
+        label: "a",
+        *[(_.a = [_.b], Symbol.iterator)]() {
+          yield* _.a
+        }
+      },
+      api_label: "a"
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/writes.html
@@ -1,0 +1,16 @@
+<main><!--M_|1 a--><button>show</button><!--M_*1 b--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    e: "a",
+    f: _.b = _(1, "a0"),
+    g: {
+      label: "a",
+      *[(_.a = [_.b], Symbol.iterator)]() {
+        yield* _.a
+      }
+    },
+    h: "a"
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8151,
+      "brotli": 3650
+    }
+  },
+  "html": {
+    "min": 450,
+    "brotli": 309
+  },
+  "patch": {
+    "min": 94,
+    "brotli": 98
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko
@@ -1,0 +1,14 @@
+<const/getTitle=() => input.title/>
+<const/api={
+  label: input.title,
+  [Symbol.iterator]: function* () {
+    yield getTitle;
+  },
+}/>
+<let/show=false/>
+<main>
+  <if=show>
+    <p>${api.label}:${[...api].length}</p>
+  </if>
+  <button onClick() { show = true }>show</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
@@ -1,0 +1,13 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// A registered function inside a custom iterator the deposit scan cannot
+// traverse still serializes: its own write channel deposits it first, and
+// deposits share by value identity across the frame.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [{ title: "a" }, click, { title: "b" }],
+};

--- a/packages/runtime-tags/src/common/constants/patch-key.debug.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.debug.ts
@@ -11,7 +11,6 @@ export const DynamicTag = "PatchDynamicTag:";
 export const Globals = "$global:";
 export const Loop = "PatchLoop:";
 export const Pending = "PatchPending:";
-export const Poison = "PatchPoison:";
 export const Setup = "PatchSetup:";
 export const Text = "PatchText:";
 export const Value = "PatchValue:";

--- a/packages/runtime-tags/src/common/constants/patch-key.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.ts
@@ -18,7 +18,6 @@ export const DynamicTag = "f";
 export const Globals = "$";
 export const Loop = "l";
 export const Pending = "p";
-export const Poison = "x";
 export const Setup = "s";
 export const Text = "t";
 export const Value = "v";

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -106,7 +106,6 @@ export function renderPatch(
 class PatchState extends State {
   public sentShells?: Set<string>;
   public bindDeposits?: Map<WeakKey, number>;
-  public poisonSent?: 1;
   public shellFrames = "";
   override writesPatches = true;
   override shipShell(shellId: string | 0 | undefined) {
@@ -121,16 +120,10 @@ class PatchState extends State {
   }
 
   override flushChunk(_html: string, scripts: string) {
-    // Everything after a delivered poison frame is dead: the client
-    // already rejected and navigated.
-    if (this.poisonSent) return "";
-    if (this.patchPoison) this.poisonSent = 1;
     const out = scripts ? scripts + "\n" : "";
-    if (!this.patchPoison) {
-      this.patchFlushed = undefined;
-      this.patchPartials = undefined;
-      this.serializer = new Serializer();
-    }
+    this.patchFlushed = undefined;
+    this.patchPartials = undefined;
+    this.serializer = new Serializer();
     return out;
   }
 
@@ -138,13 +131,6 @@ class PatchState extends State {
   // mid-expression) hoists shells into a preceding `_()` call.
   override resumeScript(resumes: string) {
     this.patchFlushed = 1;
-    // A poisoned frame (a bound registration with no rebind entry) is
-    // replaced by a bare poison tree: the client rejects and navigates.
-    if (this.patchPoison) {
-      this.shellFrames = "";
-      this.patchDeferred = undefined;
-      return '[{"' + PatchKey.Poison + '":1}]';
-    }
     const shellChunks = this.shellFrames && this.shellFrames.slice(1);
     this.shellFrames = "";
     if (this.patchDeferred) {

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -769,14 +769,9 @@ function writeRegistered(
     const n = (
       state.boundary.state as { bindDeposits?: Map<WeakKey, number> }
     ).bindDeposits?.get(val);
-    if (n) {
-      state.buf.push(BIND_DEPOSIT_FRAME_VAR + "(" + n + ")");
-    } else {
-      // No deposit (a container the render-time scan cannot reach): the
-      // frame poisons and its buffered access is never evaluated.
-      state.boundary.state.patchPoison = 1;
-      state.buf.push(registered.access);
-    }
+    // Deposit `0` is never written, so a registration the render-time scan
+    // could not reach rejects at the frame's commit check (navigation).
+    state.buf.push(BIND_DEPOSIT_FRAME_VAR + "(" + (n || 0) + ")");
   } else if (scope) {
     // Registered factories read their self-resolving scope only when invoked.
     const ref = new Reference(

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -238,7 +238,6 @@ export function _el_resume(
 export function writePatch(scopeId: number, entries: Record<string, unknown>) {
   const { state } = $chunk.boundary;
   if (state.patchFlushed) {
-    if (state.patchPoison) return;
     throw new Error(
       "A persisted patch cannot write after its frame flushed (async patch content is not supported).",
     );
@@ -1249,7 +1248,6 @@ export class State implements SerializeState {
   declare patchPending?: Record<number, [parentScopeId: number, key: string]>;
   declare patchFlushed?: 1;
   declare patchDeferred?: 1;
-  declare patchPoison?: 1;
   public writeReorders: Chunk[] | null = null;
   public scopes = new Map<number, ScopeInternals>();
   public flushScopes = false;


### PR DESCRIPTION
## Description

Deletes the last of the patch poison machinery: `PatchState.patchPoison`/`poisonSent`, the poison-tree `resumeScript` branch, the post-flush write softening, and `PatchKey.Poison`. The serializer's former backstop (a scope-bound registration in a container the render-time deposit scan cannot traverse) now emits a reference to deposit `0`, which is never written — the frame's existing commit check rejects it to navigation, and a page without the bind feature rejects at frame eval. Fail-closed behavior is preserved with zero dedicated machinery; `failPatch` is now the only rejection primitive.

New fixture `persisted-branch-iterable-fn-fill` landed as positive coverage: a registered function held only by a custom iterator still serializes live, because deposits share by value identity across the frame (its own write channel deposits it first).

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [x] I have added tests to cover my changes.