### PR TITLE
Make the bundled `entities` a devDependency

### DIFF
--- a/.changeset/olive-rings-shave.md
+++ b/.changeset/olive-rings-shave.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Stop installing `entities` in consumer projects; it is bundled into the published output.

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -72,7 +72,6 @@
   "dependencies": {
     "@luxass/strip-json-comments": "^2.0.1",
     "complain": "^1.6.1",
-    "entities": "^8.0.0",
     "htmljs-parser": "^5.14.0",
     "jsesc": "^3.1.0",
     "kleur": "^4.1.5",
@@ -86,6 +85,7 @@
     "source-map-support": "^0.5.21"
   },
   "devDependencies": {
+    "entities": "^8.0.0",
     "marko": "^5.39.34"
   },
   "engines": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       complain:
         specifier: ^1.6.1
         version: 1.6.1
-      entities:
-        specifier: ^8.0.0
-        version: 8.0.0
       htmljs-parser:
         specifier: ^5.14.0
         version: 5.14.0
@@ -206,6 +203,9 @@ importers:
         specifier: ^0.5.21
         version: 0.5.21
     devDependencies:
+      entities:
+        specifier: ^8.0.0
+        version: 8.0.0
       marko:
         specifier: ^5.39.34
         version: link:../runtime-class


### PR DESCRIPTION
`entities` is bundled into the published `dist`, so consumers were installing a copy they never load. This matches how Babel is handled: it is the largest bundled dependency and lives in devDependencies for the same reason.

Follow-up to #4018.