### PR TITLE
refactor(runtime-tags): fold bind deposits into the existing bind vocabulary

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko_0/mk",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko0": bind(1),
   "PatchWrite:input_title": "b"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko_0/mk",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-arrow-curried/template.marko0": bind(1),
   "PatchWrite:input_title": "c"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-fn-fill/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-fn-fill/__snapshots__/patches.debug.js
@@ -1,6 +1,6 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-fn-fill/template.marko_0/getTitle",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-fn-fill/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-fn-fill/template.marko0": bind(1),
   "PatchWrite:input_title": "b"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko_0/onChange",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko0": bind(1),
   "PatchWrite:input_prefix": "B"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko_0/onChange",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-ctrl-server-handler/template.marko0": bind(1),
   "PatchWrite:input_prefix": "C"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/__snapshots__/patches.debug.js
@@ -2,7 +2,7 @@
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/template.marko_0/api",
   "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/template.marko0": {
-    get: bindDeposit(1),
+    get: bind(1),
     label: "title"
   },
   "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/template.marko1": "title",

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-embedded-fn-fill/test.ts
@@ -5,8 +5,8 @@ const click = (document: Document) => {
 };
 
 // A root arrow over server input EMBEDDED in a composite value: the fill
-// ships the object as data with the function as a bind-deposit reference
-// (`_._.b(n)`), so calls after a patch read the live title.
+// ships the object as data with the function as a bind reference
+// (`bind(n)`), so calls after a patch read the live title.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ title: "a" }, click, { title: "b" }],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/__snapshots__/patches.debug.js
@@ -2,12 +2,12 @@
 {
   "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko0": {
     label: "b",
-    *[(_.a = [bindDeposit(1)], Symbol.iterator)]() {
+    *[(_.a = [bind(1)], Symbol.iterator)]() {
       yield* _.a
     }
   },
   "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko1": "b",
   "PatchWrite:input_title": "b",
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/template.marko_0/getTitle",
-  "PatchWrite:getTitle": bindDeposit(1)
+  "PatchWrite:getTitle": bind(1)
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
@@ -4,9 +4,9 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// A registered function inside a custom iterator the deposit scan cannot
-// traverse still serializes: its own write channel deposits it first, and
-// deposits share by value identity across the frame.
+// A registered function inside a custom iterator the bind scan cannot
+// traverse still serializes: its own write channel binds it first, and
+// binds share by value identity across the frame.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ title: "a" }, click, { title: "b" }],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko_0/handle",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko0": bind(1),
   "PatchWrite:input_prefix": "B"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko_0/handle",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-child-ctrl-server-handler/template.marko0": bind(1),
   "PatchWrite:input_prefix": "C"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/__snapshots__/patches.debug.js
@@ -1,9 +1,9 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko_0/fa",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko0": bind(1),
   "PatchBindSource:2": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko_0/fb",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko1": bindDeposit(2),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko1": bind(2),
   "PatchWrite:input_a": "2",
   "PatchWrite:input_b": "y"
 }
@@ -11,9 +11,9 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko_0/fa",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko0": bind(1),
   "PatchBindSource:2": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko_0/fb",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko1": bindDeposit(2),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-bound-pair/template.marko1": bind(2),
   "PatchWrite:input_a": "3",
   "PatchWrite:input_b": "z"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-embedded-fn/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-embedded-fn/__snapshots__/patches.debug.js
@@ -2,7 +2,7 @@
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-embedded-fn/template.marko_0/mk",
   "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-embedded-fn/template.marko0": {
-    get: bindDeposit(1)
+    get: bind(1)
   },
   "PatchWrite:input_title": "b"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko0": bind(1),
   "PatchWrite:input_title": "b"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-destructure/template.marko0": bind(1),
   "PatchWrite:input_title": "c"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko_0/up",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko0": bind(1),
   "PatchWrite:input_title": "b"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko_0/low",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/template.marko0": bind(1),
   "PatchWrite:input_title": "c"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/__snapshots__/patches.debug.js
@@ -1,7 +1,7 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko0": bind(1),
   "PatchWrite:input_a": "2",
   "PatchWrite:input_b": "y"
 }
@@ -9,7 +9,7 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-fill-multicap/template.marko0": bind(1),
   "PatchWrite:input_a": "3",
   "PatchWrite:input_b": "z"
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/__snapshots__/patches.debug.js
@@ -1,13 +1,13 @@
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko0": bind(1),
   "PatchWrite:input_title": "b"
 }
 
 // PATCH
 {
   "PatchBindSource:1": "packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko_0/fmt",
-  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko0": bindDeposit(1),
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-fn/template.marko0": bind(1),
   "PatchWrite:input_title": "c"
 }

--- a/packages/runtime-tags/src/common/constants/patch-key.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.ts
@@ -2,7 +2,7 @@
 // patch-only, so these never meet live scope accessor prefixes.
 export const Attr = "a";
 export const Bind = "d";
-// A bound registration resolved against its paired live scope, deposited
+// A bound registration resolved against its paired live scope, stored
 // in the frame's bind table for `_._.b(n)` references to resolve.
 export const BindSource = "h";
 export const Branch = "b";
@@ -22,7 +22,7 @@ export const Setup = "s";
 export const Text = "t";
 export const Value = "v";
 // A fill whose value is a rebound registration: the entry carries the
-// bind-table index its `BindSource` deposited.
+// bind-table index its `BindSource` stored.
 export const Write = "w";
 
 type Self = typeof import("./patch-key");

--- a/packages/runtime-tags/src/common/meta.ts
+++ b/packages/runtime-tags/src/common/meta.ts
@@ -7,5 +7,5 @@ export const DYNAMIC_TAG_SCRIPT_REGISTER_ID = MARKO_DEBUG
 
 export const DYNAMIC_TAG_VAR_REGISTER_ID = MARKO_DEBUG ? "_dynamicTagVar" : "e";
 
-// Frame-scoped var resolving a patch frame's bind-deposit references.
-export const BIND_DEPOSIT_FRAME_VAR = MARKO_DEBUG ? "bindDeposit" : "b";
+// Frame-scoped var resolving an index in the frame's bind table.
+export const BIND_FRAME_VAR = MARKO_DEBUG ? "bind" : "b";

--- a/packages/runtime-tags/src/dom/patch-value-bind.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-value-bind.feat.ts
@@ -1,13 +1,13 @@
 import "./patch-value.feat";
-import { BIND_DEPOSIT_FRAME_VAR } from "../common/meta";
+import { BIND_FRAME_VAR } from "../common/meta";
 import type { Scope } from "../common/types";
 import { PatchKey } from "../common/types";
 import { frameChecks, frameVars } from "./patch";
 import { failPatch, getRegisteredWithScope, patchers, patchId } from "./resume";
 
-// Per-frame bind deposits: a source entry re-binds its registration
+// The frame's bind table: a source entry re-binds its registration
 // against the paired live scope it anchors at, and bound fills reference
-// the deposit by index. Epoch-keyed so a lost source entry in a later
+// the bind by index. Epoch-keyed so a lost source entry in a later
 // frame can never read an earlier frame's handler.
 let frameBinds: Record<string, unknown> = {};
 let frameBindsPatch = 0;
@@ -25,26 +25,26 @@ patchers[PatchKey.BindSource] = (scope, key, id) => {
     ) => unknown
   )(scope);
 };
-// The frame's bind-deposit references: each wrapper resolves lazily (its
-// deposit walks in after the frame text evaluates), validated at commit.
-let expectedEmbedded: [deposits: Record<string, unknown>, n: number][] = [];
+// The frame's bind references: each wrapper resolves lazily (its bind
+// walks in after the frame text evaluates), validated at commit.
+let expectedEmbedded: [binds: Record<string, unknown>, n: number][] = [];
 let expectedEmbeddedPatch = 0;
 frameChecks.push(() => {
   const expected = expectedEmbedded;
   expectedEmbedded = [];
   if (expectedEmbeddedPatch === patchId) {
-    for (const [deposits, n] of expected) {
-      if (!(n in deposits)) failPatch();
+    for (const [frameBinds, n] of expected) {
+      if (!(n in frameBinds)) failPatch();
     }
   }
 });
-frameVars[BIND_DEPOSIT_FRAME_VAR] = (n: number) => {
-  const deposits = binds();
+frameVars[BIND_FRAME_VAR] = (n: number) => {
+  const frameBinds = binds();
   if (expectedEmbeddedPatch !== patchId) {
     expectedEmbeddedPatch = patchId;
     expectedEmbedded = [];
   }
-  expectedEmbedded.push([deposits, n]);
+  expectedEmbedded.push([frameBinds, n]);
   return (...args: unknown[]) =>
-    (deposits[n] as (...args: unknown[]) => unknown)(...args);
+    (frameBinds[n] as (...args: unknown[]) => unknown)(...args);
 };

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -108,7 +108,7 @@ let embedRenders:
 let readyIds: undefined | Set<string>;
 let patchRender: RenderData | 0 = 0;
 let patching: 0 | 1 = 0;
-// Frame epoch: per-frame tables (bind deposits) key off it so entries
+// Frame epoch: per-frame tables (the bind table) key off it so entries
 // from one frame can never satisfy a later frame's references.
 export let patchId = 0;
 

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -105,7 +105,7 @@ export function renderPatch(
 // source: a frame carries only patch fills.
 class PatchState extends State {
   public sentShells?: Set<string>;
-  public bindDeposits?: Map<WeakKey, number>;
+  public binds?: Map<WeakKey, number>;
   public shellFrames = "";
   override writesPatches = true;
   override shipShell(shellId: string | 0 | undefined) {
@@ -355,9 +355,9 @@ export function _patch_value(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    // Bound registrations cannot ride the wire as data: each deposits at
-    // its bound scope and the serialized value references the deposit.
-    depositEmbeddedBinds(state as PatchState, value);
+    // Bound registrations cannot ride the wire as data: each stores a
+    // bind at its bound scope and the serialized value references it.
+    writeEmbeddedBinds(state as PatchState, value);
     if (setup) {
       if (state.patchFlushed) {
         throw new Error(
@@ -392,7 +392,7 @@ export function _patch_control(
 ) {
   const state = getState();
   if (state.writesPatches && serverOwned(owned, group)) {
-    depositEmbeddedBinds(state as PatchState, value);
+    writeEmbeddedBinds(state as PatchState, value);
     writePatch(scopeId, { [PatchKey.Control + type + accessor]: value });
   }
   return "";
@@ -453,7 +453,7 @@ export function _patch_bind(
       // slot), while the setup entry lands after a construct's seeds — a
       // seed's first-render write resets the change slot, so apply-time
       // installs cannot last.
-      depositEmbeddedBinds(state as PatchState, value);
+      writeEmbeddedBinds(state as PatchState, value);
       const partial = patchPartial(state, scopeId);
       partial[PatchKey.Write + accessor] = value;
       if (isInResumedBranch()) {
@@ -476,7 +476,7 @@ export function _patch_write(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    depositEmbeddedBinds(state as PatchState, value);
+    writeEmbeddedBinds(state as PatchState, value);
     if (setup) {
       const partial = patchPartial(state, scopeId);
       ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
@@ -491,9 +491,9 @@ export function _patch_write(
   return "";
 }
 
-// Deposits each scope-bound registration in a patch value while the
+// Binds each scope-bound registration in a patch value while the
 // partial tree still accepts writes; the serialized slot references it.
-function depositEmbeddedBinds(
+function writeEmbeddedBinds(
   state: PatchState,
   value: unknown,
   seen?: Set<unknown>,
@@ -508,33 +508,29 @@ function depositEmbeddedBinds(
   const registered = getRegistered(value as WeakKey);
   const bound = registered && (registered.scope as ScopeInternals | undefined);
   if (bound) {
-    const deposits = (state.bindDeposits ??= new Map());
-    if (!deposits.has(value as WeakKey)) {
+    const binds = (state.binds ??= new Map());
+    if (!binds.has(value as WeakKey)) {
       const n = (state.patchBinds = (state.patchBinds || 0) + 1);
       writePatch(bound[K_SCOPE_ID]!, {
         [PatchKey.BindSource + n]: registered.id,
       });
-      deposits.set(value as WeakKey, n);
+      binds.set(value as WeakKey, n);
     }
     return;
   }
   (seen ??= new Set()).add(value);
   if (Array.isArray(value)) {
-    for (const item of value) depositEmbeddedBinds(state, item, seen);
+    for (const item of value) writeEmbeddedBinds(state, item, seen);
   } else if (value instanceof Map) {
     for (const [key, item] of value) {
-      depositEmbeddedBinds(state, key, seen);
-      depositEmbeddedBinds(state, item, seen);
+      writeEmbeddedBinds(state, key, seen);
+      writeEmbeddedBinds(state, item, seen);
     }
   } else if (value instanceof Set) {
-    for (const item of value) depositEmbeddedBinds(state, item, seen);
+    for (const item of value) writeEmbeddedBinds(state, item, seen);
   } else if (typeof value === "object") {
     for (const key in value) {
-      depositEmbeddedBinds(
-        state,
-        (value as Record<string, unknown>)[key],
-        seen,
-      );
+      writeEmbeddedBinds(state, (value as Record<string, unknown>)[key], seen);
     }
   }
 }

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1,4 +1,4 @@
-import { BIND_DEPOSIT_FRAME_VAR } from "../common/meta";
+import { BIND_FRAME_VAR } from "../common/meta";
 import * as Char from "./constants/char";
 import type { Boundary } from "./writer";
 
@@ -764,14 +764,14 @@ function writeRegistered(
 ) {
   const { scope } = registered;
   // Patch-render scope ids have no client-side map, so a bound
-  // registration references the deposit recorded at render time instead.
+  // registration references the bind recorded at render time instead.
   if (scope && state.boundary?.state?.writesPatches) {
     const n = (
-      state.boundary.state as { bindDeposits?: Map<WeakKey, number> }
-    ).bindDeposits?.get(val);
-    // Deposit `0` is never written, so a registration the render-time scan
+      state.boundary.state as { binds?: Map<WeakKey, number> }
+    ).binds?.get(val);
+    // Bind `0` is never written, so a registration the render-time scan
     // could not reach rejects at the frame's commit check (navigation).
-    state.buf.push(BIND_DEPOSIT_FRAME_VAR + "(" + (n || 0) + ")");
+    state.buf.push(BIND_FRAME_VAR + "(" + (n || 0) + ")");
   } else if (scope) {
     // Registered factories read their self-resolving scope only when invoked.
     const ref = new Reference(


### PR DESCRIPTION
## Description

Removes the "deposit" coinage from the embedded-bind machinery — the codebase already named this family "bind" (`BindSource`, `PatchKey.Bind`, `patchBinds`, `frameBinds`). The frame var is now `bind(n)` in debug wire (`BIND_FRAME_VAR`), the server map is `PatchState.binds`, the scan is `writeEmbeddedBinds` (joining the patch-writer verb family), and all comments say "bind table"/"bind". No behavior or optimized-wire change; debug frame snapshots regenerated.

## Checklist:

- [x] I have read the **CONTRIBUTING** document and have signed (or will sign) the CLA.
- [ ] I have updated/added documentation affected by my changes.
- [ ] I have added tests to cover my changes.