### PR TITLE
agent-feedback: render abort, serialization edges, and Marko 5 interop

### DIFF
--- a/agent-feedback/items/2026-08-21-abort-a-try-s-catch-boundary-when-the.md
+++ b/agent-feedback/items/2026-08-21-abort-a-try-s-catch-boundary-when-the.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-tags/src/html/writer.ts › tryCatch
+---
+
+# Abort a `<try>`'s catch boundary when the render is aborted
+
+`tryCatch` builds `new Boundary(state, undefined, boundary)`, so a `<try>` that has a `<@catch>` gets a child boundary that never subscribes to anything and `Boundary.abort` never walks children. `_await` gates its body on `!boundary.signal.aborted`, and for an `<await>` inside such a `<try>` that boundary is the catch boundary, which no abort ever reaches — so after the consumer gives up, every pending region in the page keeps rendering into a stream nobody reads. Aborting a 3-region page 50 ms after the shell flush still ran the bodies at +315 ms, +1116 ms and +2616 ms, while the same page with no `<try>`, or with a `<try>` carrying only a `<@placeholder>` (which forks on the parent boundary), stops immediately; both `$global.signal` and the async iterator's `return()` behave the same way. The parent's signal cannot just be forwarded, because `catchBoundary.signal.aborted` doubles as "the body threw" and would render `<@catch>` on a disconnect; the reorder flush already walks `boundary.parent` for an aborted ancestor, and `_await` can make the same walk before `chunk.render`.
+
+Check: render three `<try><await|v|=deferred><@catch>` regions to an async iterator and abort `$global.signal` 50 ms after the first chunk — all three bodies still execute today; expect none to execute after the abort, which is already what happens when the `<@catch>` is removed.

--- a/agent-feedback/items/2026-08-21-cache-a-taglib-only-after-its-json-parses.md
+++ b/agent-feedback/items/2026-08-21-cache-a-taglib-only-after-its-json-parses.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/compiler/src/taglib/loader/loadTaglibFromFile.js › loadFromFile
+---
+
+# Cache a taglib only after its JSON parses; today a fixed `marko-tag.json` never reloads
+
+`loadFromFile` runs `cache.put(filePath, taglib)` before `jsonFileReader.readFileSync(filePath)`, so a malformed `marko-tag.json` leaves an empty `Taglib` in the module-level cache. The parse error surfaces once; every later lookup in the same process takes the `if (!taglib)` early exit and returns that empty taglib with no error at all, so the tag silently stops existing and the consuming template reports `Unable to find entry point for custom tag <legacy-panel>` — pointing at the file that used the tag rather than the file that is broken. Repairing the JSON does not clear it: only `taglib.clearCaches()` does, which is why a dev server has to be restarted after a taglib typo and why the symptom outlives its cause. Move the `cache.put` after `loadTaglibFromProps` succeeds (or key the entry on mtime/content so a repaired file re-reads), and carry the parse position into the message — `json-file-reader.js` already attaches `Expected ',' or '}' after property value in JSON at position 52 (line 1 column 53)` as `cause` while `Unable to parse JSON file at path "…"` says none of it.
+
+Check: with a malformed `marko-tag.json`, `loader.loadTaglibFromFile(f)` throws `Unable to parse JSON file at path "…"`; rewrite the file to valid JSON and call it again in the same process — it returns a taglib whose `tags` keys are `[]`, and only returns `["legacy-panel"]` after `taglib.clearCaches()`. Expect the second call to return the tag.

--- a/agent-feedback/items/2026-08-21-flush-a-synchronous-page-incrementally-instead-of-buffering.md
+++ b/agent-feedback/items/2026-08-21-flush-a-synchronous-page-incrementally-instead-of-buffering.md
@@ -1,0 +1,12 @@
+---
+type: perf
+impact: high
+effort: high
+site: packages/runtime-tags/src/html/template.ts › ServerRendered.#read
+---
+
+# Flush a synchronous page incrementally instead of buffering the whole response
+
+`render` runs `head.render(this, input)` to completion before it constructs the `ServerRendered`, so `#read` only ever sees a finished buffer and a page with no async boundary does not stream at all. `<for|i| to=input.rows><p>row ${i}</p></for>` at 500,000 rows produces an 8,388,907-byte response in exactly one `write`, at 84 ms, so TTFB equals total time, and the string buffer holds 55.0 MB — 6.9x the response — before a byte leaves. It is linear: 2,000,000 rows gives 34,888,908 bytes, still one chunk, 226.7 MB retained, 6.8x. That multiple is per in-flight request, so an abandoned connection on such a page parks it for the life of the socket, and the event loop is blocked for the whole render. The machinery is already there for the async case — an `<await>` page flushes in two chunks with a 0 ms first chunk — so what is missing is a yield point in a synchronous body, e.g. a size threshold in the `Chunk` writer that hands the accumulated HTML to the consumer mid-render.
+
+Check: `template.render({ rows: 500000 }).pipe(sink)` on `<for|i| to=input.rows><p>row ${i}</p></for>` counts `chunks=1` with `ttfb === total === 84ms` and 55.0 MB of heap retained after `render()` returns, against an 8.4 MB response; expect a first chunk in single-digit ms and a high-water mark that does not scale with the response.

--- a/agent-feedback/items/2026-08-21-isolate-a-throwing-onmount-and-name-the.md
+++ b/agent-feedback/items/2026-08-21-isolate-a-throwing-onmount-and-name-the.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-class/src/node_modules/@internal/components-registry/index-browser.js › initClientRendered
+---
+
+# Isolate a throwing `onMount` and name the component that threw
+
+`initClientRendered` runs `for (i = len; i--;) initComponent(componentDef, host)` with no guard, and `initComponent` ends in `component.___emitMount()`, which calls the user's `onMount`. The loop deliberately walks backwards so nested components initialize before their ancestors, so one throwing `onMount` leaves every ancestor uninitialized and `this.emit(...)` from anywhere on the page stops reaching a parent's `on<Event>("method")` binding — while the DOM listeners attached earlier in `initComponent` keep working, so the page looks alive and only the custom-event wiring is dead. The stock way to trip it is `onMount() { this.el = this.getEl("readout") }`: `el` is a getter on `componentProto`, the assignment throws `Cannot set property el of #<Component> which has only a getter`, and that sentence is the entire diagnostic — no component, no template, no frame. Wrap the `initComponent` call so the loop continues and report the failure with `component.___type`, the template path `getComponentClass` already pins on the prototype.
+
+Check: two sibling Class components under a parent listening with `onChange("handler")`/`onAdd("handler")`, one of them assigning `this.el` in `onMount` — today the parent's event log stays empty for both children and the console shows only `Cannot set property el of #<Component> which has only a getter`; expect the sibling's events to still arrive and the error to name the offending template.

--- a/agent-feedback/items/2026-08-21-keep-a-getter-a-getter-when-a-let.md
+++ b/agent-feedback/items/2026-08-21-keep-a-getter-a-getter-when-a-let.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-tags/src/translator/util/signals.ts › replaceRegisteredFunctionNode
+---
+
+# Keep a getter a getter when a `<let>` object literal is serialized
+
+`replaceRegisteredFunctionNode`'s `ObjectMethod` case rebuilds every accessor as `t.objectProperty(node.key, replacement, node.computed)`, dropping `node.kind`. So a getter inside a serialized `<let>` stops being an accessor on the server: `<let/state={ get computed() { return 42 } }/>` compiles to `{ computed: _resume(function () { return 42 }, …) }` and `${typeof state.computed}` renders `function`, not `number`. The same object in a `<const>` nothing in the browser reads renders `number`, so whether a getter stays a getter depends on who else touches the value. A getter/setter pair is worse: `{ _v: 1, get v() { return this._v * 10 }, set v(n) { this._v = n } }` emits two `v:` properties and the setter wins, so `${o.v}` renders the setter's source. Identical in debug and optimize output, with no diagnostic. `references.ts` already distinguishes the kinds ("Accessor bodies run when the property is observed"), so either preserve the accessor when rebuilding or refuse to register one and report it.
+
+Check: `pnpm run compile -- -o html -d` on `<let/state={ get computed() { return 42 } }/><div>${typeof state.computed}</div>` emits `computed: _resume(function () { return 42; }, …)` and the render prints `function`; the same file with `<const>` prints `number`. Expect both to print `number`.

--- a/agent-feedback/items/2026-08-21-name-the-state-a-throwing-getter-was-serializing.md
+++ b/agent-feedback/items/2026-08-21-name-the-state-a-throwing-getter-was-serializing.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/runtime-tags/src/html/serializer.ts › writeObjectProps
+---
+
+# Name the state a throwing getter was serializing instead of letting the throw escape bare
+
+`writeObjectProps` reads each own enumerable key as `val[key]`, so a getter on any value that reaches the browser is invoked during serialization. When it throws, nothing catches it: a `<let>` holding `{ get bad() { throw new Error("x") } }` fails the render with `Error: x`, a stack that starts in the author's getter and continues into `writeObjectProps`, and none of the context `throwUnserializable` builds — the same slot holding a plain class instance reports `Unable to serialize "state" in …/template.marko:1:6. Values referenced in the browser must be serializable.` So the one failure with a user-authored callee is the one that names neither the state variable nor the file, and the reader hunts for a caller that is the runtime. Wrap the property read and hand the thrown value to `throwUnserializable` as `cause`, which reuses the existing accessor walk. The non-throwing case wants a line at the site as well: the getter runs exactly once and the client receives a frozen data property, so a value that recomputes per read on the server never recomputes on the client.
+
+Check: render a template whose `<let>` holds `input.obj`, read only from a handler, with `input.obj = { get bad() { throw new Error("x") } }`. Today the render throws `Error: x` out of `writeObjectProps` with no file, line or state name, while `input.obj = new (class {})()` throws `Unable to serialize "state" in …:1:6`; expect the getter throw to carry the same location and be reported as the cause.

--- a/agent-feedback/items/2026-08-21-point-the-json-stringify-attribute-deprecation-at-the.md
+++ b/agent-feedback/items/2026-08-21-point-the-json-stringify-attribute-deprecation-at-the.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: packages/runtime-class/src/runtime/html/helpers/attr.js › nonVoidAttr
+---
+
+# Point the `JSON.stringify` attribute deprecation at the template, not at `attrs.js`
+
+The `complain(…, { locationIndex: 2 })` that fires for an object attribute value is calibrated for `attr()` called straight from a compiled template, and every spread adds a frame: `<div data-direct=obj>` reports `at src/pages/probe/template.marko:24:45`, but `<div ...spread>` in the same file reports `at node_modules/marko/src/runtime/html/helpers/attrs.js:12:19`, and the stock `vite-express-marko-5` example's first `GET /` reports `at node_modules/marko/src/runtime/html/helpers/merge-attrs.js:47:21`. A deprecation whose only frame is inside `marko` cannot be traced to a template or an attribute, and the spread path is exactly where object-valued attributes come from (`app-button`/`app-checkbox` in that example both forward `...attrs`), so a first-party example warns out of the box with nothing to act on. Either derive the index from the caller or raise the complaint from `attrs`/`mergeAttrs`, where the extra frame is known.
+
+Check: with `SHOW_MODULE_COMPLAINS=1`, render a page holding both `<div data-direct=obj>` and `<div ...spread>` where both values are objects — the first warning names the `.marko` file and the second names `helpers/attrs.js`; expect both to name the template.

--- a/agent-feedback/items/2026-08-21-register-a-const-defined-function-a-class-api.md
+++ b/agent-feedback/items/2026-08-21-register-a-const-defined-function-a-class-api.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-tags/src/translator/visitors/function.ts › finalizeFunctionRegistry
+---
+
+# Register a `<const>`-defined function a Class API child's handler closes over
+
+A Tags parent that declares `<const/log = (s) => s * 2/>` and passes `onCount(newCount) { count = log(newCount) }` to a Class API child fails SSR with `TypeError: Unable to serialize "log" in …/template.marko:1:8`. Two controls isolate it: the identical template with a Tags child renders, and inlining the body into the handler renders. The compiled output shows why — with a Tags child the declaration becomes `const log = _resume((s) => s * 2, "…/log")`, a registered function the serializer can write, while through the interop path (`_dynamic_tag` onto the Class renderer) it stays a bare `const log = (s) => s * 2` even though `writeScope($scope0_id, { log }, …)` still lists the binding. So the serialize-reason analysis and the function-registration analysis disagree about one binding, and the error names neither the interop boundary nor `<const>`. `resolveSerializeReason` needs the class-child attribute reference to count the way the tags-child one already does.
+
+Check: an interop fixture whose Tags parent holds `<const/log = (s) => s * 2/>` and passes `onCount(newCount) { count = log(newCount) }` to a `components/class-counter.marko` Class child fails its `ssr` step with `Unable to serialize "log"`, while the same fixture pointed at a Tags child passes every step; expect both to pass.

--- a/agent-feedback/items/2026-08-21-reject-a-tag-body-on-marko-5-s.md
+++ b/agent-feedback/items/2026-08-21-reject-a-tag-body-on-marko-5-s.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-class/src/translator/taglib/core/translate-await.js › enter
+---
+
+# Reject a tag body on Marko 5's `<await>` instead of dropping it
+
+`enter` checks only the argument count, so the Marko 6 spelling `<await(promise)|v|><span>${v}</span></await>` compiles clean in a Class API file into `renderTag(_await, { _provider, _name, renderBody: (out, v) => … })`. `core-tags/core/await/renderer.js` renders `input.then.renderBody`, `input.catch.renderBody` and `input.placeholder.renderBody` and never the tag's own `renderBody`, so the body and its parameter are discarded: the region is empty in the response, the status is 200 and nothing is logged, while the correct `<@then|v|>` form beside it in the same template renders. This is the exact edit a migration makes, and it is the one direction that goes quiet — the Tags API rejects the same source with `Tag does not support arguments. Write the promise as a value attribute and receive the result as a tag parameter instead`. `enter` already walks the tag; have it throw a code-frame error naming `<@then|result|>` when `<await>` carries a body or params.
+
+Check: compile and render `<await(Promise.resolve("x"))|v|><span>${v}</span></await>` in a Class API template — the emitted region is empty today with no diagnostic; expect a compile error pointing at `<@then>`.

--- a/agent-feedback/items/2026-08-21-say-in-marko-5-s-shipped-docs-that.md
+++ b/agent-feedback/items/2026-08-21-say-in-marko-5-s-shipped-docs-that.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: packages/runtime-class/docs/getting-started.md › Setup
+---
+
+# Say in `marko@5`'s shipped docs that Marko 6 exists
+
+`docs` is in the package's `files`, so every `marko@5` install carries 35 pages of offline manual, and `grep -rli 'marko 6\|tags api' packages/runtime-class/docs/ packages/runtime-class/README.md` matches none of them — nothing states that Marko 5 is in maintenance, even though the same `package.json` already depends on `@marko/runtime-tags@^6.3.44`. `getting-started.md` is worse than silent: its recommended setup is `npm init marko -- -t basic`, which resolves to `create-marko@6.3.0` and scaffolds a Tags API app, and the rest of the same page then teaches `class {}` components and `on-` attributes that the scaffold does not use. The only migration page is `marko-5-upgrade.md`, which is Marko 4 → 5 and opens by warning `Do not run npm install marko (without the @^4)`, so a reader on 5.39.36 who searches for "upgrade" is routed backwards. Add a maintenance note and a link to the 5 → 6 interop guide on the index and on `getting-started.md`, and say which major `npm init marko` produces.
+
+Check: `grep -rli 'marko 6\|tags api' packages/runtime-class/docs/` prints nothing while `npm view create-marko version` prints `6.3.0`; expect the index and `getting-started.md` to name the current major and link the 5 → 6 guide.

--- a/agent-feedback/items/2026-08-21-say-in-the-cheatsheet-that-html-script-and-html-style.md
+++ b/agent-feedback/items/2026-08-21-say-in-the-cheatsheet-that-html-script-and-html-style.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: packages/runtime-tags/cheatsheet.md › Golden rules
+---
+
+# Say in the cheatsheet that `<html-script>`/`<html-style>` escape only the closing tag
+
+`grep -in 'escap\|xss\|html-script\|nonce\|csp' packages/runtime-tags/cheatsheet.md` matches nothing, so the offline reference an agent is told to open never mentions escaping, the `$!{...}` raw form, the two raw-text core tags, or CSP. What escaping exists guards the element boundary and nothing else: `html/content.ts` rewrites only `</script`, `<script` and `<!--` for `_escape_script` and only `</style` for `_escape_style`. So `<html-script>const cfg = { user: "${name}" }</html-script>` with `name` = `";globalThis.codePwn=1;//` renders JavaScript that runs, and the CSS analogue closes the rule and opens another, while `</SCRIPT>` in the same slot is correctly neutralised — partial escaping that reads as total. The website says "never interpolate untrusted input into `<script>`, escaping notwithstanding"; the in-repo reference should carry the same golden rule, since it is the one a contributor working offline actually has.
+
+Check: `grep -in 'escap\|xss\|html-script\|nonce\|csp' packages/runtime-tags/cheatsheet.md` exits 1 with no output; expect a Golden-rules line naming `<html-script>`/`<html-style>`, stating that only their closing tag is escaped and that an interpolation inside them is executed as code.

--- a/agent-feedback/items/2026-08-21-serialize-a-regexp-whose-source-contains-a-less.md
+++ b/agent-feedback/items/2026-08-21-serialize-a-regexp-whose-source-contains-a-less.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-tags/src/html/serializer.ts › writeRegExp
+---
+
+# Serialize a `RegExp` whose source contains `<` without breaking regexp syntax
+
+`writeRegExp` emits the source inside a regexp literal and `replaceUnsafeRegExpSourceChar` rewrites every `<` as `\x3C`. That escape stands for the character `<` but not for regexp _syntax_, so a named group or a lookbehind is destroyed: `/(?<name>a)/` ships as `/(?\x3Cname>a)/`, which the browser rejects with `SyntaxError: Invalid regular expression: Invalid group` while parsing the resume script — the whole `M._.r=[…]` payload fails to parse, nothing hydrates and no handler binds, on a page the server returned as a clean 200. `/(?<=a)b/` and `/(?<!a)b/` fail the same way, and every other `<` silently changes the round-tripped value, since `/a<b/` arrives with `.source === "a\\x3Cb"`. Emitting `new RegExp(<quoted source>, <flags>)` when the source contains `<` keeps `quote`'s existing script-safe escaping and restores the source exactly; `serializer.test.ts › regexp` covers `<` but has no group or lookbehind case to pin it.
+
+Check: `new Serializer().stringifyScopes([[1, {}, { value: /(?<name>a)/ }]])` returns `_=>[1,{value:/(?\x3Cname>a)/}]` and `eval("/(?\\x3Cname>a)/")` throws `SyntaxError: Invalid regular expression: /(?\x3Cname>a)/: Invalid group`; expect a payload that evaluates back to a RegExp whose `.source` is `(?<name>a)`.

--- a/agent-feedback/items/2026-08-21-suppress-a-did-you-mean-that-repeats-the.md
+++ b/agent-feedback/items/2026-08-21-suppress-a-did-you-mean-that-repeats-the.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts › tagNotFoundError
+---
+
+# Suppress a did-you-mean that repeats the tag name that just failed
+
+`tagNotFoundError` accepts any `closest` match with `distance(tagName, closestTag) < 4`, and 0 is under 4, so a tag that is present in the taglib but has no resolvable entry point suggests itself: a `marko.json` declaring `"<my-thing>"` with no template makes `<my-thing/>` report ``Unable to find entry point for [custom tag](…) `<my-thing>`. Did you mean `<my-thing>`?`` A suggestion identical to the input reads as a compiler malfunction and sends the reader looking for a typo instead of a missing renderer, and it is not exotic — the open item on `resolveMarkoFile` records the same shape for a relative child template that fails to parse. Case-only misses land in the same branch from the other side: `<DIV>x</DIV>` is edit distance 3 from both `div` and `a`, `closest` returns `a`, and the message never mentions that tag names are case-sensitive. Require `distance > 0`, and prefer a case-insensitive exact match over edit distance so an uppercase native tag is told what is actually wrong.
+
+Check: with `marko.json` holding `{ "<my-thing>": { "attributes": { "*": "string" } } }`, `pnpm run compile -- -o html -d` on `<my-thing/>` prints ``Did you mean `<my-thing>`?`` and on `<DIV>x</DIV>` prints ``Did you mean `<a>`?``; expect the first suggestion dropped and the second replaced by a case-sensitivity note naming `<div>`.

--- a/agent-feedback/items/2026-08-21-translate-babel-s-parseexpression-messages-before-they-reach.md
+++ b/agent-feedback/items/2026-08-21-translate-babel-s-parseexpression-messages-before-they-reach.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: med
+site: packages/compiler/src/babel-utils/parse.js › tryParse
+---
+
+# Translate Babel's `parseExpression()` messages before they reach a Marko diagnostic
+
+`tryParse` hands `err.message` from `babelParseExpression` straight to `createParseError`, so Babel's internal API name and its framing become the entire Marko diagnostic for two ordinary mistakes. `<const/x=/* pre */ 1 /* post */>` reports `Unexpected parseExpression() input: The input is empty or contains only comments.` with the caret beside the `1` — describing the opposite of what is on the line, because the attribute value ends at the first `*/` and `1` is then scanned as the next attribute name, which is the fact worth saying. `<div class="a"id="b"/>` reports `Unexpected parseExpression() input: The input should contain exactly one expression, but the first expression is followed by the unexpected character \`i\`.` when the fix is a space between two attributes. Both are reachable from valid-looking source and neither message mentions attributes at all. Classify the two Babel messages at this relay — the surrounding tag diagnostics already write in Marko's own vocabulary and link the docs.
+
+Check: `pnpm run compile -- -o html -d` on `<const/x=/* pre */ 1 /* post */>` and on `<div class="a"id="b"/>` prints the two `Unexpected parseExpression() input:` messages above; expect one naming the comment that terminated the attribute value and one naming the missing whitespace between attributes, with no Babel API name in either.


### PR DESCRIPTION
Fourteen new items.

Serialization: a getter stops being a getter once a `<let>` object literal is serialized, a `RegExp` whose source contains `<` breaks regexp syntax, and a getter that throws escapes without naming the state it was serializing. Rendering: a `<try>` catch boundary outlives an aborted render, a synchronous page is buffered rather than flushed incrementally, and a throwing `onMount` is not isolated to its own component.

Marko 5 interop: a `<const>`-defined function a Class API child closes over is never registered, a tag body on Marko 5's `<await>` is dropped silently, and `marko@5`'s shipped docs do not mention that Marko 6 exists. The rest are diagnostic quality, including a deprecation warning that points at `attrs.js` rather than the template and untranslated Babel `parseExpression()` messages.
