### PR TITLE
fix(runtime-tags): closure-only intersection renders after the derived value it feeds

### DIFF
--- a/.changeset/closure-intersection-order.md
+++ b/.changeset/closure-intersection-order.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a derived value computed only from closures inside a branch (`<if>`, `<for>`) rendering one update late when the same event also updated an input of the tag that consumes it.

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,88 @@
+// tags/child.marko
+const $template$2 = "<button> </button><a>x</a>";
+const $walks$2 = " D l b";
+const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$scope.input_onToggle();
+}));
+const $setup$2 = $setup__script;
+const $input_label = ($scope, input_label) => _text($scope["#text/1"], input_label);
+const $input$1 = ($scope, input) => {
+	_attr($scope["#a/2"], "href", input.hrefFor("x"));
+	$input_onToggle$1($scope, input.onToggle);
+	$input_label($scope, input.label);
+	$input_count$1($scope, input.count);
+};
+const $input_count$1 = ($scope, input_count) => _attr_class($scope["#a/2"], input_count % 2 ? "odd" : "even");
+const $input_onToggle$1 = /*@__PURE__*/ _const("input_onToggle");
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$2, $walks$2, $setup$2, $input$1);
+
+// tags/parent.marko
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label = /*@__PURE__*/ _or(3, ($scope) => $input$1($scope["#childScope/0"], {
+	label: $scope.label,
+	count: $scope._.input_count,
+	hrefFor: $scope._.hrefFor,
+	onToggle: $onToggle$1($scope)
+}), 4);
+const $if_content__input_count = /*@__PURE__*/ _if_closure("#text/0", 0, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__setup = ($scope) => {
+	$if_content__input_count._($scope);
+	$if_content__input_onToggle._($scope);
+	$if_content__prefix._($scope);
+	$if_content__shut._($scope);
+	$if_content__hrefFor._($scope);
+	$setup$2($scope["#childScope/0"]);
+};
+const $if_content__input_onToggle = /*@__PURE__*/ _if_closure("#text/0", 0, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__label = /*@__PURE__*/ _const("label", $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__prefix__OR__shut = /*@__PURE__*/ _or(1, ($scope) => $if_content__label($scope, $scope._.shut ? `${$scope._.prefix}:shut` : `${$scope._.prefix}:open`));
+const $if_content__prefix = /*@__PURE__*/ _if_closure("#text/0", 0, $if_content__prefix__OR__shut);
+const $if_content__shut = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => {
+	$if_content__prefix__OR__shut($scope);
+	$if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label($scope);
+});
+const $if_content__hrefFor = /*@__PURE__*/ _if_closure("#text/0", 0, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $prefix = /*@__PURE__*/ _const("prefix");
+const $shut = /*@__PURE__*/ _let("shut/6", $if_content__shut);
+const $hrefFor2 = /*@__PURE__*/ _const("hrefFor");
+const $if = /*@__PURE__*/ _if("#text/0", $template$2, /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$2), $if_content__setup);
+function $setup$1($scope) {
+	$prefix($scope, "a");
+	$shut($scope, false);
+	$hrefFor2($scope, $hrefFor);
+	$if($scope, true ? 0 : 1);
+}
+const $input = ($scope, input) => {
+	$input_count($scope, input.count);
+	$input_onToggle($scope, input.onToggle);
+};
+const $input_count = /*@__PURE__*/ _const("input_count", $if_content__input_count);
+const $input_onToggle = /*@__PURE__*/ _const("input_onToggle", $if_content__input_onToggle);
+const $onToggle$1 = ($scope) => function() {
+	$shut($scope._, !$scope._.shut);
+	$scope._.input_onToggle();
+};
+function $hrefFor(key) {
+	return `#${key}`;
+}
+_resume("__tests__/tags/parent.marko_1/onToggle", $onToggle$1);
+_resume("__tests__/tags/parent.marko_0/hrefFor", $hrefFor);
+var parent_default = /*@__PURE__*/ _template("__tests__/tags/parent.marko", $template$1, "b%c", $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $count = /*@__PURE__*/ _let("count/1", ($scope) => {
+	$input_count($scope["#childScope/0"], $scope.count);
+	$input_onToggle($scope["#childScope/0"], $onToggle($scope));
+});
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$count($scope, 0);
+}
+const $onToggle = ($scope) => function() {
+	$count($scope, +$scope.count + 1);
+};
+_resume("__tests__/template.marko_0/onToggle", $onToggle);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/dom.bundle.js
@@ -1,0 +1,51 @@
+// tags/child.marko
+const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$scope.f();
+}));
+const $input_label = ($scope, input_label) => _text($scope.b, input_label);
+const $input = ($scope, input) => {
+	_attr($scope.c, "href", input.hrefFor("x"));
+	$input_onToggle$1($scope, input.onToggle);
+	$input_label($scope, input.label);
+	$input_count$1($scope, input.count);
+};
+const $input_count$1 = ($scope, input_count) => _attr_class($scope.c, input_count % 2 ? "odd" : "even");
+const $input_onToggle$1 = /*@__PURE__*/ _const(5);
+
+// tags/parent.marko
+const $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label = /*@__PURE__*/ _or(3, ($scope) => $input($scope.a, {
+	label: $scope.c,
+	count: $scope._.d,
+	hrefFor: $scope._.h,
+	onToggle: $onToggle$1($scope)
+}), 4);
+const $if_content__input_count = /*@__PURE__*/ _if_closure(0, 0, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__input_onToggle = /*@__PURE__*/ _if_closure(0, 0, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__label = /*@__PURE__*/ _const(2, $if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label);
+const $if_content__prefix__OR__shut = /*@__PURE__*/ _or(1, ($scope) => $if_content__label($scope, $scope._.g ? `${$scope._.f}:shut` : `${$scope._.f}:open`));
+const $if_content__shut = /*@__PURE__*/ _if_closure(0, 0, ($scope) => {
+	$if_content__prefix__OR__shut($scope);
+	$if_content__input_count__OR__input_onToggle__OR__shut__OR__hrefFor__OR__label($scope);
+});
+const $shut = /*@__PURE__*/ _let(6, $if_content__shut);
+const $input_count = /*@__PURE__*/ _const(3, $if_content__input_count);
+const $input_onToggle = /*@__PURE__*/ _const(4, $if_content__input_onToggle);
+const $onToggle$1 = ($scope) => function() {
+	$shut($scope._, !$scope._.g);
+	$scope._.e();
+};
+function $hrefFor(key) {
+	return `#${key}`;
+}
+_resume("c1", $onToggle$1);
+_resume("c0", $hrefFor);
+
+// template.marko
+const $count = /*@__PURE__*/ _let(1, ($scope) => {
+	$input_count($scope.a, $scope.b);
+	$input_onToggle($scope.a, $onToggle($scope));
+});
+const $onToggle = ($scope) => function() {
+	$count($scope, +$scope.b + 1);
+};
+_resume("a0", $onToggle);

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,74 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<button>${_escape(input.label)}${_el_resume($scope0_id, "#text/1", _serialize_guard($scope0_reason, 1))}</button>${_el_resume($scope0_id, "#button/0")}<a${_attr("href", input.hrefFor("x"))} class=${input.count % 2 ? "odd" : "even"}>x</a>${_el_resume($scope0_id, "#a/2", _serialize_guard($scope0_reason, 0))}`);
+	_script($scope0_id, "__tests__/tags/child.marko_0");
+	writeScope($scope0_id, { input_onToggle: input.onToggle }, "__tests__/tags/child.marko", 0, { input_onToggle: ["input.onToggle"] });
+});
+
+// tags/parent.marko
+var parent_default = _template("__tests__/tags/parent.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const prefix = "a";
+	let shut = false;
+	const hrefFor = _resume((key) => `#${key}`, "__tests__/tags/parent.marko_0/hrefFor");
+	_if(() => {
+		if (true) {
+			const $scope1_id = _scope_id();
+			const label = shut ? `${prefix}:shut` : `${prefix}:open`;
+			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
+			child_default({
+				label,
+				count: input.count,
+				hrefFor,
+				onToggle: _resume(function() {
+					shut = !shut;
+					input.onToggle();
+				}, "__tests__/tags/parent.marko_1/onToggle", $scope1_id)
+			});
+			writeScope($scope1_id, {
+				label: _serialize_if($scope0_reason, 0) && label,
+				_: _scope_with_id($scope0_id),
+				"#childScope/0": _existing_scope($childScope)
+			}, "__tests__/tags/parent.marko", "12:2", { label: "13:10" });
+			return 0;
+		}
+	}, $scope0_id, "#text/0", 1, 0, 0);
+	writeScope($scope0_id, {
+		input_count: input.count,
+		input_onToggle: input.onToggle,
+		prefix,
+		shut,
+		hrefFor
+	}, "__tests__/tags/parent.marko", 0, {
+		input_count: ["input.count"],
+		input_onToggle: ["input.onToggle"],
+		prefix: "9:8",
+		shut: "10:6",
+		hrefFor: "11:8"
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	parent_default({
+		count,
+		onToggle: _resume(function() {
+			count++;
+		}, "__tests__/template.marko_0/onToggle", $scope0_id)
+	});
+	writeScope($scope0_id, {
+		count,
+		"#childScope/0": _existing_scope($childScope)
+	}, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.js
@@ -1,0 +1,68 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<button>${_escape(input.label)}${_el_resume($scope0_id, "b", _serialize_guard($scope0_reason, 1))}</button>${_el_resume($scope0_id, "a")}<a${_attr("href", input.hrefFor("x"))} class=${input.count % 2 ? "odd" : "even"}>x</a>${_el_resume($scope0_id, "c", _serialize_guard($scope0_reason, 0))}`);
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, { f: input.onToggle });
+});
+
+// tags/parent.marko
+var parent_default = _template("c", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	const prefix = "a";
+	let shut = false;
+	const hrefFor = _resume((key) => `#${key}`, "c0");
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			const label = shut ? `${prefix}:shut` : `${prefix}:open`;
+			_set_serialize_reason(1);
+			const $childScope = _peek_scope_id();
+			child_default({
+				label,
+				count: input.count,
+				hrefFor,
+				onToggle: _resume(function() {
+					shut = !shut;
+					input.onToggle();
+				}, "c1", $scope1_id)
+			});
+			writeScope($scope1_id, {
+				c: _serialize_if($scope0_reason, 0) && label,
+				_: _scope_with_id($scope0_id),
+				a: _existing_scope($childScope)
+			});
+			return 0;
+		}
+	}, $scope0_id, "a", 1, 0, 0);
+	writeScope($scope0_id, {
+		d: input.count,
+		e: input.onToggle,
+		f: prefix,
+		g: shut,
+		h: hrefFor
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_set_serialize_reason(1);
+	const $childScope = _peek_scope_id();
+	parent_default({
+		count,
+		onToggle: _resume(function() {
+			count++;
+		}, "a0", $scope0_id)
+	});
+	writeScope($scope0_id, {
+		b: count,
+		a: _existing_scope($childScope)
+	});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/render.debug.md
@@ -1,0 +1,75 @@
+# Render
+```html
+<button>
+  a:open
+</button>
+<a
+  class="even"
+  href="#x"
+>
+  x
+</a>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:shut
+</button>
+<a
+  class="odd"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:open" => "a:shut"
+UPDATE: .odd[class] "even" => "odd"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:open
+</button>
+<a
+  class="even"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:shut" => "a:open"
+UPDATE: .even[class] "odd" => "even"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:shut
+</button>
+<a
+  class="odd"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:open" => "a:shut"
+UPDATE: .odd[class] "even" => "odd"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/render.md
@@ -1,0 +1,75 @@
+# Render
+```html
+<button>
+  a:open
+</button>
+<a
+  class="even"
+  href="#x"
+>
+  x
+</a>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:shut
+</button>
+<a
+  class="odd"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:open" => "a:shut"
+UPDATE: .odd[class] "even" => "odd"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:open
+</button>
+<a
+  class="even"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:shut" => "a:open"
+UPDATE: .even[class] "odd" => "even"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a:shut
+</button>
+<a
+  class="odd"
+  href="#x"
+>
+  x
+</a>
+```
+## Change
+```
+UPDATE: button::text "a:open" => "a:shut"
+UPDATE: .odd[class] "even" => "odd"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/writes.debug.html
@@ -1,0 +1,31 @@
+<button>a:open<!--M_*4 #text/1--></button><!--M_*4 #button/0--><a href=#x
+  class=even>x</a><!--M_*4 #a/2-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0,
+      "#childScope/0": _(2)
+    }, {
+      "BranchScopes:#text/0": _(3),
+      input_count: 0,
+      input_onToggle: _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/template.marko_0/onToggle"
+        ),
+      prefix: "a",
+      shut: !1,
+      hrefFor: _._[
+        "packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/parent.marko_0/hrefFor"
+        ]
+    }, {
+      label: "a:open",
+      _: _(2),
+      "#childScope/0": _(4)
+    }, {
+      input_onToggle: _(3,
+        "packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/parent.marko_1/onToggle"
+        )
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/child.marko_0 4"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/writes.html
@@ -1,0 +1,23 @@
+<button>a:open<!--M_*4 b--></button><!--M_*4 a--><a href=#x
+  class=even>x</a><!--M_*4 c-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    b: 0,
+    a: _(2)
+  }, {
+    Aa: _(3),
+    d: 0,
+    e: _(1, "a0"),
+    f: "a",
+    g: !1,
+    h: _._.c0
+  }, {
+    c: "a:open",
+    _: _(2),
+    a: _(4)
+  }, {
+    f: _(3, "c1")
+  }], "b0 4"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3848,
+        "brotli": 1877
+      },
+      "files": {
+        "tags/child.marko": 578,
+        "tags/parent.marko": 1468,
+        "template.marko": 279
+      }
+    }
+  },
+  "html": {
+    "min": 491,
+    "brotli": 331
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/child.marko
@@ -1,0 +1,8 @@
+export interface Input {
+  label: string;
+  count: number;
+  hrefFor: (key: string) => string;
+  onToggle: () => void;
+}
+<button onClick() { input.onToggle() }>${input.label}</button>
+<a href=input.hrefFor("x") class=(input.count % 2 ? "odd" : "even")>x</a>

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/parent.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/tags/parent.marko
@@ -1,0 +1,23 @@
+export interface Input {
+  count: number;
+  onToggle: () => void;
+}
+
+// `label` is derived only from closures of the outer scope (`shut`,
+// `prefix`); the click flips `shut` and, through the parent, `count` in
+// the same event.
+<const/prefix="a">
+<let/shut=false>
+<const/hrefFor=(key: string) => `#${key}`>
+<if=true>
+  <const/label=(shut ? `${prefix}:shut` : `${prefix}:open`)>
+  <child
+    label=label
+    count=input.count
+    hrefFor=hrefFor
+    onToggle() {
+      shut = !shut;
+      input.onToggle();
+    }
+  />
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/template.marko
@@ -1,0 +1,2 @@
+<let/count=0/>
+<parent count=count onToggle() { count++ }/>

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1396,15 +1396,17 @@ export function finalizeReferences() {
         }
       }
 
+      // Renders run in id order, so a closure-only intersection must come
+      // before the owned derived binding it may feed.
       intersections.sort((a, b) => {
         const aAnchor = sectionAnchors.get(a);
         const bAnchor = sectionAnchors.get(b);
         return aAnchor
           ? bAnchor
             ? bindingUtil.compare(aAnchor, bAnchor)
-            : -1
+            : 1
           : bAnchor
-            ? 1
+            ? -1
             : 0;
       });
     }
@@ -1413,6 +1415,20 @@ export function finalizeReferences() {
     let nextId = 0;
     let intersection: Intersection;
     forEach(ownedBindings, (binding) => {
+      // Dom ids are the walker's dense indexes; unanchored intersections
+      // slot in right after them, ahead of every other owned binding.
+      if (binding.type !== BindingType.dom) {
+        while (
+          intersectionIndex < intersections.length &&
+          !anchors!.get((intersection = intersections[intersectionIndex]))
+        ) {
+          intersectionIndex++;
+          intersectionMeta.set(intersection, {
+            id: nextId++,
+            scopeOffset: getMaxOwnSourceOffset(intersection, section),
+          });
+        }
+      }
       binding.id = nextId++;
       // Reserved ids follow the binding's own; dom bindings never reserve
       // since their ids are the walker's dense indexes.


### PR DESCRIPTION
In a branch section, an intersection made only of closures (e.g. `<const/label=(shut ? … : …)>` under `<if>`, with `shut` from the outer scope) got its signal id after every owned binding, so when the same event also changed a tag input consuming `label`, the tag-input render ran first with the stale value and the recomputed value's re-trigger was deduped away — the child showed each click one update late.

Unanchored intersections now take ids right after the dom bindings, ahead of the owned bindings they may feed. Fixture: `derived-from-closures-updates-tag-input`.