### PR TITLE
fix(runtime-tags): link interactive roots from the client page entry

### DIFF
--- a/.changeset/interop-interactive-roots.md
+++ b/.changeset/interop-interactive-roots.md
@@ -1,0 +1,6 @@
+---
+"@marko/runtime-tags": patch
+"marko": patch
+---
+
+Client page entries now link the interactive roots of a template tree instead of the root-most template, so a Class API layout wrapping Tags API components is no longer pulled into the client bundle.

--- a/agent-feedback/items/2026-08-20-make-the-dynamic-tag-compat-patch-order-independent.md
+++ b/agent-feedback/items/2026-08-20-make-the-dynamic-tag-compat-patch-order-independent.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: med
+site: packages/runtime-tags/src/dom/control-flow.ts › patchDynamicTag
+---
+
+# Make the dynamic tag compat patch independent of module evaluation order
+
+`patchDynamicTag` reassigns the exported `let _dynamic_tag`, but generated Tags templates call `_dynamic_tag(...)` at module scope, so a template whose module evaluates before `marko/src/runtime/helpers/tags-compat/dom-*.mjs` captures the unpatched helper and silently never renders a Class API renderer or `renderBody` handed to it. Bundlers decide that order, so correctness depends on chunking; the page entry builder only works around it by linking the compat runtime first when a Class template bridges into Tags. Either have the returned signal read the patch at call time, or have the patch rewrap already-created signals.
+
+Check: drop the `getCompatRuntimeFile()` import that `packages/runtime-tags/src/translator/interop/index.ts` › `patchTranslateProgram` prepends to a mixed page entry, then run `pnpm test -- --grep "translator-interop custom-tag-parameters-from-args"` — the `<div>Counts: …</div>` body the Class parent passes to the Tags child disappears from `render.debug.md`.

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -152,7 +152,7 @@ export const analyze = {
       const childFile = loadFileForTag(tag);
       if (childFile?.ast.program.extra?.featureType === "tags") {
         tag.node.extra.featureType = "tags";
-        (file.path.node.extra ??= {}).needsCompat = true;
+        markInteropBoundary(file, tag);
       }
     } else if (isDynamicTag(tag)) {
       // A dynamic `<${expr}/>` whose name references an imported Tags API
@@ -169,7 +169,7 @@ export const analyze = {
           );
           if (childFile?.ast.program.extra?.featureType === "tags") {
             (tag.node.extra ??= {}).featureType = "tags";
-            (file.path.node.extra ??= {}).needsCompat = true;
+            markInteropBoundary(file, tag);
             return true;
           }
         }
@@ -702,6 +702,39 @@ export function getRuntimeEntryFiles(output, optimize) {
   ];
 }
 
+/**
+ * Records what crosses into a Tags child so the page entry can link the client
+ * side of the boundary: anything passed at all is revived through the compat
+ * layer, and a direct function attribute is hoisted into this module and
+ * registered for resume, so the module itself has to load — a split component's
+ * browser file is not enough.
+ */
+function markInteropBoundary(file, tag) {
+  const extra = (file.path.node.extra ??= {});
+  extra.needsCompat = true;
+
+  if (!extra.resumesClassFns) {
+    for (const attr of tag.get("attributes")) {
+      const value = attr.isMarkoAttribute() && attr.get("value");
+      if (
+        value &&
+        (value.isFunctionExpression() || value.isArrowFunctionExpression())
+      ) {
+        extra.resumesClassFns = true;
+        break;
+      }
+    }
+  }
+
+  if (
+    tag.node.attributes.length ||
+    tag.node.body.body.length ||
+    tag.node.attributeTags.length
+  ) {
+    extra.bridgesToTags = true;
+  }
+}
+
 function isRenderContent({ node }) {
   return /^Marko/.test(node.type) && !node.static;
 }
@@ -733,15 +766,25 @@ function getClassHydrationMode(file, visited = new Set()) {
   // A Tags template records interactivity on its program, not in metadata;
   // it hydrates itself, so a Class ancestor has to keep the boundary.
   if (file.ast.program.extra?.isInteractive) {
+    meta.hydratesTags = true;
     return (meta.classHydration = CLASS_HYDRATION_SELF);
   }
 
+  let mode;
   for (const tag of meta.tags) {
     if (tag.endsWith(".marko")) {
       const childFile = loadFileForImport(file, tag);
       if (childFile && getClassHydrationMode(childFile, visited)) {
-        return (meta.classHydration = CLASS_HYDRATION_DESCENDANT);
+        mode = CLASS_HYDRATION_DESCENDANT;
+        // A Tags descendant resumes through this boundary, which a Tags
+        // ancestor has to keep alive; a Class one hydrates on its own.
+        if (childFile.metadata.marko.hydratesTags) {
+          meta.hydratesTags = true;
+          break;
+        }
       }
     }
   }
+
+  return mode && (meta.classHydration = mode);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,28 @@
+// template.marko
+var import_vdom = require_vdom();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
+		out.be("div", null, "1", _component, null, 0);
+		out.t("Counts: ", _component);
+		out.t(count, _component);
+		out.t(",", _component);
+		out.t(count2, _component);
+		out.ee();
+	}, null, null, _componentDef, "0");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();
 
@@ -5,7 +30,6 @@ var v_template_marko_hydrate_6_default = () => init();
 var v_template_marko_hydrate_5_default = () => {};
 
 // components/custom-tag.marko
-var import_vdom = require_vdom();
 const $template = "<button class=inc><!>,<!></button><!><!>";
 const $walks = " D%c%l%c";
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/3", 0, 0, 1);
@@ -30,27 +54,3 @@ function $setup($scope) {
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__OR__x__OR__y);
 const $input = ($scope, input) => $input_content($scope, input.content);
 var custom_tag_default = /*@__PURE__*/ _template("__tests__/components/custom-tag.marko", $template, $walks, $setup, $input);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
-		out.be("div", null, "1", _component, null, 0);
-		out.t("Counts: ", _component);
-		out.t(count, _component);
-		out.t(",", _component);
-		out.t(count2, _component);
-		out.ee();
-	}, null, null, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true,
-	d: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
@@ -1,7 +1,4 @@
 // components/custom-tag.marko
-var import_vdom = require_vdom();
-const $template = "<button class=inc><!>,<!></button><!><!>";
-const $walks = " D%c%l%c";
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(3, 0, 0, 1);
 const $input_content__OR__x__OR__y = /*@__PURE__*/ _or(9, ($scope) => $dynamicTag($scope, $scope.g, () => [$scope.h, $scope.i]), 2);
 const $x = /*@__PURE__*/ _let(7, ($scope) => {
@@ -16,37 +13,6 @@ const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function
 	$x($scope, +$scope.h + 1);
 	$y($scope, +$scope.i + 1);
 }));
-function $setup($scope) {
-	$x($scope, 1);
-	$y($scope, 10);
-	$setup__script($scope);
-}
-const $input_content = /*@__PURE__*/ _const(6, $input_content__OR__x__OR__y);
-const $input = ($scope, input) => $input_content($scope, input.content);
-var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
-		out.be("div", null, "1", _component, null, 0);
-		out.t("Counts: ", _component);
-		out.t(count, _component);
-		out.t(",", _component);
-		out.t(count2, _component);
-		out.ee();
-	}, null, null, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,12 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64664,
-        "brotli": 20216
+        "min": 55522,
+        "brotli": 17639
       },
       "files": {
-        "components/custom-tag.marko": 1076,
-        "template.marko": 1076,
+        "components/custom-tag.marko": 626,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,21 @@
+// template.marko
+var import_vdom = require_vdom();
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init$1();
 
@@ -7,6 +25,7 @@ var import_components = require_components();
 var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
 
 // components/tags-pinger.marko
+var import_vdom = require_vdom();
 const $template = "<button id=tags> </button>";
 const $walks = " D l";
 const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
@@ -34,35 +53,21 @@ var component_browser_default = class {
 
 // components/class-host/index.marko
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "__tests__/components/class-host/index.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+const _marko_componentType = "__tests__/components/class-host/index.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
 const _marko_class_fn = (_component) => function(count) {
 	_component.handlePing(count);
 };
 (0, import_runtime_dom.f)("__tests__/components/class-host/index.marko/h0", _marko_class_fn);
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+(0, import_registry.r)(_marko_componentType, () => component_browser_default);
+const _marko_component = {};
+component_browser_default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
 	out.be("div", { "id": "class" }, "0", _component, null, 1);
 	out.t("none", _component);
 	out.ee();
 	(0, import_dynamic_tag.default)(out, tags_pinger_default, () => ({ "onPing": _marko_class_fn(_component) }), null, null, null, _componentDef, "1");
 }, {
-	t: _marko_componentType$1,
-	s: true,
-	d: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
 	t: _marko_componentType,
-	i: true,
+	s: true,
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,4 +1,5 @@
 // components/tags-pinger.marko
+var import_vdom = require_vdom();
 var import_const_element = /* @__PURE__ */ __toESM(require_const_element());
 const $template = "<button id=tags> </button>";
 const $walks = " D l";
@@ -27,33 +28,20 @@ var component_browser_default = class {
 
 // components/class-host/index.marko
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "c", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+const _marko_componentType = "c", _marko_template = (0, import_vdom.t)(_marko_componentType);
 const _marko_node = (0, import_const_element.default)("div", { "id": "class" }, 1).t("none");
 const _marko_class_fn = (_component) => function(count) {
 	_component.handlePing(count);
 };
 (0, import_runtime_dom.f)("c/h0", _marko_class_fn);
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+(0, import_registry.r)(_marko_componentType, () => component_browser_default);
+const _marko_component = {};
+component_browser_default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
 	out.n(_marko_node, _component);
 	(0, import_dynamic_tag.default)(out, tags_pinger_default, () => ({ "onPing": _marko_class_fn(_component) }), null, null, null, _componentDef, "1");
 }, {
-	t: _marko_componentType$1,
-	s: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
 	t: _marko_componentType,
-	i: true
+	s: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
@@ -2,14 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65561,
-        "brotli": 20383
+        "min": 65242,
+        "brotli": 20357
       },
       "files": {
-        "components/tags-pinger.marko": 702,
+        "components/tags-pinger.marko": 736,
         "components/class-host/component-browser.js": 381,
-        "components/class-host/index.marko": 1098,
-        "template.marko": 661,
+        "components/class-host/index.marko": 1076,
         "v:template.marko.hydrate-6.js": 110,
         "v:template.marko.hydrate-5.js": 242
       }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,38 +1,8 @@
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init$1();
-
-// v:template.marko.hydrate-5.js
-var import_components = require_components();
-(0, import_components.register)("__tests__/components/class-host/index.marko", component_browser_default);
-var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
-
-// components/tags-pinger.marko
-const $template = "<button id=tags> </button>";
-const $walks = " D l";
-const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
-const $setup__script = _script("__tests__/components/tags-pinger.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$count($scope, +$scope.count + 1);
-	$scope.input_onPing($scope.count);
-}));
-function $setup($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = ($scope, input) => $input_onPing($scope, input.onPing);
-const $input_onPing = /*@__PURE__*/ _const("input_onPing");
-var tags_pinger_default = /*@__PURE__*/ _template("__tests__/components/tags-pinger.marko", $template, $walks, $setup, $input);
-
-// components/class-host/component-browser.js
-var import_registry = require_registry();
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var component_browser_default = class {
-	handlePing(count) {
-		document.getElementById("class").textContent = "ping:" + count;
-	}
-};
-
 // components/class-host/index.marko
+var import_vdom = require_vdom();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
 const _marko_componentType$1 = "__tests__/components/class-host/index.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
 (0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
@@ -66,3 +36,34 @@ _marko_template._ = (0, import_renderer.default)(function(input, out, _component
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+(0, import_components.register)("__tests__/components/class-host/index.marko", component_browser_default);
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
+
+// components/tags-pinger.marko
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
+const $setup__script = _script("__tests__/components/tags-pinger.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, +$scope.count + 1);
+	$scope.input_onPing($scope.count);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input = ($scope, input) => $input_onPing($scope, input.onPing);
+const $input_onPing = /*@__PURE__*/ _const("input_onPing");
+var tags_pinger_default = /*@__PURE__*/ _template("__tests__/components/tags-pinger.marko", $template, $walks, $setup, $input);
+
+// components/class-host/component-browser.js
+var component_browser_default = class {
+	handlePing(count) {
+		document.getElementById("class").textContent = "ping:" + count;
+	}
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,66 +1,21 @@
 // components/tags-pinger.marko
-var import_const_element = /* @__PURE__ */ __toESM(require_const_element());
-const $template = "<button id=tags> </button>";
-const $walks = " D l";
 const $count = /*@__PURE__*/ _let(5, ($scope) => _text($scope.b, $scope.f));
 const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$count($scope, +$scope.f + 1);
 	$scope.e($scope.f);
 }));
-function $setup($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = ($scope, input) => $input_onPing($scope, input.onPing);
-const $input_onPing = /*@__PURE__*/ _const(4);
-var tags_pinger_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
 
 // components/class-host/component-browser.js
-var import_registry = require_registry();
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_components = require_components();
 var component_browser_default = class {
 	handlePing(count) {
 		document.getElementById("class").textContent = "ping:" + count;
 	}
 };
 
-// components/class-host/index.marko
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "c", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
-const _marko_node = (0, import_const_element.default)("div", { "id": "class" }, 1).t("none");
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	out.n(_marko_node, _component);
-	(0, import_dynamic_tag.default)(out, tags_pinger_default, null, null, null, null, _componentDef, "1", [[
-		"ping",
-		"handlePing",
-		false
-	]]);
-}, {
-	t: _marko_componentType$1,
-	s: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
-
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init$1();
-
 // v:template.marko.hydrate-5.js
-var import_components = require_components();
 (0, import_components.register)("c", component_browser_default);
 var v_template_marko_hydrate_5_default = () => (0, import_components.init)();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,16 +2,14 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65403,
-        "brotli": 20342
+        "min": 55685,
+        "brotli": 17687
       },
       "files": {
-        "components/tags-pinger.marko": 702,
-        "components/class-host/component-browser.js": 381,
-        "components/class-host/index.marko": 951,
-        "template.marko": 661,
+        "components/tags-pinger.marko": 272,
         "v:template.marko.hydrate-6.js": 110,
-        "v:template.marko.hydrate-5.js": 242
+        "components/class-host/component-browser.js": 245,
+        "v:template.marko.hydrate-5.js": 196
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
@@ -1,24 +1,5 @@
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init();
-
-// v:template.marko.hydrate-5.js
-var v_template_marko_hydrate_5_default = () => {};
-
-// components/tags-counter.marko
-var import_vdom = require_vdom();
-const $template = "<button id=counter> </button>";
-const $walks = " D l";
-const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
-const $setup__script = _script("__tests__/components/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$n($scope, +$scope.n + 1);
-}));
-function $setup($scope) {
-	$n($scope, 0);
-	$setup__script($scope);
-}
-var tags_counter_default = /*@__PURE__*/ _template("__tests__/components/tags-counter.marko", $template, $walks, $setup);
-
 // template.marko
+var import_vdom = require_vdom();
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
 var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
 var import_registry = require_registry();
@@ -36,3 +17,22 @@ _marko_template._ = (0, import_renderer.default)(function(input, out, _component
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// components/tags-counter.marko
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/components/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("__tests__/components/tags-counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
@@ -1,34 +1,8 @@
 // components/tags-counter.marko
-var import_vdom = require_vdom();
-const $template = "<button id=counter> </button>";
-const $walks = " D l";
 const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
 const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$n($scope, +$scope.c + 1);
 }));
-function $setup($scope) {
-	$n($scope, 0);
-	$setup__script($scope);
-}
-var tags_counter_default = /*@__PURE__*/ _template("b", $template, $walks, $setup);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	out.be("div", null, "0", _component, null, 0);
-	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
-	out.ee();
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
@@ -2,12 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64247,
-        "brotli": 20089
+        "min": 3126,
+        "brotli": 1531
       },
       "files": {
-        "components/tags-counter.marko": 505,
-        "template.marko": 936,
+        "components/tags-counter.marko": 244,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// tags/list.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
-const $setup$1 = () => {};
-const $input_item__script = _script("__tests__/tags/list.marko_0_input_item#3", ($scope) => _el_read($scope["#div/0"]).textContent = [...$scope.input_item].map((item) => item.label).join("|"));
-const $input_item = /*@__PURE__*/ _const("input_item", $input_item__script);
-const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, " b", 0, $input);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
@@ -15,3 +6,12 @@ function $setup($scope) {
 	$input_item($scope["#childScope/1"], attrTag({ label: "solo" }));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/list.marko
+const $template = "<div></div>";
+const $walks = " b";
+const $setup = () => {};
+const $input_item__script = _script("__tests__/tags/list.marko_0_input_item#3", ($scope) => _el_read($scope["#div/0"]).textContent = [...$scope.input_item].map((item) => item.label).join("|"));
+const $input_item = /*@__PURE__*/ _const("input_item", $input_item__script);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,3 @@
-// tags/counter.marko
-const $template$1 = "<button> </button>";
-const $walks$1 = " D l";
-const $clickCount = /*@__PURE__*/ _let("clickCount/2", ($scope) => _text($scope["#text/1"], $scope.clickCount));
-const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$clickCount($scope, +$scope.clickCount + 1);
-}));
-function $setup$1($scope) {
-	$clickCount($scope, 0);
-	$setup__script($scope);
-}
-var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template$1, $walks$1, $setup$1);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div>${_w0}</div>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}&l`)($walks$1);
@@ -18,3 +5,16 @@ function $setup($scope) {
 	$setup$1($scope["#childScope/0"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/counter.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $clickCount = /*@__PURE__*/ _let("clickCount/2", ($scope) => _text($scope["#text/1"], $scope.clickCount));
+const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$clickCount($scope, +$scope.clickCount + 1);
+}));
+function $setup($scope) {
+	$clickCount($scope, 0);
+	$setup__script($scope);
+}
+var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.bundle.debug.js
@@ -3,21 +3,6 @@ const formatNumber = (n) => {
 	return "$" + n.toFixed(2);
 };
 
-// tags/counter.marko
-const $template$1 = "<button> </button>";
-const $walks$1 = " D l";
-const $input__OR__count = /*@__PURE__*/ _or(5, ($scope) => _text($scope["#text/1"], $scope.input.format($scope.count)));
-const $count = /*@__PURE__*/ _let("count/4", $input__OR__count);
-const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$count($scope, +$scope.count + 1);
-}));
-function $setup$1($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = /*@__PURE__*/ _const("input", $input__OR__count);
-var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template$1, $walks$1, $setup$1, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -26,3 +11,18 @@ function $setup($scope) {
 	$input($scope["#childScope/0"], { format: formatNumber });
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/counter.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $input__OR__count = /*@__PURE__*/ _or(5, ($scope) => _text($scope["#text/1"], $scope.input.format($scope.count)));
+const $count = /*@__PURE__*/ _let("count/4", $input__OR__count);
+const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, +$scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input = /*@__PURE__*/ _const("input", $input__OR__count);
+var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<p> </p>";
-const $walks$1 = "D l";
-const $setup$1 = () => {};
-const $name__script = _script("__tests__/tags/child.marko_0_name#3", ($scope) => {
-	_lifecycle($scope, { onDestroy: function() {
-		console.log(`lifecycle ${$scope.name} destroyed`);
-	} });
-	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.name} destroyed`);
-});
-const $name = /*@__PURE__*/ _const("name", ($scope) => {
-	_text($scope["#text/0"], $scope.name);
-	$signalReset($scope, 0);
-	$name__script($scope);
-});
-const $input = ($scope, input) => $name($scope, input.name);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
-
 // template.marko
 const $template = "<div></div>";
 const $walks = " b";
@@ -35,3 +17,21 @@ function $setup($scope) {
 	$items($scope, ["a", "b"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);
+
+// tags/child.marko
+const $template = "<p> </p>";
+const $walks = "D l";
+const $setup = () => {};
+const $name__script = _script("__tests__/tags/child.marko_0_name#3", ($scope) => {
+	_lifecycle($scope, { onDestroy: function() {
+		console.log(`lifecycle ${$scope.name} destroyed`);
+	} });
+	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.name} destroyed`);
+});
+const $name = /*@__PURE__*/ _const("name", ($scope) => {
+	_text($scope["#text/0"], $scope.name);
+	$signalReset($scope, 0);
+	$name__script($scope);
+});
+const $input = ($scope, input) => $name($scope, input.name);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<div><!></div><div> </div>";
-const $walks$1 = " D%lD l";
-const $setup$1 = () => {};
-const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
-const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
-	_attrs($scope, "#div/0", $scope.rest);
-	$rest__script($scope);
-});
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
-const $input_content = $dynamicTag;
-const $input = ($scope, input) => {
-	_text($scope["#text/2"], Object.keys(input));
-	(({ content, ...rest }) => $rest($scope, rest))(input);
-	$input_content($scope, input.content);
-};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -28,3 +10,21 @@ function $setup($scope) {
 	$value($scope, 1);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<div><!></div><div> </div>";
+const $walks = " D%lD l";
+const $setup = () => {};
+const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
+const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
+	_attrs($scope, "#div/0", $scope.rest);
+	$rest__script($scope);
+});
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
+const $input_content = $dynamicTag;
+const $input = ($scope, input) => {
+	_text($scope["#text/2"], Object.keys(input));
+	(({ content, ...rest }) => $rest($scope, rest))(input);
+	$input_content($scope, input.content);
+};
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,20 @@
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
+const $child_content__value = /*@__PURE__*/ _closure_get("value", ($scope) => _text($scope["#text/0"], $scope._.value));
+const $child_content__setup = $child_content__value;
+const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
+const $value = /*@__PURE__*/ _const("value");
+function $setup($scope) {
+	$input($scope["#childScope/0"], { content: $child_content($scope) });
+	$value($scope, 1);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/child.marko
-const $template$1 = "<div><!></div>";
-const $walks$1 = " D%l";
-const $setup$1 = () => {};
+const $template = "<div><!></div>";
+const $walks = " D%l";
+const $setup = () => {};
 const $input_class = ($scope, input_class) => _attr_class($scope["#div/0"], [input_class, "foo"]);
 const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
 const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
@@ -15,17 +28,4 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
-// template.marko
-const $template = $template$1;
-const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
-const $child_content__value = /*@__PURE__*/ _closure_get("value", ($scope) => _text($scope["#text/0"], $scope._.value));
-const $child_content__setup = $child_content__value;
-const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
-const $value = /*@__PURE__*/ _const("value");
-function $setup($scope) {
-	$input($scope["#childScope/0"], { content: $child_content($scope) });
-	$value($scope, 1);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<div><!></div>";
-const $walks$1 = " D%l";
-const $setup$1 = () => {};
-const $content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/1");
-const $rest__script = _script("__tests__/tags/child.marko_0_rest#5", ($scope) => _attrs_script($scope, "#div/0"));
-const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
-	_attrs($scope, "#div/0", $scope.rest);
-	$rest__script($scope);
-});
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
-const $content = $dynamicTag;
-const $input = ($scope, input) => {
-	(({ content, ...rest }) => $rest($scope, rest))(input);
-	$content($scope, input.content);
-};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -29,3 +11,21 @@ function $setup($scope) {
 	$value($scope, 1);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<div><!></div>";
+const $walks = " D%l";
+const $setup = () => {};
+const $content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/1");
+const $rest__script = _script("__tests__/tags/child.marko_0_rest#5", ($scope) => _attrs_script($scope, "#div/0"));
+const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
+	_attrs($scope, "#div/0", $scope.rest);
+	$rest__script($scope);
+});
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
+const $content = $dynamicTag;
+const $input = ($scope, input) => {
+	(({ content, ...rest }) => $rest($scope, rest))(input);
+	$content($scope, input.content);
+};
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
@@ -1,19 +1,3 @@
-// tags/wrapper.marko
-const $template$1 = "<!><!><!>";
-const $walks$1 = "b%c";
-const $setup$1 = () => {};
-_resume_dynamic_tag();
-const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
-const $input_as__OR__htmlInput = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.inputAs || "div", () => $scope.htmlInput));
-const $inputAs = /*@__PURE__*/ _const("inputAs", $input_as__OR__htmlInput);
-const $htmlInput = /*@__PURE__*/ _const("htmlInput", $input_as__OR__htmlInput);
-const $input = ($scope, input) => {
-	(({ as, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
-	$inputAs($scope, input.as);
-};
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `<div>${_w0}</div><div>${_w1}</div><div>${_w2}</div><div>${_w3}</div>`)($template$1, $template$1, $template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `D/${_w0}&lD/${_w1}&lD/${_w2}&lD/${_w3}&l`)("b%c", "b%c", "b%c", "b%c");
@@ -28,3 +12,19 @@ function $setup($scope) {
 	$htmlInput($scope["#childScope/3"], {});
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/wrapper.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+_resume_dynamic_tag();
+const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
+const $input_as__OR__htmlInput = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.inputAs || "div", () => $scope.htmlInput));
+const $inputAs = /*@__PURE__*/ _const("inputAs", $input_as__OR__htmlInput);
+const $htmlInput = /*@__PURE__*/ _const("htmlInput", $input_as__OR__htmlInput);
+const $input = ($scope, input) => {
+	(({ as, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
+	$inputAs($scope, input.as);
+};
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,19 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>${_w0}</div><div>${_w1}</div>`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `D/${_w0}&lD/${_w1}&l`)("b%c", "b%c");
+function $setup($scope) {
+	$input($scope["#childScope/0"], { id: "foo" });
+	$foo($scope["#childScope/1"], "bar");
+	const $wrapper_input_spread = { id: "foo" };
+	$inputAs($scope["#childScope/1"], $wrapper_input_spread.as);
+	$htmlInput($scope["#childScope/1"], (({ as, foo, ...htmlInput }) => htmlInput)($wrapper_input_spread));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/wrapper.marko
-const $template$1 = "<!><!><!>";
-const $walks$1 = "b%c";
-const $setup$1 = () => {};
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
 _resume_dynamic_tag();
 const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
@@ -17,16 +29,4 @@ const $input = ($scope, input) => {
 	$inputAs($scope, input.as);
 	$foo($scope, input.foo);
 };
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>${_w0}</div><div>${_w1}</div>`)($template$1, $template$1);
-const $walks = /*@__PURE__*/ ((_w0, _w1) => `D/${_w0}&lD/${_w1}&l`)("b%c", "b%c");
-function $setup($scope) {
-	$input($scope["#childScope/0"], { id: "foo" });
-	$foo($scope["#childScope/1"], "bar");
-	const $wrapper_input_spread = { id: "foo" };
-	$inputAs($scope["#childScope/1"], $wrapper_input_spread.as);
-	$htmlInput($scope["#childScope/1"], (({ as, foo, ...htmlInput }) => htmlInput)($wrapper_input_spread));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.debug.js
@@ -1,6 +1,15 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$setup$1($scope["#childScope/1"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/child.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
+const $template = "<div></div>";
+const $walks = " b";
 const $if_content__text = /*@__PURE__*/ _if_closure("#div/0", 0, ($scope) => _text($scope["#text/0"], $scope._.text));
 const $if_content__setup = $if_content__text;
 const $if = /*@__PURE__*/ _if("#div/0", "<div> </div>", "D ", $if_content__setup);
@@ -18,19 +27,10 @@ const $id = /*@__PURE__*/ _const("id", ($scope) => {
 	_attr($scope["#div/0"], "id", $scope.id);
 	$id__script($scope);
 });
-function $setup$1($scope) {
+function $setup($scope) {
 	$hide($scope, true);
 	$text($scope, "");
 	$id($scope, _id($scope));
 }
 const $text_length = /*@__PURE__*/ _const("text_length", $hide__OR__text_length);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", $setup$1);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
-const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$setup$1($scope["#childScope/1"]);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,13 +43,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,13 +43,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,11 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+const $load_Child_trigger = /*@__PURE__*/ _load_visible_trigger("body");
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", /*@__PURE__*/ $load_Child_trigger(() => import("./v:child.marko.setup.mjs")));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,14 +44,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-const $load_Child_trigger = /*@__PURE__*/ _load_visible_trigger("body");
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", /*@__PURE__*/ $load_Child_trigger(() => import("./v:child.marko.setup.mjs")));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,14 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+let $load_Child_tag_input_value = /*@__PURE__*/ _load_signal(() => import("./v:child.marko.input_value.mjs"));
+function $setup($scope) {
+	$load_Child_setup($scope);
+	$load_Child_tag_input_value($scope["#childScope/1"], 1);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button>count: <!></button>";
 const $walks = " Db%l";
@@ -9,17 +20,6 @@ const $setup__script = _script("__tests__/child.marko_0", ($scope) => _on($scope
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_value($scope, input.value);
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-let $load_Child_tag_input_value = /*@__PURE__*/ _load_signal(() => import("./v:child.marko.input_value.mjs"));
-function $setup($scope) {
-	$load_Child_setup($scope);
-	$load_Child_tag_input_value($scope["#childScope/1"], 1);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 83
+      "min": 70,
+      "brotli": 68
     },
     "template.marko.page.mjs": {
-      "min": 407,
-      "brotli": 274
+      "min": 66,
+      "brotli": 69
     },
     "child.mjs": {
-      "min": 137,
-      "brotli": 107
+      "min": 128,
+      "brotli": 104
     },
     "shared": {
-      "min": 4981,
-      "brotli": 2345
+      "min": 2749,
+      "brotli": 1404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// child.marko
-const $template = "<span class=child> </span>";
-const $walks = " D l";
-const $input_value = ($scope, input_value) => _text($scope["#text/1"], input_value);
-const $setup__script = _script("__tests__/child.marko_0", ($scope) => console.log("child connected when script ran:", _el_read($scope["#span/0"]).isConnected));
-const $setup = $setup__script;
-const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
-
 // template.marko
 const $template = "<!><!><!>";
 const $walks = "b%/&c";
@@ -17,6 +8,15 @@ function $setup($scope) {
 	$load_Child_tag_input_value($scope["#childScope/1"], "hi");
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// child.marko
+const $template = "<span class=child> </span>";
+const $walks = " D l";
+const $input_value = ($scope, input_value) => _text($scope["#text/1"], input_value);
+const $setup__script = _script("__tests__/child.marko_0", ($scope) => console.log("child connected when script ran:", _el_read($scope["#span/0"]).isConnected));
+const $setup = $setup__script;
+const $input = ($scope, input) => $input_value($scope, input.value);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 69
+      "min": 75,
+      "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 114,
+      "min": 110,
       "brotli": 95
     },
     "shared": {
-      "min": 4277,
-      "brotli": 2023
+      "min": 1799,
+      "brotli": 951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<div id=ref>0</div>";
 const $walks = "b";
@@ -9,13 +16,6 @@ function $setup($scope) {
 	$promise($scope, Promise.resolve("hello"));
 }
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "b", $setup);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 69
+      "min": 75,
+      "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 118,
-      "brotli": 89
+      "min": 114,
+      "brotli": 80
     },
     "shared": {
-      "min": 4418,
-      "brotli": 2101
+      "min": 1940,
+      "brotli": 1026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button>count: <!></button>";
 const $walks = " Db%l";
@@ -10,13 +17,6 @@ function $setup($scope) {
 	$setup__script($scope);
 }
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 83
+      "min": 70,
+      "brotli": 68
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 263
+      "min": 58,
+      "brotli": 59
     },
     "child.mjs": {
-      "min": 150,
-      "brotli": 113
+      "min": 141,
+      "brotli": 110
     },
     "shared": {
-      "min": 4981,
-      "brotli": 2345
+      "min": 2749,
+      "brotli": 1404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// tags/child.marko
-const $template = "<span> </span>";
-const $walks = "D l";
-const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
-const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => console.log("loaded"));
-const $setup = $setup__script;
-const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", $setup, $input);
-
 // tags/parent-a.marko
 const $template$2 = "<!><!><!>";
 const $walks$2 = "b%/&c";
@@ -39,6 +30,15 @@ function $setup($scope) {
 	$setup$1($scope["#childScope/1"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<span> </span>";
+const $walks = "D l";
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => console.log("loaded"));
+const $setup = $setup__script;
+const $input = ($scope, input) => $input_value($scope, input.value);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", $setup, $input);
 
 // tags/v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 70
+      "min": 75,
+      "brotli": 69
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 72,
-      "brotli": 65
+      "min": 68,
+      "brotli": 64
     },
     "shared": {
-      "min": 4277,
-      "brotli": 2023
+      "min": 1799,
+      "brotli": 951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/my-box.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
-const $input__OR__extra__script = _script("__tests__/tags/my-box.marko_0_input#2_extra#3", ($scope) => _attrs_script($scope, "#div/0"));
-const $input__OR__extra = /*@__PURE__*/ _or(4, ($scope) => {
-	_attrs_content($scope, "#div/0", {
-		...$scope.input,
-		...$scope.extra
-	});
-	$input__OR__extra__script($scope);
-});
-const $extra = /*@__PURE__*/ _const("extra", $input__OR__extra);
-function $setup$1($scope) {
-	$extra($scope, { id: "x" });
-}
-const $input = /*@__PURE__*/ _const("input", $input__OR__extra);
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, " b", $setup$1, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
@@ -28,3 +10,21 @@ function $setup($scope) {
 	});
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/my-box.marko
+const $template = "<div></div>";
+const $walks = " b";
+const $input__OR__extra__script = _script("__tests__/tags/my-box.marko_0_input#2_extra#3", ($scope) => _attrs_script($scope, "#div/0"));
+const $input__OR__extra = /*@__PURE__*/ _or(4, ($scope) => {
+	_attrs_content($scope, "#div/0", {
+		...$scope.input,
+		...$scope.extra
+	});
+	$input__OR__extra__script($scope);
+});
+const $extra = /*@__PURE__*/ _const("extra", $input__OR__extra);
+function $setup($scope) {
+	$extra($scope, { id: "x" });
+}
+const $input = /*@__PURE__*/ _const("input", $input__OR__extra);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/dom.bundle.debug.js
@@ -1,6 +1,16 @@
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
+const $mydiv_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input($scope["#childScope/0"], { content: $mydiv_content($scope) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/my-div.marko
-const $template$1 = "<div></div><button></button><span>Overridden</span><output></output><strong></strong><p></p><em></em>";
-const $walks$1 = " b b b b b b b";
+const $template = "<div></div><button></button><span>Overridden</span><output></output><strong></strong><p></p><em></em>";
+const $walks = " b b b b b b b";
 const $CustomContent_content = _content_resume("__tests__/tags/my-div.marko_1*content", "Custom content");
 const $input__OR__CustomContent_content__script = _script("__tests__/tags/my-div.marko_0_input#8_CustomContent_content#10", ($scope) => _attrs_script($scope, "#p/5"));
 const $input__OR__CustomContent_content = /*@__PURE__*/ _or(11, ($scope) => {
@@ -33,7 +43,7 @@ const $CustomContent = ($scope, CustomContent) => {
 	_attr_content($scope, "#em/6", CustomContent);
 	$CustomContent_content2($scope, CustomContent?.content);
 };
-function $setup$1($scope) {
+function $setup($scope) {
 	_attr_content($scope, "#output/3", undefined);
 	$CustomContent($scope, { content: $CustomContent_content($scope) });
 }
@@ -41,14 +51,4 @@ const $CustomContent_content2 = /*@__PURE__*/ _const("CustomContent_content", ($
 	_attr_content($scope, "#strong/4", $scope.CustomContent_content);
 	$input__OR__CustomContent_content($scope);
 });
-var my_div_default = /*@__PURE__*/ _template("__tests__/tags/my-div.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = $template$1;
-const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
-const $mydiv_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input($scope["#childScope/0"], { content: $mydiv_content($scope) });
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var my_div_default = /*@__PURE__*/ _template("__tests__/tags/my-div.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,26 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
+const $outer_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<span>static</span>");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input_content($scope["#childScope/0"], $outer_content($scope));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/inner.marko
-const $template$2 = "<!><!><!>";
-const $walks$2 = "b%c";
-const $setup$2 = () => {};
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
 const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content$1 = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content$1($scope, input.content);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", 0, $input$1);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$1, "b%c", 0, $input$1);
 
 // tags/outer.marko
-const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
-const $walks$1 = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $inner_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
 const $inner_content__input_content = /*@__PURE__*/ _closure_get("input_content", ($scope) => $inner_content__dynamicTag($scope, $scope._.input_content));
 const $inner_content__setup__script = _script("__tests__/tags/outer.marko_1", ($scope) => _on($scope["#button/0"], "click", function() {
@@ -21,20 +31,10 @@ const $inner_content__setup = ($scope) => {
 	$inner_content__setup__script($scope);
 };
 const $inner_content = /*@__PURE__*/ _content("__tests__/tags/outer.marko_1*content", "<button>click</button><!><!>", " b%", $inner_content__setup);
-function $setup$1($scope) {
+function $setup($scope) {
 	$input_content_direct($scope["#childScope/0"], $inner_content($scope));
 }
 const $input = ($scope, input) => $input_content($scope, input.content);
 const $input_content__closure = /*@__PURE__*/ _closure($inner_content__input_content);
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__closure);
-var outer_default = /*@__PURE__*/ _template("__tests__/tags/outer.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
-const $outer_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<span>static</span>");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input_content($scope["#childScope/0"], $outer_content($scope));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var outer_default = /*@__PURE__*/ _template("__tests__/tags/outer.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/translator/interop/index.ts
+++ b/packages/runtime-tags/src/translator/interop/index.ts
@@ -9,7 +9,17 @@ import { generator } from "@marko/compiler/internal/babel";
 
 import * as translate6 from "..";
 import { resolveRelativeToEntry } from "../util/resolve-relative-to-entry";
+import { getCompatRuntimeFile } from "../util/runtime";
 import { isTagsAPI } from "./feature-detection";
+
+declare module "@marko/compiler/dist/types" {
+  export interface ProgramExtra {
+    /** A Class API template that registers hoisted handlers for Tags resume. */
+    resumesClassFns?: boolean;
+    /** A Class API template that passes anything into a Tags child. */
+    bridgesToTags?: boolean;
+  }
+}
 
 type TagDef = Record<string, unknown>;
 type Taglibs = [taglibId: string, taglib: Record<string, unknown>][];
@@ -50,6 +60,8 @@ export function createInteropTranslator(translate5: any) {
       [kState]?: {
         has5: boolean;
         has6: boolean;
+        needsCompat: boolean;
+        compatFiles: Set<string>;
       };
     };
     const { Program } = visitor;
@@ -88,6 +100,19 @@ export function createInteropTranslator(translate5: any) {
               );
             };
             return [
+              // A Tags template captures the dynamic tag helper at module scope,
+              // so the Class runtime has to patch it in before either half runs.
+              ...(state.needsCompat
+                ? [
+                    t.importDeclaration(
+                      [],
+                      t.stringLiteral(getCompatRuntimeFile()),
+                    ),
+                  ]
+                : []),
+              ...Array.from(state.compatFiles, (compatFile) =>
+                t.importDeclaration([], t.stringLiteral(compatFile)),
+              ),
               importHydrateProgram(
                 "6",
                 translate6.internalEntryBuilder.build(entryFile, true),
@@ -118,6 +143,8 @@ export function createInteropTranslator(translate5: any) {
         const state = (entryFile[kState] ||= {
           has5: false,
           has6: false,
+          needsCompat: false,
+          compatFiles: new Set(),
         });
 
         if (isTagsAPI(file)) {
@@ -125,6 +152,15 @@ export function createInteropTranslator(translate5: any) {
           translate6.internalEntryBuilder.visit(file, entryFile, visitChild);
         } else {
           state.has5 = true;
+          if (file.path.node.extra?.bridgesToTags) {
+            state.needsCompat = true;
+          }
+          if (file.path.node.extra?.resumesClassFns) {
+            // Its Tags resume registrations run when the module itself is loaded.
+            state.compatFiles.add(
+              resolveRelativePath(entryFile, file.opts.filename as string),
+            );
+          }
           translate5.internalEntryBuilder.visit(file, entryFile, visitChild);
         }
       },

--- a/packages/runtime-tags/src/translator/util/entry-builder.ts
+++ b/packages/runtime-tags/src/translator/util/entry-builder.ts
@@ -1,7 +1,8 @@
-import path from "node:path";
-
 import { types as t } from "@marko/compiler";
-import { getTemplateId } from "@marko/compiler/babel-utils";
+import {
+  getTemplateId,
+  resolveRelativePath,
+} from "@marko/compiler/babel-utils";
 
 import { resolveRelativeToEntry } from "./resolve-relative-to-entry";
 import type { DOMRuntimeHelpers } from "./runtime";
@@ -15,9 +16,18 @@ declare module "@marko/compiler/dist/types" {
   }
 }
 
+interface VisitedFile {
+  /** Runs client side work of its own, so the page needs the runtime at all. */
+  interactive: boolean;
+  /** Also true when the client only revives what this template registered. */
+  resumed: boolean;
+  assets: string[] | undefined;
+  children: string[] | undefined;
+  lazyChildren: string[] | undefined;
+}
 interface EntryState {
-  init: boolean;
-  assets: Set<string>;
+  /** Visited templates keyed by their entry relative import, in top down order. */
+  files: Map<string, VisitedFile>;
 }
 type EntryFile = t.BabelFile & {
   [kState]?: EntryState;
@@ -32,12 +42,18 @@ export default {
         "Unable to build hydrate code, no files were visited before finalizing the build",
       );
     }
+    const { interactive, roots, assets } = resolveInteractiveRoots(state);
     const body: t.Statement[] = [];
-    if (state.init) {
+
+    // Client assets (styles, css imports, etc) of templates outside an interactive
+    // root are linked directly; the rest arrive through their root's import.
+    for (const asset of assets) {
+      body.push(t.importDeclaration([], t.stringLiteral(asset)));
+    }
+
+    if (interactive) {
       const isPage = entryFile.path.node.extra.page;
       const initHelper: DOMRuntimeHelpers = isPage ? "init" : "initEmbedded";
-      // The main entry import below pulls in every template (and their client assets)
-      // transitively, so the collected asset imports are not needed here.
       body.push(
         t.importDeclaration(
           [
@@ -52,11 +68,12 @@ export default {
             }dom`,
           ),
         ),
-        t.importDeclaration(
-          [],
-          t.stringLiteral(`./${path.basename(entryFile.opts.filename)}`),
-        ),
       );
+
+      for (const root of roots) {
+        body.push(t.importDeclaration([], t.stringLiteral(root)));
+      }
+
       const { runtimeId } = entryFile.markoOpts;
       const readyId =
         !isPage && getTemplateId(entryFile.markoOpts, entryFile.opts.filename);
@@ -78,21 +95,15 @@ export default {
             )
           : t.expressionStatement(initExpression),
       );
-    } else {
-      // A server only page has no runtime to initialize, so its client assets must be
-      // linked directly (an interactive page receives them transitively via the main entry import).
-      for (const asset of state.assets) {
-        body.push(t.importDeclaration([], t.stringLiteral(asset)));
-      }
-
-      if (exportInit) {
-        body.push(
-          t.exportDefaultDeclaration(
-            t.arrowFunctionExpression([], t.blockStatement([])),
-          ),
-        );
-      }
+    } else if (exportInit) {
+      // A server only page has no runtime to initialize.
+      body.push(
+        t.exportDefaultDeclaration(
+          t.arrowFunctionExpression([], t.blockStatement([])),
+        ),
+      );
     }
+
     return body;
   },
   visit(
@@ -100,23 +111,36 @@ export default {
     entryFile: EntryFile,
     visitChild: (id: string) => void,
   ) {
-    const state = (entryFile[kState] ||= {
-      init: false,
-      assets: new Set(),
-    });
+    const state = (entryFile[kState] ||= { files: new Map() });
     const programExtra = file.path.node.extra;
-    const { analyzedTags, assetImports } = file.metadata.marko;
+    const { analyzedTags, assetImports, loadImports } = file.metadata.marko;
+    const id = resolveRelativePath(entryFile, file.opts.filename as string);
 
-    if (programExtra.isInteractive || programExtra.needsCompat) {
-      state.init = true;
-    }
-
-    // Link the template's known client side assets (styles, css imports, etc) into
-    // the page entry so that static routes still ship them; collected during analyze.
-    if (assetImports) {
-      for (const request of assetImports) {
-        state.assets.add(resolveRelativeToEntry(entryFile, file, request));
-      }
+    if (!state.files.has(id)) {
+      const interactive = !!(
+        programExtra.isInteractive ||
+        programExtra.needsCompat ||
+        programExtra.rendersClassTag
+      );
+      state.files.set(id, {
+        interactive,
+        resumed: interactive || !!programExtra.registersForResume,
+        assets:
+          assetImports &&
+          Array.from(assetImports, (request) =>
+            resolveRelativeToEntry(entryFile, file, request),
+          ),
+        children:
+          analyzedTags &&
+          Array.from(analyzedTags, (tag) =>
+            resolveRelativeToEntry(entryFile, file, tag),
+          ),
+        lazyChildren:
+          loadImports &&
+          Array.from(loadImports, (request) =>
+            resolveRelativeToEntry(entryFile, file, request),
+          ),
+      });
     }
 
     for (const tag of analyzedTags || []) {
@@ -124,3 +148,70 @@ export default {
     }
   },
 };
+
+/**
+ * The topmost interactive templates are what the client bundle needs; each pulls
+ * its own subtree in transitively, so an inert ancestor never has to be bundled.
+ */
+function resolveInteractiveRoots(state: EntryState) {
+  const roots: string[] = [];
+  const assets = new Set<string>();
+  const bundled = new Set<string>();
+  let interactive = false;
+
+  for (const info of state.files.values()) {
+    if (info.interactive) {
+      interactive = true;
+      break;
+    }
+  }
+
+  // A lazily imported subtree is linked by its own load entry, never the page.
+  for (const info of state.files.values()) {
+    if (info.lazyChildren) {
+      for (const lazyChild of info.lazyChildren) {
+        if (!isEagerlyUsed(lazyChild)) addBundled(lazyChild);
+      }
+    }
+  }
+
+  // Top down, so a template that is already inside a root is skipped.
+  if (interactive) {
+    for (const [id, info] of state.files) {
+      if (info.resumed && !bundled.has(id)) {
+        roots.push(id);
+        addBundled(id);
+      }
+    }
+  }
+
+  for (const [id, info] of state.files) {
+    if (info.assets && !bundled.has(id)) {
+      for (const asset of info.assets) {
+        assets.add(asset);
+      }
+    }
+  }
+
+  return { interactive, roots, assets };
+
+  function isEagerlyUsed(id: string) {
+    for (const info of state.files.values()) {
+      if (info.children?.includes(id) && !info.lazyChildren?.includes(id)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function addBundled(id: string) {
+    if (bundled.has(id)) return;
+    bundled.add(id);
+    const info = state.files.get(id);
+    if (info?.children) {
+      for (const child of info.children) {
+        addBundled(child);
+      }
+    }
+  }
+}

--- a/packages/runtime-tags/src/translator/util/tag-name-type.ts
+++ b/packages/runtime-tags/src/translator/util/tag-name-type.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import type { MarkoTagExtra } from "@marko/compiler/babel-types";
 import {
+  getProgram,
   getTagDef,
   isNativeTag,
   loadFileForTag,
@@ -10,9 +11,18 @@ import type { LoadImportConfig } from "../visitors/import-declaration";
 import * as TagNameType from "./constants/tag-name-type";
 import { isCoreTag } from "./is-core-tag";
 
+declare module "@marko/compiler" {
+  export interface MarkoMeta {
+    /** Set by the Class API translator when Tags content resumes below here. */
+    hydratesTags?: boolean;
+  }
+}
+
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
     featureType?: "class" | "tags";
+    /** Renders a Class API child that wraps Tags content needing hydration. */
+    rendersClassTag?: boolean;
   }
   export interface MarkoTagExtra {
     tagNameType?: TagNameType;
@@ -74,6 +84,11 @@ export default function analyzeTagNameType(
         extra.tagNameType = TagNameType.DynamicTag;
         extra.tagNameDynamic = true;
         extra.featureType = "class";
+        if (childFile?.metadata.marko.hydratesTags) {
+          // The interop has to rebuild this boundary before its Tags
+          // descendants can resume, so this template stays in the bundle.
+          getProgram().node.extra!.rendersClassTag = true;
+        }
       } else if (!childFile) {
         extra.tagNameType = TagNameType.DynamicTag;
         extra.tagNameDynamic = true;

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -21,6 +21,13 @@ import {
   trackImportedFn,
 } from "./function";
 
+declare module "@marko/compiler" {
+  export interface MarkoMeta {
+    /** Absolute filenames of templates this one imports with `load`. */
+    loadImports?: Set<string>;
+  }
+}
+
 declare module "@marko/compiler/dist/types" {
   export interface NodeExtra {
     tagImport?: string;
@@ -108,6 +115,12 @@ export default {
           "Unable to resolve marko file for load import.",
         );
       }
+
+      // The page entry links eager templates only; a lazy one arrives through
+      // its own load entry.
+      (file.metadata.marko.loadImports ??= new Set()).add(
+        loadFile.opts.filename as string,
+      );
 
       // The compat dynamic tag this child renders through cannot read the load
       // config, so it would reference a binding this import no longer declares.

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -7,6 +7,7 @@ import {
 
 import { hasAnalyzeErrors } from "../../util/analyze-errors";
 import { addAssetImport } from "../../util/asset-imports";
+import { isSectionRendererElided } from "../../util/binding-has-prop";
 import {
   type BindingPropTree,
   getBindingPropTree,
@@ -27,7 +28,11 @@ import {
 } from "../../util/references";
 import { resolveRelativeToEntry } from "../../util/resolve-relative-to-entry";
 import { getCompatRuntimeFile, getRuntimePath } from "../../util/runtime";
-import { startSection } from "../../util/sections";
+import {
+  forEachSection,
+  getSectionRegisterReasons,
+  startSection,
+} from "../../util/sections";
 import { sectionHasSetupStatements } from "../../util/setup-statements";
 import type { TemplateVisitor } from "../../util/visitors";
 import programDOM from "./dom";
@@ -39,6 +44,7 @@ export let localsIdentifier: t.Identifier;
 
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
+    registersForResume?: boolean;
     domExports?: {
       template: string;
       walks: string;
@@ -102,6 +108,23 @@ export default {
       }
 
       const section = programExtra.section!;
+
+      // Anything serialized, and any registered content renderer, is revived
+      // against this module, so it has to reach the client even with no client
+      // statements of its own.
+      forEachSection((childSection) => {
+        if (
+          !programExtra.registersForResume &&
+          (childSection.serializeReason ||
+            childSection.serializeReasons.size ||
+            (childSection !== section &&
+              !isSectionRendererElided(childSection) &&
+              getSectionRegisterReasons(childSection)))
+        ) {
+          programExtra.registersForResume = true;
+        }
+      });
+
       if (!section.hoistedTo && !sectionHasSetupStatements(section)) {
         // The setup export will be a noop, letting parent templates skip
         // importing and calling it (checked when this template translates).


### PR DESCRIPTION
A Tags API page entry imported the root-most template, so a Class API layout at the root dragged itself and the Marko 5 runtime into the client bundle even when only a Tags component below it was interactive.

The entry builder now links the topmost templates that actually contribute client work (client statements, resume registrations, or an interop boundary a Tags descendant resumes through) and skips lazily loaded subtrees, which their own load entry links. The interop entry additionally links the Class modules that register hoisted handlers for Tags resume, plus the compat runtime when a Class template passes anything into a Tags child.