### PR TITLE
test(runtime-tags): check every persisted patch against a fresh render

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // runs it against current globals, and later global changes re-queue it.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { show: true, $global: { brand: "Marko", serializedGlobals: ["brand"] } },
     { show: false, $global: { brand: "Marko", serializedGlobals: ["brand"] } },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // value changes, and a constructed branch runs it against current fills.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { title: "Store", show: true, value: "a" },
     { title: "Store", show: true, value: "b" },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/test.ts
@@ -12,6 +12,8 @@ const step = (value: string, brand: string, title = "Store") => ({
 
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     step("a", "Marko"),
     step("b", "Marko"),

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/test.ts
@@ -5,6 +5,8 @@ import type { TestConfig } from "../../main.test";
 // merely pairs the already-shown branch.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { title: "Store", show: true },
     { title: "Store!", show: true },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-script-global/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // stamp is depth-independent, so the effect re-queues across templates.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { $global: { brand: "Marko", serializedGlobals: ["brand"] } },
     { $global: { brand: "Marko", serializedGlobals: ["brand"] } },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/test.ts
@@ -16,6 +16,9 @@ const check = (document: Document) => {
 // input to uncontrolled behavior — typing sticks, nothing reports.
 export const config: TestConfig = {
   persisted: true,
+  // An uncontrolled input keeps its live value (CSR semantics); a fresh
+  // render shows the new default.
+  skip_fresh_render: true,
   steps: [
     { title: "Store", value: "first", wire: true },
     { title: "Store!", value: "second", wire: false },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/test.ts
@@ -13,6 +13,8 @@ const globals = (brand: string, locale: string, other: string) => ({
 
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     globals("Marko", "en", "x"),
     globals("Marko", "en", "y"),

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-opaque/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // change to ANY serialized global re-runs the script (never goes stale).
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     {
       $global: {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // re-queues the effect, while an unchanged re-ship never re-runs it.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { $global: { brand: "Marko", serializedGlobals: ["brand"] } },
     { $global: { brand: "Marko", serializedGlobals: ["brand"] } },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-input/test.ts
@@ -4,6 +4,8 @@ import type { TestConfig } from "../../main.test";
 // then — the runs counter shows patches without a change skip it).
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { title: "Store", announce: "sale" },
     { title: "Store!", announce: "sale" },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-inputs/test.ts
@@ -5,6 +5,8 @@ import type { TestConfig } from "../../main.test";
 // returning to a former one (a: x->z->x) still re-runs each time.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [
     { title: "Store", a: "x", b: "y" },
     { title: "Store!", a: "x", b: "y" },

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-effect/test.ts
@@ -4,5 +4,7 @@ import type { TestConfig } from "../../main.test";
 // refreshes it and re-runs the reader per frame change.
 export const config: TestConfig = {
   persisted: true,
+  // The script leaves state on the page a fresh render lacks.
+  skip_fresh_render: true,
   steps: [{ title: "a" }, { title: "a" }, { title: "b" }],
 };

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -38,7 +38,7 @@ import {
   stripDebugRuntime,
   stripOptimizeRuntime,
 } from "./utils/strip-inline-runtime";
-import createMutationTracker from "./utils/track-mutations";
+import createMutationTracker, { formatBody } from "./utils/track-mutations";
 
 const require = createRequire(import.meta.url);
 
@@ -93,6 +93,9 @@ export type TestConfig = {
   runtime_id?: string;
   /** Compiles the fixture with the `persisted` compiler option. */
   persisted?: boolean;
+  /** Persisted: skip checking each patched page against a fresh render of
+   * the same input (client effects leave state a fresh render lacks). */
+  skip_fresh_render?: boolean;
 };
 
 // `scripts/test-parallel` fans the fixtures across CPU cores by giving each
@@ -417,8 +420,46 @@ function testFixtures(interop?: true) {
               browser.ctx as typeof import("@marko/runtime-tags/dom");
             let rejected = false;
 
+            // Until a client-side step diverges the page from what the
+            // server would render for the same input, every applied patch
+            // must leave the DOM as a fresh render of that input would.
+            let diverged = hasFlush || !!config.skip_fresh_render;
+            const assertPatchedLikeFresh = async (input: Input) => {
+              const capture = captureConsole();
+              const freshChunks: string[] = [];
+              try {
+                resetResolveState();
+                for await (const data of template.render(input)) {
+                  freshChunks.push(data);
+                }
+              } finally {
+                resetResolveState();
+                capture.cleanup();
+              }
+              // The fresh page resumes like the live one did, so client
+              // effects and reorders land on both sides.
+              const fresh = createBrowser(
+                runner.assets,
+                config.load_order,
+                rejectLoad || undefined,
+              );
+              browsers.push(fresh);
+              const freshFlush = fresh.stream(freshChunks);
+              while (freshFlush());
+              await fresh.runAsyncScripts();
+              const expected = formatBody(fresh.window.document.body, false);
+              const actual = formatBody(browser.window.document.body, false);
+              if (expected !== actual) {
+                throw new Error(
+                  `A persisted patch left the page unlike a fresh render of ${JSON.stringify(input)}.\n--- fresh render\n${expected}\n--- patched page\n${actual}\n`,
+                );
+              }
+            };
             await runSteps(steps, tracker, browser, run, {
               onFlush: hasFlush ? flushAndRun : undefined,
+              onStep: () => {
+                diverged = true;
+              },
               onInput: persisted
                 ? async (input, betweenFrames) => {
                     tracker.beginUpdate();
@@ -442,6 +483,9 @@ function testFixtures(interop?: true) {
                     }
                     patches.push(frames.join(""));
                     tracker.logUpdate(input);
+                    if (applied && !diverged && !betweenFrames) {
+                      await assertPatchedLikeFresh(input);
+                    }
                     if (!applied) {
                       if (!config.expect_rejection) {
                         throw new Error(
@@ -637,6 +681,7 @@ async function runSteps(
   browser: ReturnType<typeof createBrowser>,
   run: () => void,
   opts: {
+    onStep?: () => void;
     onInput?: (
       input: Input,
       betweenFrames?: (document: Document) => unknown,
@@ -659,6 +704,7 @@ async function runSteps(
       run();
       tracker.logUpdate();
     } else if (isFlush(update)) {
+      opts.onStep?.();
       if (update.flushType === "stream") {
         if (opts.onFlush) {
           tracker.beginUpdate();
@@ -672,6 +718,7 @@ async function runSteps(
         tracker.logUpdate();
       }
     } else if (typeof update === "function") {
+      opts.onStep?.();
       tracker.beginUpdate();
       await update(browser.window.document);
       run();

--- a/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
+++ b/packages/runtime-tags/src/__tests__/utils/track-mutations.ts
@@ -132,6 +132,29 @@ export default function createMutationTracker(browser: {
   }
 }
 
+// The body as the render log prints it (markers, scripts and whitespace
+// dropped): two documents that print alike render alike. `defaults` off
+// drops the `default-*` annotations (a patched control keeps the defaults
+// it loaded with; a fresh render's defaults are its current values).
+export function formatBody(body: Document["body"], defaults = true) {
+  const clone = cloneAndSanitize(body);
+  if (!defaults) {
+    for (const el of (clone as Element).querySelectorAll(
+      "[default-value],[default-checked],[default-selected]",
+    )) {
+      el.removeAttribute("default-value");
+      el.removeAttribute("default-checked");
+      el.removeAttribute("default-selected");
+    }
+  }
+  return Array.from(clone.childNodes, (node) =>
+    format(node, { plugins: [DOMElement, DOMCollection] }).trim(),
+  )
+    .filter(Boolean)
+    .join("\n")
+    .trim();
+}
+
 function cloneAndSanitize(body: Document["body"]) {
   const clone = body.cloneNode(true) as ParentNode;
   const ignoredNodes: ChildNode[] = [];
@@ -247,14 +270,7 @@ function getStatusString(
     .filter(Boolean)
     .join("\n");
   const formattedHTML =
-    !body || (hasRendered && !formattedMutations)
-      ? ""
-      : Array.from(cloneAndSanitize(body).childNodes, (node) =>
-          format(node, { plugins: [DOMElement, DOMCollection] }).trim(),
-        )
-          .filter(Boolean)
-          .join("\n")
-          .trim();
+    !body || (hasRendered && !formattedMutations) ? "" : formatBody(body);
 
   if (
     hasRendered &&


### PR DESCRIPTION
Adds a fresh-render oracle to the persisted test harness: after each input step the page is rendered fresh with the same input, resumed in a scratch browser, and its printed body must match the patched page (until a click/flush step or a rejection makes them diverge by design). This catches silent-stale/blank patches that snapshot review had to spot by eye. Fixtures whose scripts or uncontrolled inputs keep client-only state opt out with `skip_fresh_render`. Test-only; no runtime or translator change.