### PR TITLE
fix(runtime-tags): restore ./tags-html export in published exports map

### DIFF
--- a/.changeset/five-poems-drum.md
+++ b/.changeset/five-poems-drum.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix the published `./tags-html` subpath export, which was dropped from the production `exports` map, breaking Marko 5's global HTML/SVG type declarations for consumers.

--- a/packages/runtime-tags/package.json
+++ b/packages/runtime-tags/package.json
@@ -62,6 +62,9 @@
     ".": {
       "types": "./index.d.ts"
     },
+    "./tags-html": {
+      "types": "./tags-html.d.ts"
+    },
     "./cheatsheet.md": "./cheatsheet.md",
     "./package.json": "./package.json",
     "./translator": "./dist/translator/index.js",


### PR DESCRIPTION
fix(runtime-tags): restore ./tags-html export in published exports map

The prior fix (#3999) added the ./tags-html subpath to package.json's
dev-mode "exports" field but not to "exports:override" (the field
swapped in at publish time), so the published tarball's exports map
never gained the entry. This silently broke resolution of
`import "@marko/runtime-tags/tags-html"` from marko 5's tags-html.d.ts,
dropping the global Marko.HTML/SVG type declarations entirely for any
consumer using the published package.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>