### PR TITLE
fix: only initialize the resume runtime when a page has something to resume

### DIFF
--- a/.changeset/client-statement-entry.md
+++ b/.changeset/client-statement-entry.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Page entries now link the topmost templates with client work instead of the root-most template, and only pull in and initialize the resume runtime when something actually resumes; a page whose only client code is static `client {}` statements just loads its modules.

--- a/.changeset/interop-interactive-roots.md
+++ b/.changeset/interop-interactive-roots.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Mixed Class/Tags page entries now link the Tags API's interactive roots instead of the root-most template, so a Class API layout wrapping Tags API components is no longer pulled into the client bundle.

--- a/agent-feedback/items/2026-08-20-make-the-dynamic-tag-compat-patch-order-independent.md
+++ b/agent-feedback/items/2026-08-20-make-the-dynamic-tag-compat-patch-order-independent.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: med
+site: packages/runtime-tags/src/dom/control-flow.ts › patchDynamicTag
+---
+
+# Make the dynamic tag compat patch independent of module evaluation order
+
+`patchDynamicTag` reassigns the exported `let _dynamic_tag`, but generated Tags templates call `_dynamic_tag(...)` at module scope, so a template whose module evaluates before `marko/src/runtime/helpers/tags-compat/dom-*.mjs` captures the unpatched helper and silently never renders a Class API renderer or `renderBody` handed to it. Bundlers decide that order, so correctness depends on chunking; the page entry builder only works around it by linking the compat runtime first when a Class template bridges into Tags. Either have the returned signal read the patch at call time, or have the patch rewrap already-created signals.
+
+Check: drop the `getCompatRuntimeFile()` import that `packages/runtime-tags/src/translator/interop/index.ts` › `patchTranslateProgram` prepends to a mixed page entry, then run `pnpm test -- --grep "translator-interop custom-tag-parameters-from-args"` — the `<div>Counts: …</div>` body the Class parent passes to the Tags child disappears from `render.debug.md`.

--- a/packages/runtime-class/src/translator/index.js
+++ b/packages/runtime-class/src/translator/index.js
@@ -152,7 +152,7 @@ export const analyze = {
       const childFile = loadFileForTag(tag);
       if (childFile?.ast.program.extra?.featureType === "tags") {
         tag.node.extra.featureType = "tags";
-        (file.path.node.extra ??= {}).needsCompat = true;
+        markInteropBoundary(file, tag);
       }
     } else if (isDynamicTag(tag)) {
       // A dynamic `<${expr}/>` whose name references an imported Tags API
@@ -169,7 +169,7 @@ export const analyze = {
           );
           if (childFile?.ast.program.extra?.featureType === "tags") {
             (tag.node.extra ??= {}).featureType = "tags";
-            (file.path.node.extra ??= {}).needsCompat = true;
+            markInteropBoundary(file, tag);
             return true;
           }
         }
@@ -702,6 +702,50 @@ export function getRuntimeEntryFiles(output, optimize) {
   ];
 }
 
+/**
+ * Records what crosses into a Tags child so the page entry can link the client
+ * side of the boundary: anything passed at all is revived through the compat
+ * layer, and a direct function attribute is hoisted into this module and
+ * registered for resume, so the module itself has to load — a split component's
+ * browser file is not enough.
+ */
+function markInteropBoundary(file, tag) {
+  const extra = (file.path.node.extra ??= {});
+  extra.needsCompat = true;
+
+  if (!extra.resumesClassFns) {
+    for (const attr of tag.get("attributes")) {
+      const value = attr.isMarkoAttribute() && attr.get("value");
+      if (
+        value &&
+        (value.isFunctionExpression() || value.isArrowFunctionExpression())
+      ) {
+        extra.resumesClassFns = true;
+        break;
+      }
+    }
+  }
+
+  if (
+    tag.node.body.body.length ||
+    tag.node.attributeTags.length ||
+    tag.node.attributes.some(isRevivedAttr)
+  ) {
+    extra.resumesCompat = true;
+  }
+}
+
+// A literal cannot be a Class renderer or a handler the Tags side revives, so
+// passing one does not pull the compat layer into the page entry.
+function isRevivedAttr(attr) {
+  return (
+    !t.isMarkoAttribute(attr) ||
+    !!attr.arguments?.length ||
+    !t.isLiteral(attr.value) ||
+    t.isTemplateLiteral(attr.value)
+  );
+}
+
 function isRenderContent({ node }) {
   return /^Marko/.test(node.type) && !node.static;
 }
@@ -733,15 +777,25 @@ function getClassHydrationMode(file, visited = new Set()) {
   // A Tags template records interactivity on its program, not in metadata;
   // it hydrates itself, so a Class ancestor has to keep the boundary.
   if (file.ast.program.extra?.isInteractive) {
+    file.ast.program.extra.hydratesTags = true;
     return (meta.classHydration = CLASS_HYDRATION_SELF);
   }
 
+  let mode;
   for (const tag of meta.tags) {
     if (tag.endsWith(".marko")) {
       const childFile = loadFileForImport(file, tag);
       if (childFile && getClassHydrationMode(childFile, visited)) {
-        return (meta.classHydration = CLASS_HYDRATION_DESCENDANT);
+        mode = CLASS_HYDRATION_DESCENDANT;
+        // A Tags descendant resumes through this boundary, which a Tags
+        // ancestor has to keep alive; a Class one hydrates on its own.
+        if (childFile.ast.program.extra?.hydratesTags) {
+          (file.ast.program.extra ??= {}).hydratesTags = true;
+          break;
+        }
       }
     }
   }
+
+  return mode && (meta.classHydration = mode);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,28 @@
+// template.marko
+var import_vdom = require_vdom();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
+		out.be("div", null, "1", _component, null, 0);
+		out.t("Counts: ", _component);
+		out.t(count, _component);
+		out.t(",", _component);
+		out.t(count2, _component);
+		out.ee();
+	}, null, null, _componentDef, "0");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();
 
@@ -5,7 +30,6 @@ var v_template_marko_hydrate_6_default = () => init();
 var v_template_marko_hydrate_5_default = () => {};
 
 // components/custom-tag.marko
-var import_vdom = require_vdom();
 const $template = "<button class=inc><!>,<!></button><!><!>";
 const $walks = " D%c%l%c";
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/3", 0, 0, 1);
@@ -30,27 +54,3 @@ function $setup($scope) {
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__OR__x__OR__y);
 const $input = ($scope, input) => $input_content($scope, input.content);
 var custom_tag_default = /*@__PURE__*/ _template("__tests__/components/custom-tag.marko", $template, $walks, $setup, $input);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
-		out.be("div", null, "1", _component, null, 0);
-		out.t("Counts: ", _component);
-		out.t(count, _component);
-		out.t(",", _component);
-		out.t(count2, _component);
-		out.ee();
-	}, null, null, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true,
-	d: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/__snapshots__/dom.bundle.js
@@ -1,7 +1,4 @@
 // components/custom-tag.marko
-var import_vdom = require_vdom();
-const $template = "<button class=inc><!>,<!></button><!><!>";
-const $walks = " D%c%l%c";
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag(3, 0, 0, 1);
 const $input_content__OR__x__OR__y = /*@__PURE__*/ _or(9, ($scope) => $dynamicTag($scope, $scope.g, () => [$scope.h, $scope.i]), 2);
 const $x = /*@__PURE__*/ _let(7, ($scope) => {
@@ -16,37 +13,6 @@ const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function
 	$x($scope, +$scope.h + 1);
 	$y($scope, +$scope.i + 1);
 }));
-function $setup($scope) {
-	$x($scope, 1);
-	$y($scope, 10);
-	$setup__script($scope);
-}
-const $input_content = /*@__PURE__*/ _const(6, $input_content__OR__x__OR__y);
-const $input = ($scope, input) => $input_content($scope, input.content);
-var custom_tag_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_dynamic_tag.default)(out, custom_tag_default, null, (out, count, count2) => {
-		out.be("div", null, "1", _component, null, 0);
-		out.t("Counts: ", _component);
-		out.t(count, _component);
-		out.t(",", _component);
-		out.t(count2, _component);
-		out.ee();
-	}, null, null, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,12 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64664,
-        "brotli": 20216
+        "min": 55522,
+        "brotli": 17639
       },
       "files": {
-        "components/custom-tag.marko": 1076,
-        "template.marko": 1076,
+        "components/custom-tag.marko": 626,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,21 @@
+// template.marko
+var import_vdom = require_vdom();
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init$1();
 
@@ -7,6 +25,7 @@ var import_components = require_components();
 var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
 
 // components/tags-pinger.marko
+var import_vdom = require_vdom();
 const $template = "<button id=tags> </button>";
 const $walks = " D l";
 const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
@@ -34,35 +53,21 @@ var component_browser_default = class {
 
 // components/class-host/index.marko
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "__tests__/components/class-host/index.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+const _marko_componentType = "__tests__/components/class-host/index.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
 const _marko_class_fn = (_component) => function(count) {
 	_component.handlePing(count);
 };
 (0, import_runtime_dom.f)("__tests__/components/class-host/index.marko/h0", _marko_class_fn);
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+(0, import_registry.r)(_marko_componentType, () => component_browser_default);
+const _marko_component = {};
+component_browser_default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
 	out.be("div", { "id": "class" }, "0", _component, null, 1);
 	out.t("none", _component);
 	out.ee();
 	(0, import_dynamic_tag.default)(out, tags_pinger_default, () => ({ "onPing": _marko_class_fn(_component) }), null, null, null, _componentDef, "1");
 }, {
-	t: _marko_componentType$1,
-	s: true,
-	d: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
 	t: _marko_componentType,
-	i: true,
+	s: true,
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,4 +1,5 @@
 // components/tags-pinger.marko
+var import_vdom = require_vdom();
 var import_const_element = /* @__PURE__ */ __toESM(require_const_element());
 const $template = "<button id=tags> </button>";
 const $walks = " D l";
@@ -27,33 +28,20 @@ var component_browser_default = class {
 
 // components/class-host/index.marko
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "c", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+const _marko_componentType = "c", _marko_template = (0, import_vdom.t)(_marko_componentType);
 const _marko_node = (0, import_const_element.default)("div", { "id": "class" }, 1).t("none");
 const _marko_class_fn = (_component) => function(count) {
 	_component.handlePing(count);
 };
 (0, import_runtime_dom.f)("c/h0", _marko_class_fn);
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+(0, import_registry.r)(_marko_componentType, () => component_browser_default);
+const _marko_component = {};
+component_browser_default.renderer = _marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
 	out.n(_marko_node, _component);
 	(0, import_dynamic_tag.default)(out, tags_pinger_default, () => ({ "onPing": _marko_class_fn(_component) }), null, null, null, _componentDef, "1");
 }, {
-	t: _marko_componentType$1,
-	s: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
 	t: _marko_componentType,
-	i: true
+	s: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
@@ -2,14 +2,13 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65561,
-        "brotli": 20383
+        "min": 65242,
+        "brotli": 20357
       },
       "files": {
-        "components/tags-pinger.marko": 702,
+        "components/tags-pinger.marko": 736,
         "components/class-host/component-browser.js": 381,
-        "components/class-host/index.marko": 1098,
-        "template.marko": 661,
+        "components/class-host/index.marko": 1076,
         "v:template.marko.hydrate-6.js": 110,
         "v:template.marko.hydrate-5.js": 242
       }

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.debug.js
@@ -1,38 +1,8 @@
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init$1();
-
-// v:template.marko.hydrate-5.js
-var import_components = require_components();
-(0, import_components.register)("__tests__/components/class-host/index.marko", component_browser_default);
-var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
-
-// components/tags-pinger.marko
-const $template = "<button id=tags> </button>";
-const $walks = " D l";
-const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
-const $setup__script = _script("__tests__/components/tags-pinger.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$count($scope, +$scope.count + 1);
-	$scope.input_onPing($scope.count);
-}));
-function $setup($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = ($scope, input) => $input_onPing($scope, input.onPing);
-const $input_onPing = /*@__PURE__*/ _const("input_onPing");
-var tags_pinger_default = /*@__PURE__*/ _template("__tests__/components/tags-pinger.marko", $template, $walks, $setup, $input);
-
-// components/class-host/component-browser.js
-var import_registry = require_registry();
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var component_browser_default = class {
-	handlePing(count) {
-		document.getElementById("class").textContent = "ping:" + count;
-	}
-};
-
 // components/class-host/index.marko
+var import_vdom = require_vdom();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
 var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
 const _marko_componentType$1 = "__tests__/components/class-host/index.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
 (0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
@@ -66,3 +36,34 @@ _marko_template._ = (0, import_renderer.default)(function(input, out, _component
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
+
+// v:template.marko.hydrate-5.js
+var import_components = require_components();
+(0, import_components.register)("__tests__/components/class-host/index.marko", component_browser_default);
+var v_template_marko_hydrate_5_default = () => (0, import_components.init)();
+
+// components/tags-pinger.marko
+const $template = "<button id=tags> </button>";
+const $walks = " D l";
+const $count = /*@__PURE__*/ _let("count/5", ($scope) => _text($scope["#text/1"], $scope.count));
+const $setup__script = _script("__tests__/components/tags-pinger.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, +$scope.count + 1);
+	$scope.input_onPing($scope.count);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input = ($scope, input) => $input_onPing($scope, input.onPing);
+const $input_onPing = /*@__PURE__*/ _const("input_onPing");
+var tags_pinger_default = /*@__PURE__*/ _template("__tests__/components/tags-pinger.marko", $template, $walks, $setup, $input);
+
+// components/class-host/component-browser.js
+var component_browser_default = class {
+	handlePing(count) {
+		document.getElementById("class").textContent = "ping:" + count;
+	}
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/__snapshots__/dom.bundle.js
@@ -1,66 +1,21 @@
 // components/tags-pinger.marko
-var import_const_element = /* @__PURE__ */ __toESM(require_const_element());
-const $template = "<button id=tags> </button>";
-const $walks = " D l";
 const $count = /*@__PURE__*/ _let(5, ($scope) => _text($scope.b, $scope.f));
 const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$count($scope, +$scope.f + 1);
 	$scope.e($scope.f);
 }));
-function $setup($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = ($scope, input) => $input_onPing($scope, input.onPing);
-const $input_onPing = /*@__PURE__*/ _const(4);
-var tags_pinger_default = /*@__PURE__*/ _template("b", $template, $walks, $setup, $input);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init$1();
 
 // components/class-host/component-browser.js
-var import_registry = require_registry();
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_components = require_components();
 var component_browser_default = class {
 	handlePing(count) {
 		document.getElementById("class").textContent = "ping:" + count;
 	}
 };
 
-// components/class-host/index.marko
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType$1 = "c", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
-const _marko_node = (0, import_const_element.default)("div", { "id": "class" }, 1).t("none");
-(0, import_registry.r)(_marko_componentType$1, () => component_browser_default);
-const _marko_component$1 = {};
-component_browser_default.renderer = _marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	out.n(_marko_node, _component);
-	(0, import_dynamic_tag.default)(out, tags_pinger_default, null, null, null, null, _componentDef, "1", [[
-		"ping",
-		"handlePing",
-		false
-	]]);
-}, {
-	t: _marko_componentType$1,
-	s: true
-}, _marko_component$1);
-_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
-
-// template.marko
-var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "0");
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
-
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init$1();
-
 // v:template.marko.hydrate-5.js
-var import_components = require_components();
 (0, import_components.register)("c", component_browser_default);
 var v_template_marko_hydrate_5_default = () => (0, import_components.init)();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,16 +2,14 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65403,
-        "brotli": 20342
+        "min": 55685,
+        "brotli": 17687
       },
       "files": {
-        "components/tags-pinger.marko": 702,
-        "components/class-host/component-browser.js": 381,
-        "components/class-host/index.marko": 951,
-        "template.marko": 661,
+        "components/tags-pinger.marko": 272,
         "v:template.marko.hydrate-6.js": 110,
-        "v:template.marko.hydrate-5.js": 242
+        "components/class-host/component-browser.js": 245,
+        "v:template.marko.hydrate-5.js": 196
       }
     }
   },

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,62 @@
+// components/class-section.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType$1 = "__tests__/components/class-section.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+(0, import_registry.r)(_marko_componentType$1, () => _marko_template$1);
+const _marko_component$1 = {};
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("section", null, "0", _component, null, 0);
+	(0, import_dynamic_tag.default)(out, tags_label_default, () => ({ "text": "count" }), null, null, null, _componentDef, "1");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "2");
+	out.ee();
+}, {
+	t: _marko_componentType$1,
+	i: true,
+	d: true
+}, _marko_component$1);
+_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component$1, _marko_template$1._);
+
+// template.marko
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", null, "0", _component, null, 0);
+	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "1");
+	out.ee();
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// tags/tags-label.marko
+const $template$1 = "<span> </span>";
+const $walks$1 = "D l";
+const $setup$1 = () => {};
+const $input_text = ($scope, input_text) => _text($scope["#text/0"], input_text);
+const $input = ($scope, input) => $input_text($scope, input.text);
+var tags_label_default = /*@__PURE__*/ _template("__tests__/tags/tags-label.marko", $template$1, "D l", 0, $input);
+
+// tags/tags-counter.marko
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/tags/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("__tests__/tags/tags-counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/dom.bundle.js
@@ -1,0 +1,11 @@
+// tags/tags-counter.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("c0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.c + 1);
+}));
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,48 @@
+// tags/tags-label.marko
+var tags_label_default = _template("__tests__/tags/tags-label.marko", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<span>${_escape(input.text)}${_el_resume($scope0_id, "#text/0", _serialize_guard($scope0_reason, 0))}</span>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {}, "__tests__/tags/tags-label.marko", 0);
+});
+
+// tags/tags-counter.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var tags_counter_default = _template("__tests__/tags/tags-counter.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/tags/tags-counter.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/tags/tags-counter.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// components/class-section.marko
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType$1 = "__tests__/components/class-section.marko", _marko_template$1 = (0, import_html.t)(_marko_componentType$1);
+const _marko_component$1 = {};
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<section>");
+	(0, import_dynamic_tag.default)(out, tags_label_default, () => ({ "text": "count" }), null, null, null, _componentDef, "1");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "2");
+	out.w("</section>");
+}, {
+	t: _marko_componentType$1,
+	i: true,
+	d: true
+}, _marko_component$1);
+
+// template.marko
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true,
+	d: true
+}, _marko_component);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/html.bundle.js
@@ -1,0 +1,44 @@
+// tags/tags-label.marko
+var tags_label_default = _template("d", (input) => {
+	const $scope0_reason = _scope_reason();
+	const $scope0_id = _scope_id();
+	_html(`<span>${_escape(input.text)}${_el_resume($scope0_id, "a", _serialize_guard($scope0_reason, 0))}</span>`);
+	_serialize_if($scope0_reason, 0) && writeScope($scope0_id, {});
+});
+
+// tags/tags-counter.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var tags_counter_default = _template("c", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button id=counter>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "c0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+});
+
+// components/class-section.marko
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType$1 = "b", _marko_template$1 = (0, import_html.t)(_marko_componentType$1);
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<section>");
+	(0, import_dynamic_tag.default)(out, tags_label_default, () => ({ "text": "count" }), null, null, null, _componentDef, "1");
+	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "2");
+	out.w("</section>");
+}, {
+	t: _marko_componentType$1,
+	i: true
+}, {});
+
+// template.marko
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+const _marko_componentType = "a", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div>");
+	(0, import_render_tag.default)(_marko_template$1, {}, out, _componentDef, "1");
+	out.w("</div>");
+}, {
+	t: _marko_componentType,
+	i: true
+}, {});

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/render.debug.md
@@ -1,0 +1,38 @@
+# Render
+```html
+<div>
+  <section>
+    <span>
+      count
+    </span>
+    <button
+      id="counter"
+    >
+      0
+    </button>
+  </section>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <section>
+    <span>
+      count
+    </span>
+    <button
+      id="counter"
+    >
+      1
+    </button>
+  </section>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/render.md
@@ -1,0 +1,38 @@
+# Render
+```html
+<div>
+  <section>
+    <span>
+      count
+    </span>
+    <button
+      id="counter"
+    >
+      0
+    </button>
+  </section>
+</div>
+```
+
+# Update
+```js
+(document.querySelector("#counter")).click();
+```
+```html
+<div>
+  <section>
+    <span>
+      count
+    </span>
+    <button
+      id="counter"
+    >
+      1
+    </button>
+  </section>
+</div>
+```
+## Change
+```
+UPDATE: #counter::text "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<div>
+  <section><span>count</span><button
+      id=counter>0<!--Ms*2 #text/1--></button><!--Ms*2 #button/0--></section>
+</div>
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [2, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/tags/tags-counter.marko_0 2"
+  ];
+  M.s.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<div>
+  <section><span>count</span><button
+      id=counter>0<!--Ms*2 b--></button><!--Ms*2 a--></section>
+</div>
+<script>
+  WALKER_RUNTIME("M")("s");
+  M.s.r = [_ => [2, {
+    c: 0
+  }], "c0 2"];
+  M.s.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/components/class-section.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/components/class-section.marko
@@ -1,0 +1,4 @@
+<section>
+  <tags-label text="count"/>
+  <tags-counter/>
+</section>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 3126,
+        "brotli": 1532
+      },
+      "files": {
+        "tags/tags-counter.marko": 238,
+        "v:template.marko.hydrate-6.js": 108,
+        "v:template.marko.hydrate-5.js": 104
+      }
+    }
+  },
+  "html": {
+    "min": 411,
+    "brotli": 267
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/tags/tags-counter.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/tags/tags-counter.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<button id="counter" onClick() { n++ }>${n}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/tags/tags-label.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/tags/tags-label.marko
@@ -1,0 +1,1 @@
+<span>${input.text}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/template.marko
@@ -1,0 +1,1 @@
+<div><class-section/></div>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-nested-tags-child/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+// An inert Class API page must stay out of the client bundle, and so must the
+// inert Tags API sibling; only the interactive Tags root is linked.
+function bump(document: Document) {
+  (document.querySelector("#counter") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, bump],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.debug.js
@@ -1,24 +1,5 @@
-// v:template.marko.hydrate-6.js
-var v_template_marko_hydrate_6_default = () => init();
-
-// v:template.marko.hydrate-5.js
-var v_template_marko_hydrate_5_default = () => {};
-
-// components/tags-counter.marko
-var import_vdom = require_vdom();
-const $template = "<button id=counter> </button>";
-const $walks = " D l";
-const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
-const $setup__script = _script("__tests__/components/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$n($scope, +$scope.n + 1);
-}));
-function $setup($scope) {
-	$n($scope, 0);
-	$setup__script($scope);
-}
-var tags_counter_default = /*@__PURE__*/ _template("__tests__/components/tags-counter.marko", $template, $walks, $setup);
-
 // template.marko
+var import_vdom = require_vdom();
 var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
 var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
 var import_registry = require_registry();
@@ -36,3 +17,22 @@ _marko_template._ = (0, import_renderer.default)(function(input, out, _component
 	d: true
 }, _marko_component);
 _marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
+
+// v:template.marko.hydrate-6.js
+var v_template_marko_hydrate_6_default = () => init();
+
+// v:template.marko.hydrate-5.js
+var v_template_marko_hydrate_5_default = () => {};
+
+// components/tags-counter.marko
+const $template = "<button id=counter> </button>";
+const $walks = " D l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/components/tags-counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var tags_counter_default = /*@__PURE__*/ _template("__tests__/components/tags-counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/__snapshots__/dom.bundle.js
@@ -1,34 +1,8 @@
 // components/tags-counter.marko
-var import_vdom = require_vdom();
-const $template = "<button id=counter> </button>";
-const $walks = " D l";
 const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
 const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
 	$n($scope, +$scope.c + 1);
 }));
-function $setup($scope) {
-	$n($scope, 0);
-	$setup__script($scope);
-}
-var tags_counter_default = /*@__PURE__*/ _template("b", $template, $walks, $setup);
-
-// template.marko
-var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
-var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
-var import_registry = require_registry();
-var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
-const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
-(0, import_registry.r)(_marko_componentType, () => _marko_template);
-const _marko_component = {};
-_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
-	out.be("div", null, "0", _component, null, 0);
-	(0, import_dynamic_tag.default)(out, tags_counter_default, null, null, null, null, _componentDef, "1");
-	out.ee();
-}, {
-	t: _marko_componentType,
-	i: true
-}, _marko_component);
-_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);
 
 // v:template.marko.hydrate-6.js
 var v_template_marko_hydrate_6_default = () => init();

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-page-with-stateful-tags-child/sizes.json
@@ -2,12 +2,11 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64247,
-        "brotli": 20089
+        "min": 3126,
+        "brotli": 1531
       },
       "files": {
-        "components/tags-counter.marko": 505,
-        "template.marko": 936,
+        "components/tags-counter.marko": 244,
         "v:template.marko.hydrate-6.js": 108,
         "v:template.marko.hydrate-5.js": 104
       }

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-body-param-event-handler-no-serialize/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-body-param-event-handler-no-serialize/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,21 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
+const $option_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "A");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input_option($scope["#childScope/0"], attrTag({
+		value: "a",
+		onSelect: function() {},
+		content: $option_content($scope)
+	}));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/ui-field.marko
-const $template$2 = "<!><!><!>";
-const $walks$2 = "b%c";
-const $setup$2 = () => {};
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, 0, 1);
 const $input_content__OR__input_description = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.input_content, () => [{ d: $scope.input_description }]));
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__OR__input_description);
@@ -10,11 +24,11 @@ const $input$1 = ($scope, input) => {
 	$input_content($scope, input.content);
 	$input_description($scope, input.description);
 };
-var ui_field_default = /*@__PURE__*/ _template("__tests__/tags/ui-field.marko", $template$2, "b%c", 0, $input$1);
+var ui_field_default = /*@__PURE__*/ _template("__tests__/tags/ui-field.marko", $template$1, "b%c", 0, $input$1);
 
 // tags/ui-select.marko
-const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
-const $walks$1 = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $for_content__c__script = _script("__tests__/tags/ui-select.marko_2_c#2", ($scope) => _attrs_script($scope, "#span/0"));
 const $for_content__c = /*@__PURE__*/ _for_closure("#text/0", ($scope) => {
 	_attrs($scope, "#span/0", $scope._.c);
@@ -30,25 +44,11 @@ const $uifield_content__setup = $uifield_content__input_option;
 const $uifield_content__$params = ($scope, $params2) => $uifield_content__c($scope, $params2[0]);
 const $uifield_content__c = /*@__PURE__*/ _const("c", $for_content__c);
 const $uifield_content = /*@__PURE__*/ _content("__tests__/tags/ui-select.marko_1*content", "<!><!><!>", "b%", $uifield_content__setup, $uifield_content__$params);
-function $setup$1($scope) {
+function $setup($scope) {
 	$input_content($scope["#childScope/0"], $uifield_content($scope));
 	$input_description($scope["#childScope/0"], "d");
 }
 const $input = ($scope, input) => $input_option($scope, input.option);
 const $input_option__closure = /*@__PURE__*/ _closure($uifield_content__input_option);
 const $input_option = /*@__PURE__*/ _const("input_option", $input_option__closure);
-var ui_select_default = /*@__PURE__*/ _template("__tests__/tags/ui-select.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
-const $option_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "A");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input_option($scope["#childScope/0"], attrTag({
-		value: "a",
-		onSelect: function() {},
-		content: $option_content($scope)
-	}));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var ui_select_default = /*@__PURE__*/ _template("__tests__/tags/ui-select.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-body-param-serialized/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-body-param-serialized/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,20 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
+const $option_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "A");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input_option($scope["#childScope/0"], attrTag({
+		value: "a",
+		content: $option_content($scope)
+	}));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/ui-field.marko
-const $template$2 = "<!><!><!>";
-const $walks$2 = "b%c";
-const $setup$2 = () => {};
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, 0, 1);
 const $input_content__OR__input_description = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.input_content, () => [{ d: $scope.input_description }]));
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__OR__input_description);
@@ -10,11 +23,11 @@ const $input$1 = ($scope, input) => {
 	$input_content($scope, input.content);
 	$input_description($scope, input.description);
 };
-var ui_field_default = /*@__PURE__*/ _template("__tests__/tags/ui-field.marko", $template$2, "b%c", 0, $input$1);
+var ui_field_default = /*@__PURE__*/ _template("__tests__/tags/ui-field.marko", $template$1, "b%c", 0, $input$1);
 
 // tags/ui-select.marko
-const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
-const $walks$1 = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $for_content__c__script = _script("__tests__/tags/ui-select.marko_2_c#2", ($scope) => _attrs_script($scope, "#span/0"));
 const $for_content__c = /*@__PURE__*/ _for_closure("#text/0", ($scope) => {
 	_attrs($scope, "#span/0", $scope._.c);
@@ -30,24 +43,11 @@ const $uifield_content__setup = $uifield_content__input_option;
 const $uifield_content__$params = ($scope, $params2) => $uifield_content__c($scope, $params2[0]);
 const $uifield_content__c = /*@__PURE__*/ _const("c", $for_content__c);
 const $uifield_content = /*@__PURE__*/ _content("__tests__/tags/ui-select.marko_1*content", "<!><!><!>", "b%", $uifield_content__setup, $uifield_content__$params);
-function $setup$1($scope) {
+function $setup($scope) {
 	$input_content($scope["#childScope/0"], $uifield_content($scope));
 	$input_description($scope["#childScope/0"], "d");
 }
 const $input = ($scope, input) => $input_option($scope, input.option);
 const $input_option__closure = /*@__PURE__*/ _closure($uifield_content__input_option);
 const $input_option = /*@__PURE__*/ _const("input_option", $input_option__closure);
-var ui_select_default = /*@__PURE__*/ _template("__tests__/tags/ui-select.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
-const $option_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "A");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input_option($scope["#childScope/0"], attrTag({
-		value: "a",
-		content: $option_content($scope)
-	}));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var ui_select_default = /*@__PURE__*/ _template("__tests__/tags/ui-select.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-serialized-iteration/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// tags/list.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
-const $setup$1 = () => {};
-const $input_item__script = _script("__tests__/tags/list.marko_0_input_item#3", ($scope) => _el_read($scope["#div/0"]).textContent = [...$scope.input_item].map((item) => item.label).join("|"));
-const $input_item = /*@__PURE__*/ _const("input_item", $input_item__script);
-const $input = ($scope, input) => $input_item($scope, input.item);
-var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template$1, " b", 0, $input);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
@@ -15,3 +6,12 @@ function $setup($scope) {
 	$input_item($scope["#childScope/1"], attrTag({ label: "solo" }));
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/list.marko
+const $template = "<div></div>";
+const $walks = " b";
+const $setup = () => {};
+const $input_item__script = _script("__tests__/tags/list.marko_0_input_item#3", ($scope) => _el_read($scope["#div/0"]).textContent = [...$scope.input_item].map((item) => item.label).join("|"));
+const $input_item = /*@__PURE__*/ _const("input_item", $input_item__script);
+const $input = ($scope, input) => $input_item($scope, input.item);
+var list_default = /*@__PURE__*/ _template("__tests__/tags/list.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,3 @@
-// tags/counter.marko
-const $template$1 = "<button> </button>";
-const $walks$1 = " D l";
-const $clickCount = /*@__PURE__*/ _let("clickCount/2", ($scope) => _text($scope["#text/1"], $scope.clickCount));
-const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$clickCount($scope, +$scope.clickCount + 1);
-}));
-function $setup$1($scope) {
-	$clickCount($scope, 0);
-	$setup__script($scope);
-}
-var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template$1, $walks$1, $setup$1);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0) => `<div>${_w0}</div>`)($template$1);
 const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}&l`)($walks$1);
@@ -18,3 +5,16 @@ function $setup($scope) {
 	$setup$1($scope["#childScope/0"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/counter.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $clickCount = /*@__PURE__*/ _let("clickCount/2", ($scope) => _text($scope["#text/1"], $scope.clickCount));
+const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$clickCount($scope, +$scope.clickCount + 1);
+}));
+function $setup($scope) {
+	$clickCount($scope, 0);
+	$setup__script($scope);
+}
+var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,6 @@
+// template.marko
+const $template = "<div>Hello</div>";
+const $walks = "b";
+const $setup = () => {};
+console.log("hello");
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/dom.bundle.js
@@ -1,0 +1,2 @@
+// template.marko
+console.log("hello");

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,6 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div>Hello</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/html.bundle.js
@@ -1,0 +1,6 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div>Hello</div>");
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/render.debug.md
@@ -1,0 +1,10 @@
+# Render
+```html
+<div>
+  Hello
+</div>
+```
+## Console
+```
+LOG "hello"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/render.md
@@ -1,0 +1,10 @@
+# Render
+```html
+<div>
+  Hello
+</div>
+```
+## Console
+```
+LOG "hello"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/writes.debug.html
@@ -1,0 +1,1 @@
+<div>Hello</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/__snapshots__/writes.html
@@ -1,0 +1,1 @@
+<div>Hello</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 394,
+      "brotli": 244
+    }
+  },
+  "html": {
+    "min": 16,
+    "brotli": 20
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/client-block-only/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/client-block-only/template.marko
@@ -1,0 +1,5 @@
+client {
+  console.log("hello");
+}
+
+<div>Hello</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-import-value/__snapshots__/dom.bundle.debug.js
@@ -3,21 +3,6 @@ const formatNumber = (n) => {
 	return "$" + n.toFixed(2);
 };
 
-// tags/counter.marko
-const $template$1 = "<button> </button>";
-const $walks$1 = " D l";
-const $input__OR__count = /*@__PURE__*/ _or(5, ($scope) => _text($scope["#text/1"], $scope.input.format($scope.count)));
-const $count = /*@__PURE__*/ _let("count/4", $input__OR__count);
-const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
-	$count($scope, +$scope.count + 1);
-}));
-function $setup$1($scope) {
-	$count($scope, 0);
-	$setup__script($scope);
-}
-const $input = /*@__PURE__*/ _const("input", $input__OR__count);
-var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template$1, $walks$1, $setup$1, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -26,3 +11,18 @@ function $setup($scope) {
 	$input($scope["#childScope/0"], { format: formatNumber });
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/counter.marko
+const $template = "<button> </button>";
+const $walks = " D l";
+const $input__OR__count = /*@__PURE__*/ _or(5, ($scope) => _text($scope["#text/1"], $scope.input.format($scope.count)));
+const $count = /*@__PURE__*/ _let("count/4", $input__OR__count);
+const $setup__script = _script("__tests__/tags/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, +$scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input = /*@__PURE__*/ _const("input", $input__OR__count);
+var counter_default = /*@__PURE__*/ _template("__tests__/tags/counter.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destroy-nested-branches/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<p> </p>";
-const $walks$1 = "D l";
-const $setup$1 = () => {};
-const $name__script = _script("__tests__/tags/child.marko_0_name#3", ($scope) => {
-	_lifecycle($scope, { onDestroy: function() {
-		console.log(`lifecycle ${$scope.name} destroyed`);
-	} });
-	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.name} destroyed`);
-});
-const $name = /*@__PURE__*/ _const("name", ($scope) => {
-	_text($scope["#text/0"], $scope.name);
-	$signalReset($scope, 0);
-	$name__script($scope);
-});
-const $input = ($scope, input) => $name($scope, input.name);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, "D l", 0, $input);
-
 // template.marko
 const $template = "<div></div>";
 const $walks = " b";
@@ -35,3 +17,21 @@ function $setup($scope) {
 	$items($scope, ["a", "b"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, " b", $setup);
+
+// tags/child.marko
+const $template = "<p> </p>";
+const $walks = "D l";
+const $setup = () => {};
+const $name__script = _script("__tests__/tags/child.marko_0_name#3", ($scope) => {
+	_lifecycle($scope, { onDestroy: function() {
+		console.log(`lifecycle ${$scope.name} destroyed`);
+	} });
+	$signal($scope, 0).onabort = () => console.log(`effect ${$scope.name} destroyed`);
+});
+const $name = /*@__PURE__*/ _const("name", ($scope) => {
+	_text($scope["#text/0"], $scope.name);
+	$signalReset($scope, 0);
+	$name__script($scope);
+});
+const $input = ($scope, input) => $name($scope, input.name);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-input/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<div><!></div><div> </div>";
-const $walks$1 = " D%lD l";
-const $setup$1 = () => {};
-const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
-const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
-	_attrs($scope, "#div/0", $scope.rest);
-	$rest__script($scope);
-});
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
-const $input_content = $dynamicTag;
-const $input = ($scope, input) => {
-	_text($scope["#text/2"], Object.keys(input));
-	(({ content, ...rest }) => $rest($scope, rest))(input);
-	$input_content($scope, input.content);
-};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -28,3 +10,21 @@ function $setup($scope) {
 	$value($scope, 1);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<div><!></div><div> </div>";
+const $walks = " D%lD l";
+const $setup = () => {};
+const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
+const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
+	_attrs($scope, "#div/0", $scope.rest);
+	$rest__script($scope);
+});
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
+const $input_content = $dynamicTag;
+const $input = ($scope, input) => {
+	_text($scope["#text/2"], Object.keys(input));
+	(({ content, ...rest }) => $rest($scope, rest))(input);
+	$input_content($scope, input.content);
+};
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-and-reference-unprovided-input/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,20 @@
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
+const $child_content__value = /*@__PURE__*/ _closure_get("value", ($scope) => _text($scope["#text/0"], $scope._.value));
+const $child_content__setup = $child_content__value;
+const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
+const $value = /*@__PURE__*/ _const("value");
+function $setup($scope) {
+	$input($scope["#childScope/0"], { content: $child_content($scope) });
+	$value($scope, 1);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/child.marko
-const $template$1 = "<div><!></div>";
-const $walks$1 = " D%l";
-const $setup$1 = () => {};
+const $template = "<div><!></div>";
+const $walks = " D%l";
+const $setup = () => {};
 const $input_class = ($scope, input_class) => _attr_class($scope["#div/0"], [input_class, "foo"]);
 const $rest__script = _script("__tests__/tags/child.marko_0_rest#6", ($scope) => _attrs_script($scope, "#div/0"));
 const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
@@ -15,17 +28,4 @@ const $input = ($scope, input) => {
 	$input_class($scope, input.class);
 	$input_content($scope, input.content);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
-// template.marko
-const $template = $template$1;
-const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
-const $child_content__value = /*@__PURE__*/ _closure_get("value", ($scope) => _text($scope["#text/0"], $scope._.value));
-const $child_content__setup = $child_content__value;
-const $child_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", " ", " ", $child_content__setup);
-const $value = /*@__PURE__*/ _const("value");
-function $setup($scope) {
-	$input($scope["#childScope/0"], { content: $child_content($scope) });
-	$value($scope, 1);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/child.marko
-const $template$1 = "<div><!></div>";
-const $walks$1 = " D%l";
-const $setup$1 = () => {};
-const $content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/1");
-const $rest__script = _script("__tests__/tags/child.marko_0_rest#5", ($scope) => _attrs_script($scope, "#div/0"));
-const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
-	_attrs($scope, "#div/0", $scope.rest);
-	$rest__script($scope);
-});
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
-const $content = $dynamicTag;
-const $input = ($scope, input) => {
-	(({ content, ...rest }) => $rest($scope, rest))(input);
-	$content($scope, input.content);
-};
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, $walks$1, 0, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
@@ -29,3 +11,21 @@ function $setup($scope) {
 	$value($scope, 1);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<div><!></div>";
+const $walks = " D%l";
+const $setup = () => {};
+const $content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/1");
+const $rest__script = _script("__tests__/tags/child.marko_0_rest#5", ($scope) => _attrs_script($scope, "#div/0"));
+const $rest = /*@__PURE__*/ _const("rest", ($scope) => {
+	_attrs($scope, "#div/0", $scope.rest);
+	$rest__script($scope);
+});
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
+const $content = $dynamicTag;
+const $input = ($scope, input) => {
+	(({ content, ...rest }) => $rest($scope, rest))(input);
+	$content($scope, input.content);
+};
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, $walks, 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-multiple/__snapshots__/dom.bundle.debug.js
@@ -1,19 +1,3 @@
-// tags/wrapper.marko
-const $template$1 = "<!><!><!>";
-const $walks$1 = "b%c";
-const $setup$1 = () => {};
-_resume_dynamic_tag();
-const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
-const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
-const $input_as__OR__htmlInput = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.inputAs || "div", () => $scope.htmlInput));
-const $inputAs = /*@__PURE__*/ _const("inputAs", $input_as__OR__htmlInput);
-const $htmlInput = /*@__PURE__*/ _const("htmlInput", $input_as__OR__htmlInput);
-const $input = ($scope, input) => {
-	(({ as, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
-	$inputAs($scope, input.as);
-};
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
-
 // template.marko
 const $template = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `<div>${_w0}</div><div>${_w1}</div><div>${_w2}</div><div>${_w3}</div>`)($template$1, $template$1, $template$1, $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1, _w2, _w3) => `D/${_w0}&lD/${_w1}&lD/${_w2}&lD/${_w3}&l`)("b%c", "b%c", "b%c", "b%c");
@@ -28,3 +12,19 @@ function $setup($scope) {
 	$htmlInput($scope["#childScope/3"], {});
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/wrapper.marko
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
+_resume_dynamic_tag();
+const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
+const $input_as__OR__htmlInput = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.inputAs || "div", () => $scope.htmlInput));
+const $inputAs = /*@__PURE__*/ _const("inputAs", $input_as__OR__htmlInput);
+const $htmlInput = /*@__PURE__*/ _const("htmlInput", $input_as__OR__htmlInput);
+const $input = ($scope, input) => {
+	(({ as, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
+	$inputAs($scope, input.as);
+};
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-spread/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,19 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>${_w0}</div><div>${_w1}</div>`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `D/${_w0}&lD/${_w1}&l`)("b%c", "b%c");
+function $setup($scope) {
+	$input($scope["#childScope/0"], { id: "foo" });
+	$foo($scope["#childScope/1"], "bar");
+	const $wrapper_input_spread = { id: "foo" };
+	$inputAs($scope["#childScope/1"], $wrapper_input_spread.as);
+	$htmlInput($scope["#childScope/1"], (({ as, foo, ...htmlInput }) => htmlInput)($wrapper_input_spread));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/wrapper.marko
-const $template$1 = "<!><!><!>";
-const $walks$1 = "b%c";
-const $setup$1 = () => {};
+const $template = "<!><!><!>";
+const $walks = "b%c";
+const $setup = () => {};
 _resume_dynamic_tag();
 const $inputAsdiv_content = _content_resume("__tests__/tags/wrapper.marko_1*content", "hi");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", $inputAsdiv_content);
@@ -17,16 +29,4 @@ const $input = ($scope, input) => {
 	$inputAs($scope, input.as);
 	$foo($scope, input.foo);
 };
-var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template$1, "b%c", 0, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0, _w1) => `<div>${_w0}</div><div>${_w1}</div>`)($template$1, $template$1);
-const $walks = /*@__PURE__*/ ((_w0, _w1) => `D/${_w0}&lD/${_w1}&l`)("b%c", "b%c");
-function $setup($scope) {
-	$input($scope["#childScope/0"], { id: "foo" });
-	$foo($scope["#childScope/1"], "bar");
-	const $wrapper_input_spread = { id: "foo" };
-	$inputAs($scope["#childScope/1"], $wrapper_input_spread.as);
-	$htmlInput($scope["#childScope/1"], (({ as, foo, ...htmlInput }) => htmlInput)($wrapper_input_spread));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/tags/wrapper.marko", $template, "b%c", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-member-expression-intersection/__snapshots__/dom.bundle.debug.js
@@ -1,6 +1,15 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$setup$1($scope["#childScope/1"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/child.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
+const $template = "<div></div>";
+const $walks = " b";
 const $if_content__text = /*@__PURE__*/ _if_closure("#div/0", 0, ($scope) => _text($scope["#text/0"], $scope._.text));
 const $if_content__setup = $if_content__text;
 const $if = /*@__PURE__*/ _if("#div/0", "<div> </div>", "D ", $if_content__setup);
@@ -18,19 +27,10 @@ const $id = /*@__PURE__*/ _const("id", ($scope) => {
 	_attr($scope["#div/0"], "id", $scope.id);
 	$id__script($scope);
 });
-function $setup$1($scope) {
+function $setup($scope) {
 	$hide($scope, true);
 	$text($scope, "");
 	$id($scope, _id($scope));
 }
 const $text_length = /*@__PURE__*/ _const("text_length", $hide__OR__text_length);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", $setup$1);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$1, $template$1);
-const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&/${_w1}&`)(" b", " b");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$setup$1($scope["#childScope/1"]);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, " b", $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,28 @@
+// layout.marko
+const $template$1 = /*@__PURE__*/ ((_w0) => `<main><h1>static heading</h1>${_w0}</main>`)($template$2);
+const $walks$1 = /*@__PURE__*/ ((_w0) => `Db/${_w0}&l`)($walks$2);
+function $setup$1($scope) {
+	$setup$2($scope["#childScope/0"]);
+}
+var layout_default = /*@__PURE__*/ _template("__tests__/layout.marko", $template$1, $walks$1, $setup$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// counter.marko
+const $template = "<button class=counter>count:<!></button>";
+const $walks = " Db%l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/counter.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var counter_default = /*@__PURE__*/ _template("__tests__/counter.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// counter.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,26 @@
+// counter.marko
+var counter_default = _template("__tests__/counter.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=counter>count:<!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/counter.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/counter.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// layout.marko
+var layout_default = _template("__tests__/layout.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<main><h1>static heading</h1>");
+	counter_default({});
+	_html("</main>");
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	layout_default({});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/html.bundle.js
@@ -1,0 +1,26 @@
+// counter.marko
+var counter_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=counter>count:<!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+});
+
+// layout.marko
+var layout_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<main><h1>static heading</h1>");
+	counter_default({});
+	_html("</main>");
+});
+
+// template.marko
+var template_default = _template("c", (input) => {
+	_scope_reason();
+	_scope_id();
+	layout_default({});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/render.debug.md
@@ -1,0 +1,34 @@
+# Render
+```html
+<main>
+  <h1>
+    static heading
+  </h1>
+  <button
+    class="counter"
+  >
+    count:0
+  </button>
+</main>
+```
+
+# Update
+```js
+(document.querySelector(".counter")).click();
+```
+```html
+<main>
+  <h1>
+    static heading
+  </h1>
+  <button
+    class="counter"
+  >
+    count:1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: .counter::text@6 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/render.md
@@ -1,0 +1,34 @@
+# Render
+```html
+<main>
+  <h1>
+    static heading
+  </h1>
+  <button
+    class="counter"
+  >
+    count:0
+  </button>
+</main>
+```
+
+# Update
+```js
+(document.querySelector(".counter")).click();
+```
+```html
+<main>
+  <h1>
+    static heading
+  </h1>
+  <button
+    class="counter"
+  >
+    count:1
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: .counter::text@6 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<main>
+  <h1>static heading</h1><button class=counter>count:<!>
+      0<!--M_*3 #text/1--></button><!--M_*3 #button/0-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [3, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/counter.marko_0 3"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/__snapshots__/writes.html
@@ -1,0 +1,11 @@
+<main>
+  <h1>static heading</h1><button class=counter>count:<!>
+      0<!--M_*3 b--></button><!--M_*3 a-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [3, {
+    c: 0
+  }], "a0 3"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/counter.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/counter.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<button.counter onClick() { n++ }>count:${n}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/layout.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/layout.marko
@@ -1,0 +1,6 @@
+import Counter from "./counter.marko"
+
+<main>
+  <h1>static heading</h1>
+  <Counter/>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2570,
+      "brotli": 1317
+    }
+  },
+  "html": {
+    "min": 411,
+    "brotli": 270
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/template.marko
@@ -1,0 +1,3 @@
+import Layout from "./layout.marko"
+
+<Layout/>

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-root-interactive-leaf/test.ts
@@ -1,0 +1,11 @@
+import type { TestConfig } from "../../main.test";
+
+// Only the interactive leaf is linked by the page entry; the inert root and
+// layout stay out of the client bundle.
+function bump(document: Document) {
+  (document.querySelector(".counter") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, bump],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-rest-attr-tag/__snapshots__/dom.bundle.debug.js
@@ -1,7 +1,20 @@
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
+const $button_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "one");
+function $setup($scope) {
+	$buttons($scope["#childScope/0"], attrTag({
+		onClick: function() {},
+		content: $button_content($scope)
+	}));
+	$htmlInput($scope["#childScope/0"], {});
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/child.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
-const $setup$1 = () => {};
+const $template = "<div></div>";
+const $walks = " b";
+const $setup = () => {};
 const $if_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $if_content__button = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $if_content__dynamicTag($scope, $scope._.button));
 const $if_content__setup = $if_content__button;
@@ -22,17 +35,4 @@ const $input = ($scope, input) => {
 	(({ button, ...htmlInput }) => $htmlInput($scope, htmlInput))(input);
 	$buttons($scope, input.button);
 };
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template$1, " b", 0, $input);
-
-// template.marko
-const $template = $template$1;
-const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
-const $button_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "one");
-function $setup($scope) {
-	$buttons($scope["#childScope/0"], attrTag({
-		onClick: function() {},
-		content: $button_content($scope)
-	}));
-	$htmlInput($scope["#childScope/0"], {});
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, " b", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/sizes.json
@@ -5,16 +5,16 @@
       "brotli": 83
     },
     "template.marko.page.mjs": {
-      "min": 560,
-      "brotli": 353
+      "min": 554,
+      "brotli": 347
     },
     "child.mjs": {
       "min": 69,
       "brotli": 69
     },
     "shared": {
-      "min": 5632,
-      "brotli": 2575
+      "min": 3558,
+      "brotli": 1618
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,13 +43,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared-reversed/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,13 +43,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-shared/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,11 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+const $load_Child_trigger = /*@__PURE__*/ _load_visible_trigger("body");
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", /*@__PURE__*/ $load_Child_trigger(() => import("./v:child.marko.setup.mjs")));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button class=child>child:<!></button><!><!>";
 const $walks = " Db%l%/&c";
@@ -36,14 +44,6 @@ const $setup__script = _script("__tests__/grand-child.marko_0", ($scope) => _on(
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_obj($scope, input.obj);
 var grand_child_default = /*@__PURE__*/ _template("__tests__/grand-child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-const $load_Child_trigger = /*@__PURE__*/ _load_visible_trigger("body");
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", /*@__PURE__*/ $load_Child_trigger(() => import("./v:child.marko.setup.mjs")));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-visible-parent/sizes.json
@@ -9,20 +9,20 @@
       "brotli": 89
     },
     "template.marko.page.mjs": {
-      "min": 92,
-      "brotli": 77
+      "min": 67,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 431,
-      "brotli": 285
+      "min": 752,
+      "brotli": 458
     },
     "grand-child.mjs": {
       "min": 213,
       "brotli": 158
     },
     "shared": {
-      "min": 5636,
-      "brotli": 2729
+      "min": 5267,
+      "brotli": 2483
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,14 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+let $load_Child_tag_input_value = /*@__PURE__*/ _load_signal(() => import("./v:child.marko.input_value.mjs"));
+function $setup($scope) {
+	$load_Child_setup($scope);
+	$load_Child_tag_input_value($scope["#childScope/1"], 1);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button>count: <!></button>";
 const $walks = " Db%l";
@@ -9,17 +20,6 @@ const $setup__script = _script("__tests__/child.marko_0", ($scope) => _on($scope
 const $setup = $setup__script;
 const $input = ($scope, input) => $input_value($scope, input.value);
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-let $load_Child_tag_input_value = /*@__PURE__*/ _load_signal(() => import("./v:child.marko.input_value.mjs"));
-function $setup($scope) {
-	$load_Child_setup($scope);
-	$load_Child_tag_input_value($scope["#childScope/1"], 1);
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-runtime-id/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 83
+      "min": 70,
+      "brotli": 68
     },
     "template.marko.page.mjs": {
-      "min": 407,
-      "brotli": 274
+      "min": 66,
+      "brotli": 69
     },
     "child.mjs": {
-      "min": 137,
-      "brotli": 107
+      "min": 128,
+      "brotli": 104
     },
     "shared": {
-      "min": 4981,
-      "brotli": 2345
+      "min": 2749,
+      "brotli": 1404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// child.marko
-const $template = "<span class=child> </span>";
-const $walks = " D l";
-const $input_value = ($scope, input_value) => _text($scope["#text/1"], input_value);
-const $setup__script = _script("__tests__/child.marko_0", ($scope) => console.log("child connected when script ran:", _el_read($scope["#span/0"]).isConnected));
-const $setup = $setup__script;
-const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
-
 // template.marko
 const $template = "<!><!><!>";
 const $walks = "b%/&c";
@@ -17,6 +8,15 @@ function $setup($scope) {
 	$load_Child_tag_input_value($scope["#childScope/1"], "hi");
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// child.marko
+const $template = "<span class=child> </span>";
+const $walks = " D l";
+const $input_value = ($scope, input_value) => _text($scope["#text/1"], input_value);
+const $setup__script = _script("__tests__/child.marko_0", ($scope) => console.log("child connected when script ran:", _el_read($scope["#span/0"]).isConnected));
+const $setup = $setup__script;
+const $input = ($scope, input) => $input_value($scope, input.value);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-script-runs-after-insert/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 69
+      "min": 75,
+      "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 114,
+      "min": 110,
       "brotli": 95
     },
     "shared": {
-      "min": 4277,
-      "brotli": 2023
+      "min": 1799,
+      "brotli": 951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<div id=ref>0</div>";
 const $walks = "b";
@@ -9,13 +16,6 @@ function $setup($scope) {
 	$promise($scope, Promise.resolve("hello"));
 }
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "b", $setup);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialize-promise/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 69
+      "min": 75,
+      "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 118,
-      "brotli": 89
+      "min": 114,
+      "brotli": 80
     },
     "shared": {
-      "min": 4418,
-      "brotli": 2101
+      "min": 1940,
+      "brotli": 1026
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/__snapshots__/dom.bundle.debug.js
@@ -1,3 +1,10 @@
+// template.marko
+const $template = "<!><!><!>";
+const $walks = "b%/&c";
+let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
+const $setup = $load_Child_setup;
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // child.marko
 const $template = "<button>count: <!></button>";
 const $walks = " Db%l";
@@ -10,13 +17,6 @@ function $setup($scope) {
 	$setup__script($scope);
 }
 var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup);
-
-// template.marko
-const $template = "<!><!><!>";
-const $walks = "b%/&c";
-let $load_Child_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", () => import("./v:child.marko.setup.mjs"));
-const $setup = $load_Child_setup;
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
 
 // v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-serialized-globals/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 83
+      "min": 70,
+      "brotli": 68
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 263
+      "min": 58,
+      "brotli": 59
     },
     "child.mjs": {
-      "min": 150,
-      "brotli": 113
+      "min": 141,
+      "brotli": 110
     },
     "shared": {
-      "min": 4981,
-      "brotli": 2345
+      "min": 2749,
+      "brotli": 1404
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/__snapshots__/dom.bundle.debug.js
@@ -1,12 +1,3 @@
-// tags/child.marko
-const $template = "<span> </span>";
-const $walks = "D l";
-const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
-const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => console.log("loaded"));
-const $setup = $setup__script;
-const $input = ($scope, input) => $input_value($scope, input.value);
-var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", $setup, $input);
-
 // tags/parent-a.marko
 const $template$2 = "<!><!><!>";
 const $walks$2 = "b%/&c";
@@ -39,6 +30,15 @@ function $setup($scope) {
 	$setup$1($scope["#childScope/1"]);
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/child.marko
+const $template = "<span> </span>";
+const $walks = "D l";
+const $input_value = ($scope, input_value) => _text($scope["#text/0"], input_value);
+const $setup__script = _script("__tests__/tags/child.marko_0", ($scope) => console.log("loaded"));
+const $setup = $setup__script;
+const $input = ($scope, input) => $input_value($scope, input.value);
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", $template, "D l", $setup, $input);
 
 // tags/v:child.marko.setup.js
 const _ = [

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/sizes.json
@@ -1,20 +1,20 @@
 {
   "dom": {
     "child.marko.load.mjs": {
-      "min": 79,
-      "brotli": 70
+      "min": 75,
+      "brotli": 69
     },
     "template.marko.page.mjs": {
-      "min": 399,
-      "brotli": 262
+      "min": 58,
+      "brotli": 60
     },
     "child.mjs": {
-      "min": 72,
-      "brotli": 65
+      "min": 68,
+      "brotli": 64
     },
     "shared": {
-      "min": 4277,
-      "brotli": 2023
+      "min": 1799,
+      "brotli": 951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,52 @@
+// inert-a.marko
+const $template$2 = "<!><!><!>";
+const $walks$2 = "b%/&c";
+const $load_LazyPart_trigger = /*@__PURE__*/ _load_visible_trigger("body");
+let $load_LazyPart_setup = /*@__PURE__*/ _load_setup("#text/0", "#childScope/1", /*@__PURE__*/ $load_LazyPart_trigger(() => import("./v:lazy-part.marko.setup.mjs")));
+const $setup$2 = $load_LazyPart_setup;
+var inert_a_default = /*@__PURE__*/ _template("__tests__/inert-a.marko", $template$2, $walks$2, $setup$2);
+
+// inert-b.marko
+const $template$1 = /*@__PURE__*/ ((_w0) => `<section>${_w0}</section>`)($template$3);
+const $walks$1 = /*@__PURE__*/ ((_w0) => `D/${_w0}&l`)($walks$3);
+function $setup$1($scope) {
+	$setup$3($scope["#childScope/0"]);
+}
+var inert_b_default = /*@__PURE__*/ _template("__tests__/inert-b.marko", $template$1, $walks$1, $setup$1);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0, _w1) => `<!>${_w0}${_w1}<!>`)($template$2, $template$1);
+const $walks = /*@__PURE__*/ ((_w0, _w1) => `b/${_w0}&/${_w1}&b`)($walks$2, $walks$1);
+function $setup($scope) {
+	$setup$2($scope["#childScope/0"]);
+	$setup$1($scope["#childScope/1"]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// lazy-part.marko
+const $template = /*@__PURE__*/ ((_w0) => `<div class=lazy>${_w0}</div>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `D/${_w0}&l`)($walks$1);
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+}
+var lazy_part_default = /*@__PURE__*/ _template("__tests__/lazy-part.marko", $template, $walks, $setup);
+
+// shared.marko
+const $template = "<button class=shared>shared:<!></button>";
+const $walks = " Db%l";
+const $n = /*@__PURE__*/ _let("n/2", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/shared.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+var shared_default = /*@__PURE__*/ _template("__tests__/shared.marko", $template, $walks, $setup);
+
+// v:lazy-part.marko.setup.js
+const _ = [
+	$template,
+	$walks,
+	$setup
+];

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// shared.marko
+const $n = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));
+const $setup__script = _script("d0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.c + 1);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,47 @@
+// shared.marko
+var shared_default = _template("__tests__/shared.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=shared>shared:<!>${_escape(n)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/shared.marko_0");
+	writeScope($scope0_id, { n }, "__tests__/shared.marko", 0, { n: "1:6" });
+	_resume_branch($scope0_id);
+});
+
+// lazy-part.marko
+var lazy_part_default = _template("__tests__/lazy-part.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<div class=lazy>");
+	shared_default({});
+	_html("</div>");
+});
+
+// inert-a.marko
+const $LazyPart_withLoadAssets = withLoadAssets(lazy_part_default, "ready:__tests__/lazy-part.marko", [{
+	type: "visible",
+	selector: "body"
+}]);
+var inert_a_default = _template("__tests__/inert-a.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	$LazyPart_withLoadAssets({});
+});
+
+// inert-b.marko
+var inert_b_default = _template("__tests__/inert-b.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_html("<section>");
+	shared_default({});
+	_html("</section>");
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	inert_a_default({});
+	inert_b_default({});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/html.bundle.js
@@ -1,0 +1,47 @@
+// shared.marko
+var shared_default = _template("d", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=shared>shared:<!>${_escape(n)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "d0");
+	writeScope($scope0_id, { c: n });
+	_resume_branch($scope0_id);
+});
+
+// lazy-part.marko
+var lazy_part_default = _template("c", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<div class=lazy>");
+	shared_default({});
+	_html("</div>");
+});
+
+// inert-a.marko
+const $LazyPart_withLoadAssets = withLoadAssets(lazy_part_default, "_c", [{
+	type: "visible",
+	selector: "body"
+}]);
+var inert_a_default = _template("a", (input) => {
+	_scope_reason();
+	_scope_id();
+	$LazyPart_withLoadAssets({});
+});
+
+// inert-b.marko
+var inert_b_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+	_html("<section>");
+	shared_default({});
+	_html("</section>");
+});
+
+// template.marko
+var template_default = _template("e", (input) => {
+	_scope_reason();
+	_scope_id();
+	inert_a_default({});
+	inert_b_default({});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-csr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-csr.debug.md
@@ -1,0 +1,28 @@
+# Render
+```html
+<section>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</section>
+```
+
+# Update
+```js
+(document.querySelector("section .shared"))?.click();
+```
+```html
+<section>
+  <button
+    class="shared"
+  >
+    shared:1
+  </button>
+</section>
+```
+## Change
+```
+UPDATE: .shared::text@7 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,46 @@
+# Render
+```html
+<div
+  class="lazy"
+>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</div>
+<section>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</section>
+```
+
+# Update
+```js
+(document.querySelector("section .shared"))?.click();
+```
+```html
+<div
+  class="lazy"
+>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</div>
+<section>
+  <button
+    class="shared"
+  >
+    shared:1
+  </button>
+</section>
+```
+## Change
+```
+UPDATE: section > button::text@7 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/render-ssr.md
@@ -1,0 +1,46 @@
+# Render
+```html
+<div
+  class="lazy"
+>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</div>
+<section>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</section>
+```
+
+# Update
+```js
+(document.querySelector("section .shared"))?.click();
+```
+```html
+<div
+  class="lazy"
+>
+  <button
+    class="shared"
+  >
+    shared:0
+  </button>
+</div>
+<section>
+  <button
+    class="shared"
+  >
+    shared:1
+  </button>
+</section>
+```
+## Change
+```
+UPDATE: section > button::text@7 "0" => "1"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/writes.debug.html
@@ -1,0 +1,30 @@
+<div class=lazy><button class=shared>shared:<!>
+      0<!--M_*4 #text/1--></button><!--M_*4 #button/0--></div>
+<section><button class=shared>shared:<!>
+      0<!--M_*6 #text/1--></button><!--M_*6 #button/0--></section>
+<script>
+  ((p, h, d, l = $ => {
+    d || p.after(new Range().createContextualFragment(d = h))
+  }) => (e => e && new IntersectionObserver((e, i) => e.some(e => e
+    .isIntersecting) && i.disconnect() + l()).observe(e))(document
+    .querySelector("body") || (console.warn(
+      "A lazy load trigger could not find an element matching \"body\". The module was loaded immediately."
+      ), l())))(document.currentScript,
+    "\x3Cscript async type=module src=\"lazy-part.marko.load.mjs\">\x3C/script>"
+    );
+  WALKER_RUNTIME("M")("_");
+  M._.b = {
+    "ready:packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/lazy-part.marko": [
+      _ => [4, {
+        n: 0
+      }],
+      "packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/shared.marko_0 4"
+    ]
+  };
+  M._.r = [_ => [6, {
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/shared.marko_0 6"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/__snapshots__/writes.html
@@ -1,0 +1,23 @@
+<div class=lazy><button class=shared>shared:<!>
+      0<!--M_*4 b--></button><!--M_*4 a--></div>
+<section><button class=shared>shared:<!>0<!--M_*6 b--></button><!--M_*6 a-->
+</section>
+<script>
+  ((p, h, d, l = $ => {
+    d || p.after(new Range().createContextualFragment(d = h))
+  }) => (e => e && new IntersectionObserver((e, i) => e.some(e => e
+    .isIntersecting) && i.disconnect() + l()).observe(e))(document
+    .querySelector("body") || l()))(document.currentScript,
+    "\x3Cscript async type=module src=\"lazy-part.marko.load.mjs\">\x3C/script>"
+    );
+  WALKER_RUNTIME("M")("_");
+  M._.b = {
+    _c: [_ => [4, {
+      c: 0
+    }], "d0 4"]
+  };
+  M._.r = [_ => [6, {
+    c: 0
+  }], "d0 6"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/inert-a.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/inert-a.marko
@@ -1,0 +1,3 @@
+import LazyPart from "./lazy-part.marko" with { load: "visible body" }
+
+<LazyPart/>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/inert-b.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/inert-b.marko
@@ -1,0 +1,5 @@
+import Shared from "./shared.marko"
+
+<section>
+  <Shared/>
+</section>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/lazy-part.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/lazy-part.marko
@@ -1,0 +1,5 @@
+import Shared from "./shared.marko"
+
+<div.lazy>
+  <Shared/>
+</div>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/shared.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/shared.marko
@@ -1,0 +1,2 @@
+<let/n=0/>
+<button.shared onClick() { n++ }>shared:${n}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/sizes.json
@@ -1,0 +1,24 @@
+{
+  "dom": {
+    "lazy-part.marko.load.mjs": {
+      "min": 74,
+      "brotli": 73
+    },
+    "template.marko.page.mjs": {
+      "min": 79,
+      "brotli": 67
+    },
+    "shared.mjs": {
+      "min": 128,
+      "brotli": 102
+    },
+    "shared": {
+      "min": 2770,
+      "brotli": 1429
+    }
+  },
+  "html": {
+    "min": 826,
+    "brotli": 465
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/template.marko
@@ -1,0 +1,5 @@
+import InertA from "./inert-a.marko"
+import InertB from "./inert-b.marko"
+
+<InertA/>
+<InertB/>

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-with-eager/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+function clickEagerShared(document: Document) {
+  (document.querySelector("section .shared") as HTMLButtonElement)?.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickEagerShared],
+  equivalent: false,
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-multi/__snapshots__/dom.bundle.debug.js
@@ -1,21 +1,3 @@
-// tags/my-box.marko
-const $template$1 = "<div></div>";
-const $walks$1 = " b";
-const $input__OR__extra__script = _script("__tests__/tags/my-box.marko_0_input#2_extra#3", ($scope) => _attrs_script($scope, "#div/0"));
-const $input__OR__extra = /*@__PURE__*/ _or(4, ($scope) => {
-	_attrs_content($scope, "#div/0", {
-		...$scope.input,
-		...$scope.extra
-	});
-	$input__OR__extra__script($scope);
-});
-const $extra = /*@__PURE__*/ _const("extra", $input__OR__extra);
-function $setup$1($scope) {
-	$extra($scope, { id: "x" });
-}
-const $input = /*@__PURE__*/ _const("input", $input__OR__extra);
-var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template$1, " b", $setup$1, $input);
-
 // template.marko
 const $template = $template$1;
 const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)(" b");
@@ -28,3 +10,21 @@ function $setup($scope) {
 	});
 }
 var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
+// tags/my-box.marko
+const $template = "<div></div>";
+const $walks = " b";
+const $input__OR__extra__script = _script("__tests__/tags/my-box.marko_0_input#2_extra#3", ($scope) => _attrs_script($scope, "#div/0"));
+const $input__OR__extra = /*@__PURE__*/ _or(4, ($scope) => {
+	_attrs_content($scope, "#div/0", {
+		...$scope.input,
+		...$scope.extra
+	});
+	$input__OR__extra__script($scope);
+});
+const $extra = /*@__PURE__*/ _const("extra", $input__OR__extra);
+function $setup($scope) {
+	$extra($scope, { id: "x" });
+}
+const $input = /*@__PURE__*/ _const("input", $input__OR__extra);
+var my_box_default = /*@__PURE__*/ _template("__tests__/tags/my-box.marko", $template, " b", $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content/__snapshots__/dom.bundle.debug.js
@@ -1,6 +1,16 @@
+// template.marko
+const $template = $template$1;
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
+const $mydiv_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input($scope["#childScope/0"], { content: $mydiv_content($scope) });
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/my-div.marko
-const $template$1 = "<div></div><button></button><span>Overridden</span><output></output><strong></strong><p></p><em></em>";
-const $walks$1 = " b b b b b b b";
+const $template = "<div></div><button></button><span>Overridden</span><output></output><strong></strong><p></p><em></em>";
+const $walks = " b b b b b b b";
 const $CustomContent_content = _content_resume("__tests__/tags/my-div.marko_1*content", "Custom content");
 const $input__OR__CustomContent_content__script = _script("__tests__/tags/my-div.marko_0_input#8_CustomContent_content#10", ($scope) => _attrs_script($scope, "#p/5"));
 const $input__OR__CustomContent_content = /*@__PURE__*/ _or(11, ($scope) => {
@@ -33,7 +43,7 @@ const $CustomContent = ($scope, CustomContent) => {
 	_attr_content($scope, "#em/6", CustomContent);
 	$CustomContent_content2($scope, CustomContent?.content);
 };
-function $setup$1($scope) {
+function $setup($scope) {
 	_attr_content($scope, "#output/3", undefined);
 	$CustomContent($scope, { content: $CustomContent_content($scope) });
 }
@@ -41,14 +51,4 @@ const $CustomContent_content2 = /*@__PURE__*/ _const("CustomContent_content", ($
 	_attr_content($scope, "#strong/4", $scope.CustomContent_content);
 	$input__OR__CustomContent_content($scope);
 });
-var my_div_default = /*@__PURE__*/ _template("__tests__/tags/my-div.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = $template$1;
-const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&`)($walks$1);
-const $mydiv_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "Hello");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input($scope["#childScope/0"], { content: $mydiv_content($scope) });
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var my_div_default = /*@__PURE__*/ _template("__tests__/tags/my-div.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/server-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/server-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 1469,
-      "brotli": 809
+      "min": 373,
+      "brotli": 250
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/static-content/__snapshots__/dom.bundle.debug.js
@@ -1,16 +1,26 @@
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
+const $outer_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<span>static</span>");
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input_content($scope["#childScope/0"], $outer_content($scope));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+
 // tags/inner.marko
-const $template$2 = "<!><!><!>";
-const $walks$2 = "b%c";
-const $setup$2 = () => {};
+const $template$1 = "<!><!><!>";
+const $walks$1 = "b%c";
+const $setup$1 = () => {};
 const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
 const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
 const $input_content$1 = $dynamicTag;
 const $input$1 = ($scope, input) => $input_content$1($scope, input.content);
-var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$2, "b%c", 0, $input$1);
+var inner_default = /*@__PURE__*/ _template("__tests__/tags/inner.marko", $template$1, "b%c", 0, $input$1);
 
 // tags/outer.marko
-const $template$1 = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$2);
-const $walks$1 = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
+const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)("b%c");
 const $inner_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/1");
 const $inner_content__input_content = /*@__PURE__*/ _closure_get("input_content", ($scope) => $inner_content__dynamicTag($scope, $scope._.input_content));
 const $inner_content__setup__script = _script("__tests__/tags/outer.marko_1", ($scope) => _on($scope["#button/0"], "click", function() {
@@ -21,20 +31,10 @@ const $inner_content__setup = ($scope) => {
 	$inner_content__setup__script($scope);
 };
 const $inner_content = /*@__PURE__*/ _content("__tests__/tags/outer.marko_1*content", "<button>click</button><!><!>", " b%", $inner_content__setup);
-function $setup$1($scope) {
+function $setup($scope) {
 	$input_content_direct($scope["#childScope/0"], $inner_content($scope));
 }
 const $input = ($scope, input) => $input_content($scope, input.content);
 const $input_content__closure = /*@__PURE__*/ _closure($inner_content__input_content);
 const $input_content = /*@__PURE__*/ _const("input_content", $input_content__closure);
-var outer_default = /*@__PURE__*/ _template("__tests__/tags/outer.marko", $template$1, $walks$1, $setup$1, $input);
-
-// template.marko
-const $template = /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1);
-const $walks = /*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1);
-const $outer_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<span>static</span>");
-function $setup($scope) {
-	$setup$1($scope["#childScope/0"]);
-	$input_content($scope["#childScope/0"], $outer_content($scope));
-}
-var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);
+var outer_default = /*@__PURE__*/ _template("__tests__/tags/outer.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/translator/interop/index.ts
+++ b/packages/runtime-tags/src/translator/interop/index.ts
@@ -9,7 +9,17 @@ import { generator } from "@marko/compiler/internal/babel";
 
 import * as translate6 from "..";
 import { resolveRelativeToEntry } from "../util/resolve-relative-to-entry";
+import { getCompatRuntimeFile } from "../util/runtime";
 import { isTagsAPI } from "./feature-detection";
+
+declare module "@marko/compiler/dist/types" {
+  export interface ProgramExtra {
+    /** A Class API template that registers hoisted handlers for Tags resume. */
+    resumesClassFns?: boolean;
+    /** A Class API template whose Tags child revives through the compat runtime. */
+    resumesCompat?: boolean;
+  }
+}
 
 type TagDef = Record<string, unknown>;
 type Taglibs = [taglibId: string, taglib: Record<string, unknown>][];
@@ -50,6 +60,8 @@ export function createInteropTranslator(translate5: any) {
       [kState]?: {
         has5: boolean;
         has6: boolean;
+        needsCompat: boolean;
+        compatFiles: Set<string>;
       };
     };
     const { Program } = visitor;
@@ -88,6 +100,20 @@ export function createInteropTranslator(translate5: any) {
               );
             };
             return [
+              // A Tags template captures the dynamic tag helper at module
+              // scope, so the Class runtime has to patch it in before either
+              // half runs.
+              ...(state.needsCompat
+                ? [
+                    t.importDeclaration(
+                      [],
+                      t.stringLiteral(getCompatRuntimeFile()),
+                    ),
+                  ]
+                : []),
+              ...Array.from(state.compatFiles, (compatFile) =>
+                t.importDeclaration([], t.stringLiteral(compatFile)),
+              ),
               importHydrateProgram(
                 "6",
                 translate6.internalEntryBuilder.build(entryFile, true),
@@ -113,11 +139,13 @@ export function createInteropTranslator(translate5: any) {
       visit(
         file: t.BabelFile,
         entryFile: EntryFile,
-        visitChild: (id: string) => void,
+        visitChild: (id: string, bundled?: boolean) => void,
       ) {
         const state = (entryFile[kState] ||= {
           has5: false,
           has6: false,
+          needsCompat: false,
+          compatFiles: new Set(),
         });
 
         if (isTagsAPI(file)) {
@@ -125,6 +153,15 @@ export function createInteropTranslator(translate5: any) {
           translate6.internalEntryBuilder.visit(file, entryFile, visitChild);
         } else {
           state.has5 = true;
+          if (file.path.node.extra?.resumesCompat) {
+            state.needsCompat = true;
+          }
+          if (file.path.node.extra?.resumesClassFns) {
+            // Its Tags resume registrations run when the module itself loads.
+            state.compatFiles.add(
+              resolveRelativePath(entryFile, file.opts.filename as string),
+            );
+          }
           translate5.internalEntryBuilder.visit(file, entryFile, visitChild);
         }
       },
@@ -143,21 +180,34 @@ export function createInteropTranslator(translate5: any) {
             return enterProgram?.call(this, program, state);
           }
 
-          const visitedFiles = new Set([
-            resolveRelativePath(entryFile, entryFile.opts.filename as string),
+          // Mirrors the Tags builder's own traversal: a file only ever
+          // reached below a bundled template is re-visited if later reached
+          // eagerly. The Class builder omits the flag, so children inherit
+          // how their parent was reached.
+          const visitedFiles = new Map([
+            [
+              resolveRelativePath(entryFile, entryFile.opts.filename as string),
+              false,
+            ],
           ]);
           entryBuilder.visit(
             entryFile,
             entryFile,
-            function visitChild(resolved) {
-              if (!visitedFiles.has(resolved)) {
-                visitedFiles.add(resolved);
-                const file = loadFileForImport(entryFile, resolved);
-                if (file) {
-                  entryBuilder.visit(file, entryFile, (id) =>
-                    visitChild(resolveRelativeToEntry(entryFile, file, id)),
-                  );
-                }
+            function visitChild(resolved: string, bundled = false) {
+              const seenBundled = visitedFiles.get(resolved);
+              if (seenBundled === false || (seenBundled && bundled)) return;
+              visitedFiles.set(resolved, bundled);
+              const file = loadFileForImport(entryFile, resolved);
+              if (file) {
+                entryBuilder.visit(
+                  file,
+                  entryFile,
+                  (id, childBundled = false) =>
+                    visitChild(
+                      resolveRelativeToEntry(entryFile, file, id),
+                      childBundled || bundled,
+                    ),
+                );
               }
             },
           );

--- a/packages/runtime-tags/src/translator/util/entry-builder.ts
+++ b/packages/runtime-tags/src/translator/util/entry-builder.ts
@@ -1,7 +1,9 @@
-import path from "node:path";
-
 import { types as t } from "@marko/compiler";
-import { getTemplateId } from "@marko/compiler/babel-utils";
+import {
+  getTemplateId,
+  loadFileForImport,
+  resolveRelativePath,
+} from "@marko/compiler/babel-utils";
 
 import { resolveRelativeToEntry } from "./resolve-relative-to-entry";
 import type { DOMRuntimeHelpers } from "./runtime";
@@ -11,20 +13,34 @@ declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
     needsCompat?: boolean;
     isInteractive?: boolean;
+    hasClientStatement?: boolean;
     page?: boolean;
   }
 }
 
 interface EntryState {
   init: boolean;
+  load: boolean;
+  /** Depth of enclosing templates whose modules the bundle already loads:
+   * below a root everything arrives through its imports, and a lazy subtree
+   * is loaded by its own load entry. */
+  bundled: number;
+  roots: string[];
+  /** Assets of templates the bundle never loads; the entry imports them. */
   assets: Set<string>;
+  /** Assets that arrive through a bundled template's imports; the entry
+   * imports them itself only when it links nothing (a server only page). */
+  bundledAssets: Set<string>;
+  /** Whether each reached file was only ever seen below a bundled template. */
+  visited: Map<string, boolean>;
 }
 type EntryFile = t.BabelFile & {
   [kState]?: EntryState;
 };
+type VisitChild = (id: string, bundled?: boolean) => void;
 const kState: unique symbol = Symbol();
 
-export default {
+const builder = {
   build(entryFile: EntryFile, exportInit?: boolean) {
     const state = entryFile[kState];
     if (!state) {
@@ -33,30 +49,53 @@ export default {
       );
     }
     const body: t.Statement[] = [];
-    if (state.init) {
+
+    // Client assets (styles, css imports, etc) of a template the bundle does
+    // not link are imported directly, so that static routes still ship them.
+    for (const asset of state.assets) {
+      body.push(t.importDeclaration([], t.stringLiteral(asset)));
+    }
+
+    if (state.init || state.load) {
       const isPage = entryFile.path.node.extra.page;
       const initHelper: DOMRuntimeHelpers = isPage ? "init" : "initEmbedded";
-      // The main entry import below pulls in every template (and their client assets)
-      // transitively, so the collected asset imports are not needed here.
-      body.push(
-        t.importDeclaration(
-          [
-            t.importSpecifier(
-              t.identifier(initHelper),
-              t.identifier(initHelper),
+      if (state.init) {
+        body.push(
+          t.importDeclaration(
+            [
+              t.importSpecifier(
+                t.identifier(initHelper),
+                t.identifier(initHelper),
+              ),
+            ],
+            t.stringLiteral(
+              `${runtimeInfo.name}/${
+                entryFile.markoOpts.optimize ? "" : "debug/"
+              }dom`,
             ),
-          ],
-          t.stringLiteral(
-            `${runtimeInfo.name}/${
-              entryFile.markoOpts.optimize ? "" : "debug/"
-            }dom`,
           ),
-        ),
-        t.importDeclaration(
-          [],
-          t.stringLiteral(`./${path.basename(entryFile.opts.filename)}`),
-        ),
-      );
+        );
+      }
+
+      // The topmost templates with client side work; everything below one of
+      // them (and its client assets) arrives through its imports.
+      for (const root of state.roots) {
+        body.push(t.importDeclaration([], t.stringLiteral(root)));
+      }
+
+      if (!state.init) {
+        // Client statements ran when the modules above loaded; with nothing
+        // to resume there is no runtime to initialize.
+        if (exportInit) {
+          body.push(
+            t.exportDefaultDeclaration(
+              t.arrowFunctionExpression([], t.blockStatement([])),
+            ),
+          );
+        }
+        return body;
+      }
+
       const { runtimeId } = entryFile.markoOpts;
       const readyId =
         !isPage && getTemplateId(entryFile.markoOpts, entryFile.opts.filename);
@@ -79,9 +118,9 @@ export default {
           : t.expressionStatement(initExpression),
       );
     } else {
-      // A server only page has no runtime to initialize, so its client assets must be
-      // linked directly (an interactive page receives them transitively via the main entry import).
-      for (const asset of state.assets) {
+      // A server only page has no runtime to initialize, so nothing loads
+      // the assets of the templates below it either.
+      for (const asset of state.bundledAssets) {
         body.push(t.importDeclaration([], t.stringLiteral(asset)));
       }
 
@@ -93,34 +132,79 @@ export default {
         );
       }
     }
+
     return body;
   },
+  // Recurses into each reachable template once, resolving and loading it; a
+  // file only ever reached below a bundled template is re-visited if later
+  // reached eagerly, since only then can it become a root itself.
+  // The interop entry passes a `visitChild` to dispatch each file itself.
   visit(
     file: t.BabelFile,
     entryFile: EntryFile,
-    visitChild: (id: string) => void,
+    visitChild: VisitChild = (id, bundled = false) => {
+      const state = entryFile[kState]!;
+      const resolved = resolveRelativeToEntry(entryFile, file, id);
+      const seenBundled = state.visited.get(resolved);
+      if (seenBundled === false || (seenBundled && bundled)) return;
+      state.visited.set(resolved, bundled);
+      const childFile = loadFileForImport(entryFile, resolved);
+      if (childFile) builder.visit(childFile, entryFile);
+    },
   ) {
     const state = (entryFile[kState] ||= {
       init: false,
+      load: false,
+      bundled: 0,
+      roots: [],
       assets: new Set(),
+      bundledAssets: new Set(),
+      visited: new Map([
+        [
+          resolveRelativePath(entryFile, entryFile.opts.filename as string),
+          false,
+        ],
+      ]),
     });
     const programExtra = file.path.node.extra;
     const { analyzedTags, assetImports } = file.metadata.marko;
+    const { loadImports } = programExtra;
 
-    if (programExtra.isInteractive || programExtra.needsCompat) {
-      state.init = true;
+    const init = !!(programExtra.isInteractive || programExtra.needsCompat);
+    const load = !!programExtra.hasClientStatement;
+    // The topmost templates with client side work are what the bundle links;
+    // everything below one of them arrives through its imports.
+    const isRoot =
+      !state.bundled && (init || load || !!programExtra.hasResumes);
+
+    if (init) state.init = true;
+    if (load) state.load = true;
+    if (isRoot) {
+      state.roots.push(
+        resolveRelativePath(entryFile, file.opts.filename as string),
+      );
     }
 
-    // Link the template's known client side assets (styles, css imports, etc) into
-    // the page entry so that static routes still ship them; collected during analyze.
+    // Collected during analyze (styles, css imports, etc).
     if (assetImports) {
+      const assets =
+        isRoot || state.bundled ? state.bundledAssets : state.assets;
       for (const request of assetImports) {
-        state.assets.add(resolveRelativeToEntry(entryFile, file, request));
+        assets.add(resolveRelativeToEntry(entryFile, file, request));
       }
     }
 
-    for (const tag of analyzedTags || []) {
-      visitChild(tag);
+    if (isRoot) state.bundled++;
+    // Copied because loading a child appends this file's own `analyzedTags`.
+    for (const tag of analyzedTags ? [...analyzedTags] : []) {
+      // A lazily imported subtree is loaded by its own load entry, never here.
+      const lazy = loadImports?.has(tag);
+      if (lazy) state.bundled++;
+      visitChild(tag, !!state.bundled);
+      if (lazy) state.bundled--;
     }
+    if (isRoot) state.bundled--;
   },
 };
+
+export default builder;

--- a/packages/runtime-tags/src/translator/util/tag-name-type.ts
+++ b/packages/runtime-tags/src/translator/util/tag-name-type.ts
@@ -1,6 +1,7 @@
 import { types as t } from "@marko/compiler";
 import type { MarkoTagExtra } from "@marko/compiler/babel-types";
 import {
+  getProgram,
   getTagDef,
   isNativeTag,
   loadFileForTag,
@@ -13,6 +14,8 @@ import { isCoreTag } from "./is-core-tag";
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
     featureType?: "class" | "tags";
+    /** Set by the Class API translator when Tags content resumes below here. */
+    hydratesTags?: boolean;
   }
   export interface MarkoTagExtra {
     tagNameType?: TagNameType;
@@ -74,6 +77,11 @@ export default function analyzeTagNameType(
         extra.tagNameType = TagNameType.DynamicTag;
         extra.tagNameDynamic = true;
         extra.featureType = "class";
+        // The interop rebuilds this boundary before its Tags descendants can
+        // resume, which is client work of this template's own.
+        if (childFile?.ast.program.extra?.hydratesTags) {
+          getProgram().node.extra!.isInteractive = true;
+        }
       } else if (!childFile) {
         extra.tagNameType = TagNameType.DynamicTag;
         extra.tagNameDynamic = true;

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -22,6 +22,10 @@ import {
 } from "./function";
 
 declare module "@marko/compiler/dist/types" {
+  export interface ProgramExtra {
+    /** Absolute filenames of templates this one imports with `load`. */
+    loadImports?: Set<string>;
+  }
   export interface NodeExtra {
     tagImport?: string;
     loadImport?: LoadImportConfig;
@@ -108,6 +112,12 @@ export default {
           "Unable to resolve marko file for load import.",
         );
       }
+
+      // The page entry links eager templates only; a lazy one arrives through
+      // its own load entry.
+      ((file.path.node.extra.loadImports ??= new Set()) as Set<string>).add(
+        loadFile.opts.filename as string,
+      );
 
       // The compat dynamic tag this child renders through cannot read the load
       // config, so it would reference a binding this import no longer declares.

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -1,12 +1,12 @@
 import { types as t } from "@marko/compiler";
 import {
   getTemplateId,
-  loadFileForImport,
   resolveRelativePath,
 } from "@marko/compiler/babel-utils";
 
 import { hasAnalyzeErrors } from "../../util/analyze-errors";
 import { addAssetImport } from "../../util/asset-imports";
+import { isSectionRendererElided } from "../../util/binding-has-prop";
 import {
   type BindingPropTree,
   getBindingPropTree,
@@ -25,9 +25,12 @@ import {
   finalizeReferences,
   trackParamsReferences,
 } from "../../util/references";
-import { resolveRelativeToEntry } from "../../util/resolve-relative-to-entry";
 import { getCompatRuntimeFile, getRuntimePath } from "../../util/runtime";
-import { startSection } from "../../util/sections";
+import {
+  forEachSection,
+  getSectionRegisterReasons,
+  startSection,
+} from "../../util/sections";
 import { sectionHasSetupStatements } from "../../util/setup-statements";
 import type { TemplateVisitor } from "../../util/visitors";
 import programDOM from "./dom";
@@ -39,6 +42,7 @@ export let localsIdentifier: t.Identifier;
 
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
+    hasResumes?: boolean;
     domExports?: {
       template: string;
       walks: string;
@@ -102,6 +106,20 @@ export default {
       }
 
       const section = programExtra.section!;
+
+      // Anything serialized, and any registered content renderer, is revived
+      // against this module, so it has to reach the client even with no client
+      // statements of its own.
+      forEachSection((childSection) => {
+        programExtra.hasResumes ||= !!(
+          childSection.serializeReason ||
+          childSection.serializeReasons.size ||
+          (childSection !== section &&
+            !isSectionRendererElided(childSection) &&
+            getSectionRegisterReasons(childSection))
+        );
+      });
+
       if (!section.hoistedTo && !sectionHasSetupStatements(section)) {
         // The setup export will be a noop, letting parent templates skip
         // importing and calling it (checked when this template translates).
@@ -176,26 +194,7 @@ export default {
 
         if (isDOMPageEntry) {
           const entryFile = program.hub.file;
-          const { filename } = entryFile.opts;
-          const visitedFiles = new Set([
-            resolveRelativePath(entryFile, filename),
-          ]);
-          entryBuilder.visit(
-            entryFile,
-            entryFile,
-            function visitChild(resolved) {
-              if (!visitedFiles.has(resolved)) {
-                visitedFiles.add(resolved);
-                const file = loadFileForImport(entryFile, resolved);
-                if (file) {
-                  entryBuilder.visit(file, entryFile, (id) =>
-                    visitChild(resolveRelativeToEntry(entryFile, file, id)),
-                  );
-                }
-              }
-            },
-          );
-
+          entryBuilder.visit(entryFile, entryFile);
           program.node.body = entryBuilder.build(entryFile);
           program.skip();
           return;

--- a/packages/runtime-tags/src/translator/visitors/scriptlet.ts
+++ b/packages/runtime-tags/src/translator/visitors/scriptlet.ts
@@ -28,7 +28,9 @@ export default {
     );
 
     if (scriptlet.node.target === "client") {
-      getProgram().node.extra.isInteractive = true;
+      // Client statements run at module load; unlike interactivity they do not
+      // need the resume runtime, only for the page entry to load the module.
+      getProgram().node.extra.hasClientStatement = true;
     }
   },
   translate: {


### PR DESCRIPTION
The Tags API page entry previously imported the root-most template and initialized the resume runtime unconditionally. Now:

- The entry links the **topmost templates with client work** (interactive, static `client {}` statements, or resume registrations) instead of the root-most template, so an inert root/layout stays out of the client bundle; lazy (`with { load }`) subtrees are linked by their own load entries.
- The resume runtime import and `init()` call are emitted only when something actually resumes. A page whose only client code is `client {}` statements just loads its modules.
- Mixed Class/Tags pages get the same treatment: the interop entry links the Tags interactive roots plus what the boundary itself needs — the compat runtime first when a Class template passes revivable content into a Tags child, and the Class modules whose hoisted handlers register for Tags resume — so an inert Class layout wrapping Tags components no longer ships with the Marko 5 runtime.