### PR TITLE
agent-feedback: compiler API surface, error shapes, and template ids

### DIFF
--- a/agent-feedback/items/2026-08-20-admit-null-in-compileresult-and-fix-the-taglib.md
+++ b/agent-feedback/items/2026-08-20-admit-null-in-compileresult-and-fix-the-taglib.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/index.d.ts › CompileResult
+---
+
+# Admit `null` in `CompileResult`, and declare the taglib objects that actually come back
+
+`CompileResult` declares `ast`, `code` and `map` as non-nullable, and all three are `null` under the defaults the docs describe: `ast` and `map` are null unless `ast: true`/`sourceMaps` is set (both default false) and `code` is null under the documented `code: false`. So `res.code.length` and `res.map.toString()` pass `tsc --strict` and throw, with no overload to narrow on the flag that caused it. `babel-utils.d.ts` leans the same way: `TagDefinition.html`, `deprecated` and `openTagOnly` are required but absent from a real definition (`buildLookup(".").getTag("if").html` is `undefined`, so the natural `def.html === false` custom-tag test never fires), `getAttribute("div", "onclick")` is missing the required `filePath`, `defaultValue`, `deprecated` and `autocomplete` while carrying an undeclared `setFlag`, and `parseTypeArgs`/`parseTypeParams` are exported from `babel-utils.js` with no declarations at all. Every one of these lies in the direction that makes a consumer crash; a `tsd`-style type test over one compile and one lookup would pin them.
+
+Check: `compileFileSync(f, { output: "html" })` returns `{ ast: null, map: null }` and `{ code: false }` returns `code: null` against non-nullable declarations, and `taglib.buildLookup(".", "@marko/runtime-tags/translator").getTag("if")` has no `html`, `deprecated` or `openTagOnly` key; expect the declarations to admit those shapes.

--- a/agent-feedback/items/2026-08-20-camel-case-a-hyphenated-class-event-name-when.md
+++ b/agent-feedback/items/2026-08-20-camel-case-a-hyphenated-class-event-name-when.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-class/src/runtime/helpers/dynamic-tag.js › addTagsEvents
+---
+
+# Camel-case a hyphenated Class event name when folding it into a Tags child's `onX`
+
+`addTagsEvents` builds the Tags-side prop with `"on" + eventName.charAt(0).toUpperCase() + eventName.slice(1)`, which only camel-cases the first segment: a Class parent's `<tags-child on-set-filter("handleSetFilter")/>` compiles to the custom event `set-filter` and lands on the child as `onSet-filter`, so the child's `input.onSetFilter` is never populated and the binding is a silent no-op. Single-word `on-ping(...)` happens to survive, which is why the existing `interop-event-class-to-tags` fixture passes and hides it, and the multi-word `on-x-y("method")` spelling is what every Marko 5 template already contains — an incremental migration makes exactly this edit on every converted child. `attrsToCamelCase`, a few lines up in the same file, already routes plain dashed attribute names through `changeCase.___dashToCamelCase`; the event path just does not. Run `eventName` through `___dashToCamelCase` before capitalizing and pin it with a multi-word interop fixture (the sibling perf item on this symbol is about caching the bound handler, not the name).
+
+Check: an interop fixture whose Class parent binds `<tags-footer on-set-filter("handleSetFilter")/>` onto a Tags child calling `input.onSetFilter(...)` fails its `ssr` step with `TypeError: $scope.input_onSetFilter is not a function`, while the same fixture spelled `onSetFilter("handleSetFilter")` passes all steps; both spellings should pass.

--- a/agent-feedback/items/2026-08-20-close-a-modal-dialog-instead-of-clearing-its-open.md
+++ b/agent-feedback/items/2026-08-20-close-a-modal-dialog-instead-of-clearing-its-open.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-tags/src/dom/controllable.ts › _attr_details_or_dialog_open_script
+---
+
+# Close a modal `<dialog>` with `close()` instead of clearing its `open` property
+
+Every controllable-open path writes the `open` property directly — `_attr_details_or_dialog_open_default` does `scope[nodeAccessor].open = isNotVoid(open)` and the `_attr_details_or_dialog_open_script` MutationObserver reverts a change with `el.open = !newValue`. Clearing `open` does not take a dialog out of the top layer in Chromium: the box disappears and `dialog.open` reads `false`, but `dialog.matches(":modal")` stays `true`, so the rest of the document stays inert and every later `.focus()` is a silent no-op. It reaches a plain template — a `<dialog>` carrying only an `openChange` handler, opened by the app's own `showModal()`, is left permanently modal after its close button runs, while the same template without `openChange` closes correctly. It also disarms the app's own recovery, because a `<script>` effect guarding on `if (node.open) node.close()` runs after the property write and sees `false`. There is no error, no console message and no visual cue. Drive the element through `close()`/`show()` (`showModal()` where the element is already in the top layer) rather than the reflected property.
+
+Check: in a browser, render `<let/open=false><button onClick(){open=true}>o</button><dialog/el openChange(v){open=v}><button onClick(){open=false}>c</button></dialog>` plus a `<script>` that calls `el().showModal()` when `open` and `el().close()` otherwise; click open then close. `dialog.matches(":modal")` is `true` after the close and `opener.focus()` leaves `document.activeElement` at `BODY`; dropping `openChange` from the same template gives `:modal === false`. Expect both to end unmodal with focus restorable.

--- a/agent-feedback/items/2026-08-20-collapse-only-ascii-whitespace-in-template-text.md
+++ b/agent-feedback/items/2026-08-20-collapse-only-ascii-whitespace-in-template-text.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/src/babel-plugin/parser.js › onText
+---
+
+# Collapse only ASCII whitespace in template text, not every codepoint JS calls `\s`
+
+`onText` normalizes a text node with `value.replace(/\s+/g, " ")`, and JavaScript's `\s` covers U+00A0, U+2028, U+2029 and U+FEFF — none of which HTML collapses. A non-breaking space typed in body text is emitted as a plain `0x20`, so it wraps like an ordinary space; a stray U+FEFF becomes a visible space. The same characters written in an attribute value are preserved (`<div title="a<NBSP>b">` keeps `\xA0`), and U+200B in text survives, so the rule is neither "strip invisibles" nor "pass through" — it is an accident of the character class. Narrow the collapse (and the surrounding `^\s+`/`\s+$` trims) to the ASCII whitespace HTML itself collapses, `[ \t\n\r\f]`, so the indentation rule the docs describe keeps working while an author-typed codepoint survives.
+
+Check: `pnpm run compile -- -o html -d` on `<div>a<NBSP>b</div>` emits `_html("<div>a b</div>")` with a `0x20` — `grep -c $'\xc2\xa0'` on the output is 0; expect the NBSP (and U+2028/U+2029/U+FEFF) to survive, as they already do inside an attribute value.

--- a/agent-feedback/items/2026-08-20-compile-a-source-string-without-requiring-the-filename-s.md
+++ b/agent-feedback/items/2026-08-20-compile-a-source-string-without-requiring-the-filename-s.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/runtime-tags/src/translator/util/get-style-file.ts › getStyleFile
+---
+
+# Compile a source string without requiring the filename's directory to exist
+
+`getStyleFile` calls `fs.readdirSync(path.dirname(filename))` unguarded to look for a sibling `*.style.*`, so `compileSync(src, filename)` — the API whose whole point is an in-memory source — dies on any synthetic path: `compileSync("<p>hi</p>", "/nonexistent/dir/x.marko", { output: "html" })` throws a bare Node `Error: ENOENT: no such file or directory, scandir '/nonexistent/dir'` with no `CompileError`, no filename in the message and no hint that a style-file lookup is what touched the disk. `packages/runtime-class/src/translator/util/get-component-files.js › getComponentFiles` has the same unguarded `readdirSync` and takes the same throw for a class-API source. The directory only has to exist, not contain anything, so the whole failure disappears behind an `existsSync` guard or a `catch` that treats an unreadable directory as "no sibling files"; the config's `fileSystem` escape hatch already proves the compile itself needs nothing from that directory.
+
+Check: `compileSync("<let/x=1><p>${x}</p>", "/nonexistent/dir/x.marko", { output: "html" })` throws `ENOENT … scandir '/nonexistent/dir'`; passing `fileSystem: { ...fs, readdirSync: () => [] }` compiles the identical source fine. Expect the plain call to compile too, or to fail with a Marko diagnostic naming the directory and the style-file lookup.

--- a/agent-feedback/items/2026-08-20-escape-rather-than-fold-unusual-characters-in-a.md
+++ b/agent-feedback/items/2026-08-20-escape-rather-than-fold-unusual-characters-in-a.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/compiler/src/babel-utils/tags.js › getTemplateId
+---
+
+# Escape rather than fold unusual characters in a template id, which collide today
+
+`getTemplateId` builds its id with `relative(root, request).replace(/[^a-zA-Z0-9_$./-]/g, "/")`, so every character outside that set becomes a path separator and two different files can produce one id: `foo+bar.marko` and `foo/bar.marko` both yield `.../foo/bar.marko`, and with `optimize: true` both hash to one `_template("<id>", …)`. That id is the key of the resume registry (`dom/resume.ts › _resume` does `registeredValues[id] = obj`), so a collision silently cross-wires two templates in production rather than failing the build. `+` is not exotic — every `@marko/run` route file is `+page.marko`/`+layout.marko`, so those ids already carry a doubled slash with the `+` gone, and spaces, `[`, `(` and non-ASCII fold the same way. Encode the rejected characters instead of replacing them (or hash the untouched relative path), and while there declare the `getTemplateId` override the function honours in `config.d.ts`, which does not list it today.
+
+Check: put `foo+bar.marko` and `foo/bar.marko` side by side, `pnpm run compile -- -o html` both, and compare the emitted `_template("…")` id — the two are byte-identical (as is `meta.id`, `…/foo/bar.marko` for both); expect distinct ids.

--- a/agent-feedback/items/2026-08-20-expose-the-resume-flag-to-script-and-lifecycle.md
+++ b/agent-feedback/items/2026-08-20-expose-the-resume-flag-to-script-and-lifecycle.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: med
+site: packages/runtime-tags/src/dom/resume.ts › isResuming
+---
+
+# Expose the resume flag to `<script>` and `<lifecycle>`
+
+`runResumeEffects` sets `isResuming = 1` around the effects it replays and `dom/controllable.ts` reads it four times to decide whether a mount is a hydration, but nothing exports it, no `.d.ts` declares it and `packages/runtime-tags/cheatsheet.md` never mentions it, so a user `<script>` — which runs inside exactly that window — cannot tell a resume from a client-side mount. The cost shows up as entry animations: every server-rendered row plays its enter transition on first paint, and the workaround people reach for, a module-scope `client const` flag flipped in a `requestAnimationFrame`, is scoped to whichever chunk the module lands in rather than to the render, so it is not stable across builds. The deterministic alternative is to pass the decision down as an attribute from the parent, which cannot express re-entering the DOM and so loses the animation on every later insertion. Expose the flag where an effect can read it (on `$signal`, as a `<lifecycle>` hook argument, or as a compiler-provided `isHydrating`) and document it under `Client-side effects`.
+
+Check: `grep -rn isResuming packages/runtime-tags/src packages/runtime-tags/*.d.ts packages/runtime-tags/cheatsheet.md` reports it only under `src/dom/`, so a `<script>` recording `window.__runs` cannot distinguish a resumed mount from a fresh client render; expect a userland-reachable signal plus a fixture asserting it is set on resume and clear on a client-only render.

--- a/agent-feedback/items/2026-08-20-extend-the-static-hint-to-every-module-level-javascript.md
+++ b/agent-feedback/items/2026-08-20-extend-the-static-hint-to-every-module-level-javascript.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: high
+effort: low
+site: packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts › knownWrongTags
+---
+
+# Extend the `static` hint to every module-level JavaScript statement
+
+`core/const.ts` and `core/let.ts` end their errors with "For a one time module level value, prefix a plain JavaScript statement with `static`", but the same mistake spelled with any other statement keyword falls through to `tagNotFoundError` and gets a nearest-name suggestion that points away from the fix: `function fmt(n) {}` reports ``Did you mean `<section>`?``, `type Row = {}` reports ``Did you mean `<style>`?``, `async function go() {}` reports ``Did you mean `<aside>`?``, and `declare const D: string` gets no hint at all. `knownWrongTags` is already the curated-pointer hook for tag names that mean something else, so `function`/`type`/`interface`/`async`/`declare`/`enum` belong in it with the `static` sentence, and a JS keyword should suppress the did-you-mean rather than measure edit distance against HTML tags. `var v = 1` is the silent case: `<var>` resolves, so it compiles to `<var v=1></var>` with no diagnostic. `packages/runtime-tags/cheatsheet.md` golden rule 10 already documents the gap as "an error that never says `static`".
+
+Check: `pnpm run compile -- -o html -d x.marko` on a root-level `function fmt(n) {}` prints ``Unable to find entry point for [custom tag](…) `<function>`. Did you mean `<section>`?`` and on `var v = 1;` emits `<var v=1></var>` with no diagnostic; each should carry the `prefix a plain JavaScript statement with static` sentence `<const>` gives, with no HTML did-you-mean for a JS keyword.

--- a/agent-feedback/items/2026-08-20-give-an-invalid-shorthand-method-parameter-a-compileerror.md
+++ b/agent-feedback/items/2026-08-20-give-an-invalid-shorthand-method-parameter-a-compileerror.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/src/babel-plugin/parser.js › onAttrMethod
+---
+
+# Give an invalid shorthand-method parameter a CompileError instead of a raw Babel `TypeError`
+
+When the parameter list of an attribute method fails to parse, `parseParams` returns `[MarkoParseError]` — a placeholder node meant to be collected and reported — and `onAttrMethod` hands it straight to `t.functionExpression`, whose builder validation throws first: `<a onX(1){}>` fails with `TypeError: Property params[0] of FunctionExpression expected node to be of a type ["FunctionParameter"] but instead got "MarkoParseError"`, `loc === undefined`, no filename, no code frame, and a stack that starts inside Babel. Every non-identifier parameter takes this path (`(1)`, `(#)`, `(,)`, `(a,#)`, `(...#)`, `(a=#)`), on both `compileSync` and `compile`. Sibling constructs that build on the same placeholder are diagnosed properly — `<div class(#)=1>` and `<a onX=(1)=>{}>` give `CompileErrors` with carets, `<for|1| of=[]>` a `CompileError` with a `loc` — so this is one unchecked handoff: report the placeholder (or defer the `functionExpression` build) before Babel's validator sees it.
+
+Check: `compileSync("<a onX(1){}>", filename, { output: "html" })` throws `TypeError: Property params[0] of FunctionExpression …` with `loc === undefined`, while `compileSync("<div class(#)=1>", …)` throws `CompileErrors` with `at …:1:12` and a caret. Expect the first to throw a `CompileError` pointing at the offending parameter, pinned by an `error_compiler` fixture per parameter shape.

--- a/agent-feedback/items/2026-08-20-give-compileerror-the-loc-shape-every-bundler.md
+++ b/agent-feedback/items/2026-08-20-give-compileerror-the-loc-shape-every-bundler.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/src/util/build-code-frame.js › CompileError
+---
+
+# Give `CompileError` the `loc` shape every bundler reads
+
+`CompileError` keeps `loc` in Babel shape (`{start:{line,column},end}`) and pre-composes the position and the code frame into `message`, then also exposes `frame`. Rollup's error contract — which `@marko/vite`, and therefore every `marko-run build`/`dev` failure, is printed through — is the opposite: a plain `message`, a flat `loc` of `{file, line, column}`, and `frame` as the only copy of the frame. `rolldown`'s `getErrorMessage` does `if (e.loc) s += ':' + e.loc.line + ':' + e.loc.column` and then `if (e.frame) joinNewLine(s, e.frame)`, so every compile failure opens with the literal `undefined:undefined` where the position belongs and repeats the frame the message already carried. Adding flat `file`/`line`/`column` alongside `start`/`end` is additive and fixes the position for `@marko/vite`, `@marko/rollup` and Vite's dev overlay at once (`@marko/vite` reads `diag.loc.start.line` for warnings, so `start` has to stay); the doubled frame then needs one owner picked between `message` and `frame`.
+
+Check: `await import("@marko/compiler").compileFile(f)` on `<section><span>Hello</section>` rejects with `err.loc` = `{start:{line:1,column:20},end:{line:1,column:30}}` — no `line`, `column` or `file` — while `err.message` already contains all of `err.frame`; the same template as a `marko-run` route prints `[plugin marko-vite:pre] <id>:undefined:undefined` above two identical code frames. Expect `<id>:1:21` (the position the error's own `at` line prints) and one frame.

--- a/agent-feedback/items/2026-08-20-keep-parse-time-linear-in-tag-count-instead.md
+++ b/agent-feedback/items/2026-08-20-keep-parse-time-linear-in-tag-count-instead.md
@@ -1,0 +1,12 @@
+---
+type: perf
+impact: med
+effort: med
+site: packages/compiler/src/babel-plugin/parser.js › enterTag
+---
+
+# Keep parse time linear in tag count instead of paying Babel's sibling-key walk per tag
+
+`enterTag` appends every parsed tag with `currentBody.pushContainer("body", node)[0]`, and Babel's `pushContainer` calls `updateSiblingKeys`, which walks every path already cached for that container — so a body of N tags costs O(N²). Text nodes do not pay it (`pushContent` pushes straight onto `node.body`); only tags do, and they are the common case. Compiling one `<p>…</p>` per line takes 82 ms at 1k tags, 493 ms at 4k, 4536 ms at 16k (82 → 284 µs per tag), and a `--cpu-prof` of the 16k run attributes 60% of self time to `updateSiblingKeys` in `@babel/traverse`'s `path/modification.js` (32% at 8k). `output: "source"` shows the same curve, so this is the parse phase, not codegen or the translator — `htmljs-parser` itself is linear. `enterTag` only needs the new node's `NodePath`, so pushing the node and taking the path without the container bookkeeping (or inserting a whole body at once) should flatten it.
+
+Check: time `pnpm run compile -- -o html -d` on generated templates of 1k/2k/4k/8k/16k sibling `<p>` tags — the marginal cost per tag climbs from 82 µs to 284 µs; it should stay flat.

--- a/agent-feedback/items/2026-08-20-link-the-cheatsheet-from-the-migration-skill-with.md
+++ b/agent-feedback/items/2026-08-20-link-the-cheatsheet-from-the-migration-skill-with.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: skills/marko-5-to-6-migration/SKILL.md › Reference files
+---
+
+# Link the cheatsheet from the migration skill, with its `marko@5` path
+
+Neither skill mentions `packages/runtime-tags/cheatsheet.md`, even though its `DON'T` table is the densest list of exactly the habits a Marko 5 migration leaves behind (`on-click("name")`, `input.renderBody`, `$ ` scriptlets, `class {}`, `{expr}`) and its golden rules cover traps none of the skill's three reference files mention — the top-level `>` that silently closes a tag, and native inputs staying uncontrolled until their `*Change` handler is added. The gap is worse during the incremental phase the skill recommends for large apps: the app is still on `marko@5`, whose `files` list ships no cheatsheet, so the file exists only at `node_modules/@marko/runtime-tags/cheatsheet.md` (reached through marko@5's own `@marko/runtime-tags` dependency) — a path no migration doc names, and not the `node_modules/marko/cheatsheet.md` the compiler's fix guide prints once the app is on marko@6. Add it to `## Reference files` with both paths and say which phase each applies to.
+
+Check: `grep -ri cheatsheet skills/` prints nothing today; it should name the file and give the `@marko/runtime-tags` path for the marko@5 phase, which `node -p "require('./packages/runtime-class/package.json').files.join()"` confirms is the only one that exists there.

--- a/agent-feedback/items/2026-08-20-point-the-migration-skill-at-marko-latest-not.md
+++ b/agent-feedback/items/2026-08-20-point-the-migration-skill-at-marko-latest-not.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: skills/marko-5-to-6-migration/SKILL.md › Flow A — Full migration finish line
+---
+
+# Point the migration skill at `marko@latest`, not `marko@next`
+
+Flow A step 3 prescribes `npm i marko@^6` but then adds "and use `marko@next` while 6 is on the `next` dist-tag". The tags have moved: `npm view marko dist-tags` is now `{"next":"6.1.8","latest":"6.3.44","m5":"5.39.36"}`, so Marko 6 _is_ `latest` and `next` is two minors behind it. An agent that takes the parenthetical literally — and it can confirm the stated condition, since 6.1.8 is a 6 — silently lands a stale runtime, and every fix that shipped in 6.2 or 6.3 comes back as an unexplained regression partway through a migration. Drop the clause; the sentence already prescribes the correct range.
+
+Check: `npm view marko dist-tags --json` prints `"next": "6.1.8"` against `"latest": "6.3.44"` while SKILL.md still routes installs at `marko@next`. Expect the step to name only `marko@^6`/`marko@latest`.

--- a/agent-feedback/items/2026-08-20-reject-an-unrecognized-output-value-instead-of.md
+++ b/agent-feedback/items/2026-08-20-reject-an-unrecognized-output-value-instead-of.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/compiler/src/index.js › loadMarkoConfig
+---
+
+# Reject an unrecognized `output` value instead of translating to DOM
+
+`output` is a closed set (`html`, `dom`, `source`, `migrate`, `hydrate`) but nothing validates it: `loadMarkoConfig` merges the user config into the defaults untouched, and the tags translator asks `isOutputHTML()` (`output === "html"`), so anything that is not the exact string `"html"` falls through to the DOM path. `compileSync(src, f, { output: "HTML" })` — like `"Html"` or `"bogus"` — emits `import … from "@marko/runtime-tags/debug/dom"` with no warning, which means a build-config typo ships the client runtime where the server one was requested and produces a plausible-looking build nothing downstream can tell from intent. `"hydrate"`, the one wrong-but-real value that does fail, reports it as a Babel message about `resolveVirtualDependency` rather than saying the mode is gone. Validate `output` in `loadMarkoConfig` and throw naming the accepted values.
+
+Check: `compileSync("<div>hi</div>", f, { output: "HTML", translator: "@marko/runtime-tags/translator" })` returns code importing `@marko/runtime-tags/debug/dom`; expect a config error naming the accepted values.

--- a/agent-feedback/items/2026-08-20-repair-compiler-md-the-only-compiler-api-doc.md
+++ b/agent-feedback/items/2026-08-20-repair-compiler-md-the-only-compiler-api-doc.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/runtime-class/docs/compiler.md
+---
+
+# Repair `compiler.md`, the only compiler-API doc, and give it the Marko 6 options
+
+`@marko/compiler` ships no README, so this file — reached only through the package's `homepage` field — is the whole prose surface for the compile API, and a reader cannot work around what is wrong with it. Its one worked example, the `@marko/webpack/loader` `resolveVirtualDependency` recipe that build-tool authors are told to copy, is not valid JavaScript: it uses `{ code, map } = …` as a statement twice, so the block throws `SyntaxError: Unexpected token '='` before it runs. It points at `@marko/compiler/taglib` for `excludeDir`/`excludePackage`, which is not in the package's exports map (those live on the main export's `taglib` namespace) and resolves to `MODULE_NOT_FOUND`. Its `CompileResult` omits `ast`, the field the documented `ast: true` workflow depends on, and calls `meta` "nothing terribly useful, probably going to get deprecated" while `index.d.ts` types it as `MarkoMeta`. And its option sections cover `hydrate`, `hydrateInit`, `hydrateIncludeImports`, `writeVersionComment` and `ignoreUnrecognizedTags` — all marked deprecated or inert under Marko 6 in `config.d.ts` — while `entry` and `linkAssets` appear nowhere, even though `entry` is unusable without `linkAssets` (`program/index.ts` throws ``The "entry" option requires the `linkAssets` compiler option to be configured``) and nothing states the shape `linkAssets` must have.
+
+Check: extract the fenced `js` block under "Example based on `@marko/webpack/loader`" and run `node --check` on it — `SyntaxError: Unexpected token '='`; `node -e "require.resolve('@marko/compiler/taglib')"` — `MODULE_NOT_FOUND`; `grep -c 'linkAssets' packages/runtime-class/docs/compiler.md` — `0`. Expect the example to parse, the taglib pointer to match the exports map, `ast` in the documented `CompileResult`, and sections for `entry`/`linkAssets`.

--- a/agent-feedback/items/2026-08-20-report-a-nesting-depth-overflow-as-a-compileerror.md
+++ b/agent-feedback/items/2026-08-20-report-a-nesting-depth-overflow-as-a-compileerror.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: low
+effort: med
+site: packages/compiler/src/index.js › compileSync
+---
+
+# Report a nesting-depth overflow as a `CompileError`, not a bare `RangeError`
+
+A legal but deeply nested template dies in Babel's recursive traversal, and the compiler passes the failure straight through: `compileSync("<div>".repeat(1200) + "x" + "</div>".repeat(1200), f, …)` throws a `RangeError: Maximum call stack size exceeded` with `loc === undefined`, no filename and a stack that points only into `@marko/compiler/dist/babel.js`, so nothing names the template that failed. The threshold is stack-dependent (700 deep compiles in ~240 ms here, 1200 throws), which makes it look like a flake when it lands in CI on a generated template. Either count depth in the parser and raise a `CompileError` with a position and a named limit, or catch a stack overflow in the `compile`/`compileSync` catch and re-throw it carrying the filename.
+
+Check: `compileSync("<div>".repeat(1200) + "x" + "</div>".repeat(1200), f, { output: "html" })` throws `RangeError: Maximum call stack size exceeded` with `err.loc === undefined`; expect an error naming the file and the construct that exceeded the limit.

--- a/agent-feedback/items/2026-08-20-say-which-bundler-plugins-span-marko-5-and-6.md
+++ b/agent-feedback/items/2026-08-20-say-which-bundler-plugins-span-marko-5-and-6.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: skills/marko-5-to-6-migration/SKILL.md › Step 2 — Modernize the foundation
+---
+
+# Say which bundler plugins actually span Marko 5 and 6
+
+Step 2.6 tells a migration that "`@marko/vite`, `@marko/webpack`, `@marko/rollup`, and `@marko/run` all support Marko 5 _and_ 6", which is the sentence that decides whether a project keeps its build tool. Two of those are wrong at the versions on npm: `@marko/webpack@10.0.1` still peer-declares `marko: ^5.7.0`, and `@marko/build@4.3.2` — the marko-cli build that wraps it, and what a `marko-build`/`marko-serve` app actually depends on — carries `marko: ^5.37.10` as a regular dependency, so it installs its own Marko 5 next to the 6 the app asked for. `@marko/vite` and `@marko/rollup` peer only `@marko/compiler ^5` and are genuinely major-agnostic. Name the ones that span both, and say that a `@marko/build`/`@marko/serve` app has to replace its build tool before Flow A can finish rather than after.
+
+Check: `npm view @marko/webpack@latest peerDependencies` prints `{"marko":"^5.7.0","webpack":"^4 || ^5"}` and `npm view @marko/build@latest dependencies.marko` prints `^5.37.10`, while Step 2.6 lists both as supporting Marko 6. Expect the step to list only the plugins whose published ranges admit 6.

--- a/agent-feedback/items/2026-08-20-terminate-sourceroot-with-a-separator-so-a-mapped.md
+++ b/agent-feedback/items/2026-08-20-terminate-sourceroot-with-a-separator-so-a-mapped.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/src/index.js › getBaseBabelConfig
+---
+
+# Terminate `sourceRoot` with a separator so a mapped `.marko` frame is openable
+
+`getBaseBabelConfig` emits `sourceRoot: path.dirname(filename)` alongside `sourceFileName: path.basename(filename)`, and Node's built-in `--enable-source-maps` prepends the root to the source with no separator, so every remapped frame names a path that cannot exist: a template at `<root>/routes/page.marko` produces `<root>/routespage.marko`. Line and column map correctly, so the frame looks navigable and is not, and the failure is silent — nothing checks that a mapped source resolves. `source-map-support`, which `register.cjs` installs, joins the two properly and hides it, so it only shows up for a consumer reading the map through Node itself. Appending `path.sep` to `sourceRoot` restores the real path; `packages/compiler/src/babel-utils/tags.js` builds the same pair for extracted files and needs it too.
+
+Check: compile a template under a subdirectory with `sourceMaps: "inline"`, throw from it, and run the output under `node --enable-source-maps` — the frame reads `<parentdir><basename>.marko:2:17` with the directory separator missing; with `path.sep` appended to `sourceRoot` the same frame reads `<parentdir>/<basename>.marko:2:17`.

--- a/agent-feedback/items/2026-08-20-window-the-error-code-frame-so-a-long-line.md
+++ b/agent-feedback/items/2026-08-20-window-the-error-code-frame-so-a-long-line.md
@@ -1,0 +1,12 @@
+---
+type: cleanup
+impact: low
+effort: low
+site: packages/compiler/src/util/build-code-frame.js › buildMessage
+---
+
+# Window the error code frame so a long line cannot produce a 400 kB message
+
+`buildMessage` hands the whole line to `codeFrameColumns` with no column window, so the message grows with the source: the frame prints the offending line once as source and once as a run of carets. A 200,007-byte template (a single 100k-character tag name) produces a `CompileError` whose `message.length` is 400,251, and 500 nested parens inside an interpolation turn 1 kB of source into a 2.2 kB message whose only prose sits past column 500 where no terminal shows it. Long single lines are not exotic — an inlined data URI or generated markup gets there. Truncate the framed line around `loc.start.column` with an ellipsis before framing, the way Babel, rustc and tsc all window.
+
+Check: compile a template whose tag name is 100k characters and read `e.message.length` — 400,251 today; expect a few kB regardless of source size, with the label still visible.


### PR DESCRIPTION
Nineteen new items, most of them on the compiler's public API.

`CompileResult` does not admit `null` and the taglib objects it returns are undeclared, `CompileError` lacks the `loc` shape bundlers read, an unrecognized `output` value translates to DOM instead of erroring, and compiling a source string requires the filename's directory to exist. Several diagnostics escape unshaped: a nesting-depth `RangeError`, an invalid shorthand-method parameter arriving as a raw Babel `TypeError`, and a code frame that can reach 400 kB on a long line. Template ids fold unusual characters, so two paths can collide.

The remainder cover parse time scaling with tag count, whitespace collapsing on every codepoint JS calls `\s` rather than ASCII, a `sourceRoot` that leaves mapped `.marko` frames unopenable, and corrections to `compiler.md` and the shipped migration skill.
