### PR TITLE
Align the `<let>` cheatsheet table row with rule 4

### DIFF
--- a/packages/runtime-tags/cheatsheet.md
+++ b/packages/runtime-tags/cheatsheet.md
@@ -200,7 +200,7 @@ Each left-hand habit is an error or silently wrong.
 | `onClick={() => ...}` / `@click` / `on-click("name")`       | `onClick() { ... }`                                                                  |
 | `const [x, setX] = useState()` / `state` / `class {}` block | `<let/x=0>` then `x = 1`                                                             |
 | `$ const y = x * 2;` (scriptlets are removed)               | `<const/y=x * 2>`                                                                    |
-| `<let/n=a + b>` for a value that should recompute           | `<const/n=a + b>`; `<let>` seeds an initial value, then de-syncs by design           |
+| `<let/n=a + b>` for a value that should recompute           | `<const/n=a + b>`; `<let>` returns state it controls, not its value                  |
 | `function fmt(n) {…}` / `const LIMIT = 10` at module level  | `static function fmt(n) {…}` / `static const LIMIT = 10`                             |
 | `type Row = {…}` at module level                            | `static type Row = {…}`                                                              |
 | `<let x=0>`                                                 | `<let/x=0>`                                                                          |


### PR DESCRIPTION
The common-mistakes table still described `<let>` as seeding an initial value and then de-syncing. Rule 4 was reworded in #4008; this row was missed.