### PR TITLE
fix(runtime-tags): separate static text at template edges

### DIFF
--- a/.changeset/tall-eagles-shave.md
+++ b/.changeset/tall-eagles-shave.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Separate a template's static text edges so they cannot merge with a parent's adjacent text into a single DOM node, which desynchronized the client-side walk and left later accessors undefined.

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// tags/child/index.marko
+const $template$1 = "X<span></span>";
+const $walks$1 = "b b";
+const $setup$1 = () => {};
+const $input_class = ($scope, input_class) => _attr_class($scope["#span/0"], input_class);
+const $input = ($scope, input) => $input_class($scope, input.class);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child/index.marko", $template$1, "b b", 0, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>before <!>${_w0} after</div><div>a ><!>${_w1} b</div>`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `Dc/${_w0}&lDc/${_w1}&l`)("b b", "b b");
+function $setup($scope) {
+	$input_class($scope["#childScope/0"], "inner");
+	$input_class($scope["#childScope/1"], "inner");
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,18 @@
+// tags/child/index.marko
+var child_default = _template("__tests__/tags/child/index.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`X<span${_attr_class(input.class)}></span>${_el_resume($scope0_id, "#span/0", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/child/index.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div>before ");
+	child_default({ class: "inner" });
+	_html(" after</div><div>a >");
+	child_default({ class: "inner" });
+	_html(" b</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/html.bundle.js
@@ -1,0 +1,18 @@
+// tags/child/index.marko
+var child_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`X<span${_attr_class(input.class)}></span>${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div>before ");
+	child_default({ class: "inner" });
+	_html(" after</div><div>a >");
+	child_default({ class: "inner" });
+	_html(" b</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/render.debug.md
@@ -1,0 +1,17 @@
+# Render
+```html
+<div>
+  before X
+  <span
+    class="inner"
+  />
+   after
+</div>
+<div>
+  a &gt;X
+  <span
+    class="inner"
+  />
+   b
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/render.md
@@ -1,0 +1,17 @@
+# Render
+```html
+<div>
+  before X
+  <span
+    class="inner"
+  />
+   after
+</div>
+<div>
+  a &gt;X
+  <span
+    class="inner"
+  />
+   b
+</div>
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/writes.debug.html
@@ -1,0 +1,2 @@
+<div>before X<span class=inner></span> after</div>
+<div>a >X<span class=inner></span> b</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/__snapshots__/writes.html
@@ -1,0 +1,2 @@
+<div>before X<span class=inner></span> after</div>
+<div>a >X<span class=inner></span> b</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 373,
+      "brotli": 250
+    }
+  },
+  "html": {
+    "min": 92,
+    "brotli": 64
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/tags/child/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/tags/child/index.marko
@@ -1,0 +1,2 @@
+-- X
+span class=input.class

--- a/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/child-leading-text-between-parent-text/template.marko
@@ -1,0 +1,6 @@
+<div>
+  before
+  <child class="inner"/>
+  after
+</div>
+<div>a ><child class="inner"/> b</div>

--- a/packages/runtime-tags/src/translator/util/constants/structure-kind.ts
+++ b/packages/runtime-tags/src/translator/util/constants/structure-kind.ts
@@ -1,4 +1,5 @@
 export const Visit = "visit";
+export const Text = "text";
 export const Child = "child";
 export const SectionRef = "sectionRef";
 export const ExportRef = "exportRef";

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -73,8 +73,16 @@ export interface StructureExportRef {
 export type StructureOp =
   | string // static markup
   | Step.Value // walk enter/exit step
+  | StructureText
   | StructureVisit
   | StructureChild;
+
+// Static text written into the markup; distinguished from markup strings so
+// resolution knows which template edges parse as text nodes.
+export interface StructureText {
+  kind: typeof StructureKind.Text;
+  value: string;
+}
 
 export interface StructureVisit {
   kind: typeof StructureKind.Visit;

--- a/packages/runtime-tags/src/translator/util/structure.ts
+++ b/packages/runtime-tags/src/translator/util/structure.ts
@@ -77,6 +77,12 @@ export function writeTo(path: t.NodePath<any>) {
   };
 }
 
+export function writeTextTo(path: t.NodePath<any>, value: string) {
+  if (value) {
+    getSection(path).structure?.push({ kind: StructureKind.Text, value });
+  }
+}
+
 function pushMarkup(structure: StructureOp[], str: string) {
   if (!str) return;
   const last = structure.length - 1;
@@ -117,14 +123,23 @@ export function resolveStructure(section: Section) {
     walkComment: [],
     steps: startDynamic ? [Step.Enter, Step.Exit] : [],
   };
+  let textEdge: undefined | "own" | "child";
 
   for (const op of section.structure!) {
     if (typeof op === "string") {
       appendLiteral(resolved.writes, op);
+      textEdge = undefined;
     } else if (typeof op === "number") {
       resolved.steps.push(op);
     } else {
       switch (op.kind) {
+        case StructureKind.Text:
+          if (textEdge === "child") {
+            separate(resolved);
+          }
+          appendLiteral(resolved.writes, op.value);
+          textEdge = "own";
+          break;
         case StructureKind.Visit:
           if (!op.claimed) continue;
           flushSteps(resolved);
@@ -132,9 +147,16 @@ export function resolveStructure(section: Section) {
           appendLiteral(resolved.walks, String.fromCharCode(op.code));
           if (op.code !== WalkCode.Get) {
             appendLiteral(resolved.writes, "<!>");
+            textEdge = undefined;
           }
           break;
         case StructureKind.Child: {
+          const content = refContent(op.renderer);
+          if (textEdge && content?.startType === ContentType.Text) {
+            separate(resolved);
+          }
+          textEdge =
+            content?.endType === ContentType.Text ? "child" : undefined;
           flushSteps(resolved);
           const template = op.renderer && resolveRef(op.renderer, "template");
           if (template) {
@@ -165,6 +187,18 @@ export function resolveStructure(section: Section) {
 
   flushSteps(resolved);
   return resolved;
+}
+
+function separate(resolved: ResolvedStructure) {
+  appendLiteral(resolved.writes, "<!>");
+  resolved.steps.push(Step.Enter, Step.Exit);
+}
+
+function refContent(ref: StructureRef | undefined) {
+  const section =
+    ref &&
+    (ref.kind === StructureKind.SectionRef ? ref.section : ref.program.section);
+  return section?.content;
 }
 
 // A ref reads this compile's identifier for a renderer part: a sibling

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -88,7 +88,7 @@ export default {
 
       const extra = node.extra || {};
       if (confident && node.escape) {
-        structure.writeTo(placeholder)`${staticText!}`;
+        structure.writeTextTo(placeholder, staticText!);
       } else {
         const siblingText = extra[kSiblingText]!;
         if (
@@ -97,7 +97,7 @@ export default {
         ) {
           structure.visit(placeholder, WalkCode.Replace);
         } else {
-          structure.writeTo(placeholder)` `;
+          structure.writeTextTo(placeholder, " ");
           structure.visit(placeholder, WalkCode.Get);
         }
       }

--- a/packages/runtime-tags/src/translator/visitors/text.ts
+++ b/packages/runtime-tags/src/translator/visitors/text.ts
@@ -12,7 +12,7 @@ export default {
     exit(text) {
       if (isNonHTMLText(text)) return;
 
-      structure.writeTo(text)`${text.node.value}`;
+      structure.writeTextTo(text, text.node.value);
       // Adjacent static text merges into one DOM text node, so only the run's
       // first node emits its walk step; later nodes defer to it.
       if (!isStaticText(getPrevStaticSibling(text))) {


### PR DESCRIPTION
A custom tag's template is inlined into its parent's template string. When the child's content starts or ends with static text and the parent renders text against that edge, the two literal text runs parse as a single DOM text node. The child's walk then stepped past one node too many, so every accessor after that resolved to the wrong node and threw on the first attribute write during CSR. SSR and hydration were unaffected.

Static text writes are now recorded as their own structure op (`StructureKind.Text`) rather than plain markup strings, so resolution knows which template edges parse as text nodes. At an inlined child boundary where a text edge meets adjacent text, the same `<!>` separator already used for dynamic edges is emitted — in the parent, so the child's own template and walks are unchanged and nothing is paid by templates that never merge.

Reproduced by the new `child-leading-text-between-parent-text` fixture, whose `csr` step failed before this change:

```
TypeError: Cannot read properties of undefined (reading 'getAttribute')
  at _attr_class (.../dom.mjs:277:2)
```

The fixture also covers text ending in a literal `>` (`<div>a ><child/> b</div>`), which defeats any markup-shape heuristic and motivated recording text-ness as a fact.

No existing fixture's compiled output or snapshots change, and `build:sizes` reports no delta on the benchmark apps.
