### PR TITLE
feat(runtime-tags): admit static scriptlets and option value/selected in persisted templates

### DIFF
--- a/agent-feedback/bugs.md
+++ b/agent-feedback/bugs.md
@@ -2,6 +2,12 @@
 
 Out-of-scope defects noticed while working on something else. Format and rules: [README.md](README.md).
 
+## A resumed unescaped placeholder updates only its last node
+
+`packages/runtime-tags/src/dom/dom.ts` › `_html` with `packages/runtime-tags/src/translator/visitors/placeholder.ts` (html output for `$!{}`) | 2026-08-17 | impact:med | effort:med
+
+`_html(scope, value, accessor)` treats `scope[accessor]` as the range's first node and `DynamicHTMLLastChild` (unset on resume) as its last, but the SSR marker (`_el_resume` after the content) resumes only the node preceding it — the LAST node of a multi-node value. So `<let/v="Hello <strong>World</strong>"/><main>$!{v}</main>` with a handler assigning `"<i>a</i> and <b>b</b>"` leaves `Hello ` behind on a resumed page (`INSERT … REMOVE: main > b + strong` — CSR removes both). Fix by resuming the range's first node (a leading separator marker, or serializing the last-child accessor) so `_html` replaces the whole range. Persisted `$!{}` admission (`admission.ts` `MarkoPlaceholder` `!node.escape`) is parked on this. Re-verify with the template above as an ssr fixture with a click step.
+
 ## Wrap reordered out-of-order content in a parser-context-legal container
 
 `packages/runtime-tags/src/html/writer.ts` › `Chunk.flushScript` | 2026-07-23 | impact:high | effort:high

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,30 @@
+// template.marko
+const $template = "<main><select></select><select id=plain><option value=a>A</option><option value=b>B</option></select><em> </em><button>+</button></main>";
+const $walks = "D bD b lD l l";
+const $for_content__o_value = ($scope, o_value) => _attr($scope["#option/0"], "value", o_value);
+const $for_content__o_label = ($scope, o_label) => _text($scope["#text/1"], o_label);
+const $for_content__$params = ($scope, $params2) => {
+	$for_content__o_value($scope, $params2[0]?.value);
+	$for_content__o_label($scope, $params2[0]?.label);
+};
+const $count = /*@__PURE__*/ _let("count/10", ($scope) => _text($scope["#text/3"], $scope.count));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/4"], "click", function() {
+	$count($scope, +$scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_picked = /*@__PURE__*/ _const("input_picked", ($scope) => _attr_select_value_default($scope, "#select/0", $scope.input_picked));
+const $for = /*@__PURE__*/ _for_of("#select/0", "<option> </option>", " D ", 0, $for_content__$params);
+const $input_options = ($scope, input_options) => $for($scope, [input_options, (o) => o.id]);
+const $input_pick = ($scope, input_pick) => {
+	_attr($scope["#option/1"], "selected", input_pick === "a");
+	_attr($scope["#option/2"], "selected", input_pick === "b");
+};
+const $input = ($scope, input) => {
+	$input_picked($scope, input.picked);
+	$input_options($scope, input.options);
+	$input_pick($scope, input.pick);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $count = /*@__PURE__*/ _let(10, ($scope) => _text($scope.d, $scope.k));
+const $setup__script = _script("a1", ($scope) => _on($scope.e, "click", function() {
+	$count($scope, +$scope.k + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,21 @@
+// template.marko
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell; D ;<option> </option>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html("<main>");
+	_attr_select_value($scope0_id, "#select/0", input.picked, void 0, () => {
+		_html(`<select${_patch_control($scope0_id, "#select/0", 3, input.picked, $scope0_owned, 0)}>`);
+		_for_of(input.options, (o) => {
+			const $scope1_id = _scope_id();
+			_html(`<option${_patch_attr_option_value($scope1_id, "#option/0", o.value, $scope0_owned, 1)}>${_patch_text($scope1_id, "#text/1", o.label, $scope0_owned, 1)}${_el_resume($scope1_id, "#text/1")}</option>${_el_resume($scope1_id, "#option/0")}`);
+			writeScope($scope1_id, {}, "__tests__/template.marko", "4:6");
+		}, (o) => o.id, $scope0_id, "#select/0", 1, 1, _source_guard($scope0_reason, 1), void 0, void 0, "__tests__/template.marko_1*shell");
+		_html("</select>");
+	});
+	_html(`${_el_resume($scope0_id, "#select/0")}<select id=plain><option${_attr_option_value("a")}${_patch_attr($scope0_id, "#option/1", "selected", input.pick === "a", $scope0_owned, 2)}>A</option>${_el_resume($scope0_id, "#option/1")}<option${_attr_option_value("b")}${_patch_attr($scope0_id, "#option/2", "selected", input.pick === "b", $scope0_owned, 2)}>B</option>${_el_resume($scope0_id, "#option/2")}</select><em>${_escape(count)}${_el_resume($scope0_id, "#text/3")}</em><button>+</button>${_el_resume($scope0_id, "#button/4")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && writeScope($scope0_id, { count }, "__tests__/template.marko", 0, { count: "1:6" });
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/html.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+_shells({ a0: ",`a0; D ;<option> </option>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html("<main>");
+	_attr_select_value($scope0_id, "a", input.picked, void 0, () => {
+		_html(`<select${_patch_control($scope0_id, "a", 3, input.picked, $scope0_owned, 0)}>`);
+		_for_of(input.options, (o) => {
+			const $scope1_id = _scope_id();
+			_html(`<option${_patch_attr_option_value($scope1_id, "a", o.value, $scope0_owned, 1)}>${_patch_text($scope1_id, "b", o.label, $scope0_owned, 1)}${_el_resume($scope1_id, "b")}</option>${_el_resume($scope1_id, "a")}`);
+			writeScope($scope1_id, {});
+		}, (o) => o.id, $scope0_id, "a", 1, 1, _source_guard($scope0_reason, 1), void 0, void 0, "a0");
+		_html("</select>");
+	});
+	_html(`${_el_resume($scope0_id, "a")}<select id=plain><option${_attr_option_value("a")}${_patch_attr($scope0_id, "b", "selected", input.pick === "a", $scope0_owned, 2)}>A</option>${_el_resume($scope0_id, "b")}<option${_attr_option_value("b")}${_patch_attr($scope0_id, "c", "selected", input.pick === "b", $scope0_owned, 2)}>B</option>${_el_resume($scope0_id, "c")}</select><em>${_escape(count)}${_el_resume($scope0_id, "d")}</em><button>+</button>${_el_resume($scope0_id, "e")}</main>`);
+	_script($scope0_id, "a1");
+	$scope0_reason && writeScope($scope0_id, { k: count });
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/patches.debug.js
@@ -1,0 +1,13 @@
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/template.marko_1*shell; D ;<option> </option>`, {
+  "PatchControl:3#select/0": "z",
+  "PatchLoop:#select/0": [1, {
+    "PatchAttr:#option/0 value": "x",
+    "PatchText:#text/1": "X"
+  }, 2, {
+    "PatchAttr:#option/0 value": "z",
+    "PatchText:#text/1": "Z"
+  }, "packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/template.marko_1*shell"],
+  "PatchAttr:#option/1 selected": 0,
+  "PatchAttr:#option/2 selected": ""
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/patches.js
@@ -1,0 +1,13 @@
+// PATCH
+[`a0; D ;<option> </option>`, {
+  n3a: "z",
+  la: [1, {
+    "aa value": "x",
+    tb: "X"
+  }, 2, {
+    "aa value": "z",
+    tb: "Z"
+  }, "a0"],
+  "ab selected": 0,
+  "ac selected": ""
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/render.debug.md
@@ -1,0 +1,185 @@
+# Render `{"picked":"x","pick":"a","options":[{"id":1,"value":"x","label":"X"},{"id":2,"value":"y","label":"Y"}]}`
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      value="y"
+    >
+      Y
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      selected=""
+      value="a"
+    >
+      A
+    </option>
+    <option
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    0
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      value="y"
+    >
+      Y
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      selected=""
+      value="a"
+    >
+      A
+    </option>
+    <option
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    1
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "0" => "1"
+```
+
+# Update `{"picked":"z","pick":"b","options":[{"id":1,"value":"x","label":"X"},{"id":2,"value":"z","label":"Z"}]}`
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      default-selected=""
+      value="z"
+    >
+      Z
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      value="a"
+    >
+      A
+    </option>
+    <option
+      selected=""
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    1
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(1)::text "X" => "X"
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)[value] "y" => "z"
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)::text "Y" => "Z"
+UPDATE: #plain > option:nth-of-type(1)[selected] "" => null
+UPDATE: #plain > option:nth-of-type(2)[selected] null => ""
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(1)[selected] "" => null
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)[selected] null => ""
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      default-selected=""
+      value="z"
+    >
+      Z
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      value="a"
+    >
+      A
+    </option>
+    <option
+      selected=""
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    2
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/render.md
@@ -1,0 +1,185 @@
+# Render `{"picked":"x","pick":"a","options":[{"id":1,"value":"x","label":"X"},{"id":2,"value":"y","label":"Y"}]}`
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      value="y"
+    >
+      Y
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      selected=""
+      value="a"
+    >
+      A
+    </option>
+    <option
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    0
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      value="y"
+    >
+      Y
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      selected=""
+      value="a"
+    >
+      A
+    </option>
+    <option
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    1
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "0" => "1"
+```
+
+# Update `{"picked":"z","pick":"b","options":[{"id":1,"value":"x","label":"X"},{"id":2,"value":"z","label":"Z"}]}`
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      default-selected=""
+      value="z"
+    >
+      Z
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      value="a"
+    >
+      A
+    </option>
+    <option
+      selected=""
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    1
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(1)::text "X" => "X"
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)[value] "y" => "z"
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)::text "Y" => "Z"
+UPDATE: #plain > option:nth-of-type(1)[selected] "" => null
+UPDATE: #plain > option:nth-of-type(2)[selected] null => ""
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(1)[selected] "" => null
+UPDATE: main > select:nth-of-type(1) > option:nth-of-type(2)[selected] null => ""
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main>
+  <select>
+    <option
+      selected=""
+      value="x"
+    >
+      X
+    </option>
+    <option
+      default-selected=""
+      value="z"
+    >
+      Z
+    </option>
+  </select>
+  <select
+    id="plain"
+  >
+    <option
+      value="a"
+    >
+      A
+    </option>
+    <option
+      selected=""
+      value="b"
+    >
+      B
+    </option>
+  </select>
+  <em>
+    2
+  </em>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > em::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/writes.debug.html
@@ -1,0 +1,23 @@
+<main><select><!--M_[-->
+    <option value=x selected>X<!--M_*2 #text/1--></option>
+    <!--M_*2 #option/0--><!--M_[2-->
+    <option value=y>Y<!--M_*3 #text/1--></option>
+    <!--M_*3 #option/0--><!--M_]1 #select/0 3-->
+  </select><!--M_*1 #select/0--><select id=plain>
+    <option value=a selected>A</option><!--M_*1 #option/1-->
+    <option value=b>B</option><!--M_*1 #option/2-->
+  </select><em>0<!--M_*1 #text/3--></em><button>+</button><!--M_*1 #button/4-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      count: 0
+    }, {
+      "#LoopKey": 1
+    }, {
+      "#LoopKey": 2
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/__snapshots__/writes.html
@@ -1,0 +1,18 @@
+<main><select><!--M_[-->
+    <option value=x selected>X<!--M_*2 b--></option><!--M_*2 a--><!--M_[2-->
+    <option value=y>Y<!--M_*3 b--></option><!--M_*3 a--><!--M_]1 a 3-->
+  </select><!--M_*1 a--><select id=plain>
+    <option value=a selected>A</option><!--M_*1 b-->
+    <option value=b>B</option><!--M_*1 c-->
+  </select><em>0<!--M_*1 d--></em><button>+</button><!--M_*1 e--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    k: 0
+  }, {
+    M: 1
+  }, {
+    M: 2
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 10510,
+      "brotli": 4646
+    }
+  },
+  "html": {
+    "min": 679,
+    "brotli": 351
+  },
+  "patch": {
+    "min": 135,
+    "brotli": 95
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/template.marko
@@ -1,0 +1,14 @@
+<let/count=0/>
+<main>
+  <select value=input.picked>
+    <for|o| of=input.options by=(o) => o.id>
+      <option value=o.value>${o.label}</option>
+    </for>
+  </select>
+  <select id="plain">
+    <option value="a" selected=(input.pick === "a")>A</option>
+    <option value="b" selected=(input.pick === "b")>B</option>
+  </select>
+  <em>${count}</em>
+  <button onClick() { count++ }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/test.ts
@@ -1,0 +1,31 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// Option `value`/`selected` patch like any attribute; a select's controlled
+// value re-syncs its options after the frame's writes land, as a render does.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    {
+      picked: "x",
+      pick: "a",
+      options: [
+        { id: 1, value: "x", label: "X" },
+        { id: 2, value: "y", label: "Y" },
+      ],
+    },
+    click,
+    {
+      picked: "z",
+      pick: "b",
+      options: [
+        { id: 1, value: "x", label: "X" },
+        { id: 2, value: "z", label: "Z" },
+      ],
+    },
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,34 @@
+// template.marko
+const $template = "<main><p><!> <!></p><!><button>+</button></main>";
+const $walks = "E%c%l%b l";
+const shout = (s) => s.toUpperCase() + "!";
+var stamp;
+const flag = "cli";
+const $if_content__input_title__OR__count = /*@__PURE__*/ _fill_join_if("__tests__/template.marko0", "input_title", /*@__PURE__*/ _init_join("__tests__/template.marko_1_input_title#6/init", /*@__PURE__*/ _or(1, ($scope) => _text($scope["#text/0"], shout($scope._.input_title) + " #" + $scope._.count))), "#text/2", 0);
+const $if_content__input_title = /*@__PURE__*/ _if_closure("#text/2", 0, $if_content__input_title__OR__count);
+const $if_content__setup = ($scope) => {
+	$if_content__input_title._($scope);
+	$if_content__count._($scope);
+};
+const $if_content__count = /*@__PURE__*/ _init_if_closure("__tests__/template.marko_1_count#8/init", "#text/2", 0, $if_content__input_title__OR__count);
+const $count = /*@__PURE__*/ _let("count/8", $if_content__count);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/3"], "click", function() {
+	$count($scope, +$scope.count + 1);
+	document.querySelector("main").dataset.flag = flag;
+}));
+function $setup($scope) {
+	_text($scope["#text/1"], stamp);
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_title = /*@__PURE__*/ _fill_const("__tests__/template.marko0", "input_title", ($scope) => {
+	_text($scope["#text/0"], shout($scope.input_title));
+	$if_content__input_title($scope);
+});
+const $if = /*@__PURE__*/ _if("#text/2", "<span> </span>", "D ", $if_content__setup);
+const $input_show = ($scope, input_show) => $if($scope, input_show ? 0 : 1);
+const $input = ($scope, input) => {
+	$input_title($scope, input.title);
+	$input_show($scope, input.show);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const shout = (s) => s.toUpperCase() + "!";
+const flag = "cli";
+const $if_content__input_title__OR__count = /*@__PURE__*/ _fill_join_if("a0", 6, /*@__PURE__*/ _init_join("a3", /*@__PURE__*/ _or(1, ($scope) => _text($scope.a, shout($scope._.g) + " #" + $scope._.i))), 2, 0);
+const $if_content__count = /*@__PURE__*/ _init_if_closure("a4", 2, 0, $if_content__input_title__OR__count);
+const $count = /*@__PURE__*/ _let(8, $if_content__count);
+const $setup__script = _script("a1", ($scope) => _on($scope.d, "click", function() {
+	$count($scope, +$scope.i + 1);
+	document.querySelector("main").dataset.flag = flag;
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,29 @@
+// template.marko
+const shout = (s) => s.toUpperCase() + "!";
+const stamp = "srv";
+var flag;
+_shells({ "__tests__/template.marko_1*shell": ",`__tests__/template.marko_1*shell __tests__/template.marko_1_input_title#6/init __tests__/template.marko_1_count#8/init;D ;<span> </span>`" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><p>${_patch_text($scope0_id, "#text/0", shout(input.title), $scope0_owned, 0)}${_el_resume($scope0_id, "#text/0")} <!>${_patch_text($scope0_id, "#text/1", stamp)}${_el_resume($scope0_id, "#text/1")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html(`<span>${_escape(shout(input.title) + " #" + count)}${_el_resume($scope1_id, "#text/0")}</span>`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "7:4");
+			return 0;
+		}
+	}, $scope0_id, "#text/2", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1*shell"]);
+	_html(`<button>+</button>${_el_resume($scope0_id, "#button/3")}</main>`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason ? writeScope($scope0_id, {
+		input_title: input.title,
+		count
+	}, "__tests__/template.marko", 0, {
+		input_title: ["input.title"],
+		count: "4:6"
+	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "__tests__/template.marko0", input.title);
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/html.bundle.js
@@ -1,0 +1,25 @@
+// template.marko
+const shout = (s) => s.toUpperCase() + "!";
+const stamp = "srv";
+_shells({ a0: ",`a0 a3 a4;D ;<span> </span>`" });
+var template_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<main><p>${_patch_text($scope0_id, "a", shout(input.title), $scope0_owned, 0)}${_el_resume($scope0_id, "a")} <!>${_patch_text($scope0_id, "b", stamp)}${_el_resume($scope0_id, "b")}</p>`);
+	_if(() => {
+		if (input.show) {
+			const $scope1_id = _scope_id();
+			_html(`<span>${_escape(shout(input.title) + " #0")}${_el_resume($scope1_id, "a")}</span>`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+			return 0;
+		}
+	}, $scope0_id, "c", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["a0"]);
+	_html(`<button>+</button>${_el_resume($scope0_id, "d")}</main>`);
+	_script($scope0_id, "a1");
+	$scope0_reason ? writeScope($scope0_id, {
+		g: input.title,
+		i: count
+	}) : _owned_guard($scope0_owned, 0) && _patch_value($scope0_id, "a0", input.title);
+	_resume_branch($scope0_id);
+}, 1, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/patches.debug.js
@@ -1,0 +1,7 @@
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko_1*shell packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko_1_input_title#6/init packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko_1_count#8/init;D ;<span> </span>`, {
+  "PatchText:#text/0": "YO!",
+  "PatchText:#text/1": "srv",
+  "PatchBranch:#text/2": "packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko_1*shell",
+  "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko0": "yo"
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/patches.js
@@ -1,0 +1,7 @@
+// PATCH
+[`a0 a3 a4;D ;<span> </span>`, {
+  ta: "YO!",
+  tb: "srv",
+  bc: "a0",
+  va0: "yo"
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/render.debug.md
@@ -1,0 +1,81 @@
+# Render `{"title":"hi","show":false}`
+```html
+<main>
+  <p>
+    HI! srv
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    HI! srv
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-flag] null => "cli"
+```
+
+# Update `{"title":"yo","show":true}`
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    YO! srv
+  </p>
+  <span>
+    YO! #1
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@0 "HI!" => "YO!"
+UPDATE: main > p::text@4 "srv" => "srv"
+INSERT: main > p + span
+UPDATE: main > span::text " " => "YO! #1"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    YO! srv
+  </p>
+  <span>
+    YO! #2
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-flag] "cli" => "cli"
+UPDATE: main > span::text "YO! #1" => "YO! #2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/render.md
@@ -1,0 +1,81 @@
+# Render `{"title":"hi","show":false}`
+```html
+<main>
+  <p>
+    HI! srv
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    HI! srv
+  </p>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-flag] null => "cli"
+```
+
+# Update `{"title":"yo","show":true}`
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    YO! srv
+  </p>
+  <span>
+    YO! #1
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main > p::text@0 "HI!" => "YO!"
+UPDATE: main > p::text@4 "srv" => "srv"
+INSERT: main > p + span
+UPDATE: main > span::text " " => "YO! #1"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<main
+  data-flag="cli"
+>
+  <p>
+    YO! srv
+  </p>
+  <span>
+    YO! #2
+  </span>
+  <button>
+    +
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: main[data-flag] "cli" => "cli"
+UPDATE: main > span::text "YO! #1" => "YO! #2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<main>
+  <p>HI!<!--M_*1 #text/0-->
+    <!>srv<!--M_*1 #text/1-->
+  </p><!--M_]1 #text/2--><button>+</button><!--M_*1 #button/3-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      input_title: "hi",
+      count: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/__snapshots__/writes.html
@@ -1,0 +1,13 @@
+<main>
+  <p>HI!<!--M_*1 a-->
+    <!>srv<!--M_*1 b-->
+  </p><!--M_]1 c--><button>+</button><!--M_*1 d-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    g: "hi",
+    i: 0
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
@@ -1,0 +1,16 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 8510,
+      "brotli": 3782
+    }
+  },
+  "html": {
+    "min": 415,
+    "brotli": 277
+  },
+  "patch": {
+    "min": 68,
+    "brotli": 72
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/template.marko
@@ -1,0 +1,11 @@
+static const shout = (s: string) => s.toUpperCase() + "!";
+server const stamp = "srv";
+client const flag = "cli";
+<let/count=0/>
+<main>
+  <p>${shout(input.title)} ${stamp}</p>
+  <if=input.show>
+    <span>${shout(input.title) + " #" + count}</span>
+  </if>
+  <button onClick() { count++; document.querySelector("main")!.dataset.flag = flag }>+</button>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/test.ts
@@ -1,0 +1,17 @@
+import type { TestConfig } from "../../main.test";
+
+const click = (document: Document) => {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+};
+
+// Static scriptlets are module-level code (shared, server-only, client-only):
+// nothing about them is per render, so patches and constructs read them freely.
+export const config: TestConfig = {
+  persisted: true,
+  steps: [
+    { title: "hi", show: false },
+    click,
+    { title: "yo", show: true },
+    click,
+  ],
+};

--- a/packages/runtime-tags/src/html.ts
+++ b/packages/runtime-tags/src/html.ts
@@ -52,6 +52,7 @@ export {
   _must_render,
   _patch_attr,
   _patch_attr_class,
+  _patch_attr_option_value,
   _patch_attr_style,
   _patch_bind,
   _patch_child,

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -11,7 +11,7 @@ import type {
   TemplateInput,
 } from "../common/types";
 import { AccessorPrefix, PatchKey } from "../common/types";
-import { _attr, stringAttr } from "./attrs";
+import { _attr, _attr_option_value, stringAttr } from "./attrs";
 import { _escape, _to_text } from "./content";
 import { getRegistered, K_SCOPE_ID, Serializer } from "./serializer";
 import { shells } from "./shells";
@@ -594,6 +594,28 @@ export function _patch_text(
   }
 
   return _escape(value);
+}
+
+// An option's `value` renders through the select-aware writer (it may add
+// `selected`); the patch entry is the plain attribute the client re-syncs.
+export function _patch_attr_option_value(
+  scopeId: number,
+  accessor: Accessor,
+  value: unknown,
+  owned?: SerializeReasonValue,
+  group?: number,
+) {
+  const state = getState();
+  if (state.writesPatches) {
+    if (serverOwned(owned, group)) {
+      writePatch(scopeId, {
+        [PatchKey.Attr + accessor + " value"]: normalizeAttrValue(value) ?? 0,
+      });
+    }
+  } else {
+    getChunk()!.needsWalk = true;
+  }
+  return _attr_option_value(value);
 }
 
 function patchStringAttr(

--- a/packages/runtime-tags/src/translator/util/persisted/admission.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/admission.ts
@@ -817,11 +817,7 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
                   )) ||
                 // `content=` mounts structural content the patch wire has no
                 // entry for, so a dynamic one cannot apply faithfully.
-                attr.name === "content" ||
-                // Option state couples to the parent select's selection;
-                // a lone attribute write cannot re-sync it.
-                (tagName === "option" &&
-                  (attr.name === "value" || attr.name === "selected")))
+                attr.name === "content")
         ) {
           unsupported(attr);
         }

--- a/packages/runtime-tags/src/translator/util/persisted/admission.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/admission.ts
@@ -361,9 +361,6 @@ export function assertSupportedPatch(program: t.NodePath<t.Program>) {
         assertDeliverableInClientOwned(node, node.value, node.value.extra);
       }
     },
-    MarkoScriptlet({ node }) {
-      unsupported(node);
-    },
     MarkoTag(tag) {
       const { node } = tag;
       const tagName = t.isStringLiteral(node.name) && node.name.value;

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -756,7 +756,19 @@ export default {
           const valueReferences = value.extra?.referencedBindings;
 
           if (tagName === "option" && name === "value") {
-            write`${callRuntime("_attr_option_value", value)}`;
+            write`${
+              !confident && writesPatchAttr(tag, tagSection, name, value)
+                ? callRuntime(
+                    "_patch_attr_option_value",
+                    getScopeIdIdentifier(tagSection),
+                    getScopeAccessorLiteral(nodeBinding!),
+                    value,
+                    ...getPatchWriteOwnership(
+                      getSerializeSourcesForExpr(value.extra || {}),
+                    ),
+                  )
+                : callRuntime("_attr_option_value", value)
+            }`;
             continue;
           }
 


### PR DESCRIPTION
Two admission assertions deleted, one commit each.

Static scriptlets (`static`/`server`/`client`) are module-level code with nothing per render, so patches and constructs read them freely. `<option value=…>`/`selected=…` now patch like any attribute — the controlled select re-syncs its options after the frame's writes land, matching a client render — and `<option value>` gains a patch writer (`_patch_attr_option_value`) since its select-aware HTML path bypassed the attribute patch write.

Unescaped placeholders stay parked on a main resume bug (recorded in agent-feedback/bugs.md); dynamic `content=` folds into the fed-renderer work.