### PR TITLE
fix(runtime-tags): give control flow its own marker under a custom tag shadowing a native name

### DIFF
--- a/.changeset/only-child-shadowed-native-tag.md
+++ b/.changeset/only-child-shadowed-native-tag.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `<if>`/`<for>` as the only child of a custom tag whose name shadows a native element (eg `tags/menu.marko`) borrowing that tag's node marker; the content crashed when re-rendered on the client because the marker lives in the parent's scope.

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,47 @@
+// tags/menu.marko
+const $template$1 = "<button> </button><!><!>";
+const $walks$1 = " D l%c";
+const $if_content2__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $if_content2__input_content = /*@__PURE__*/ _closure_get("input_content", ($scope) => $if_content2__dynamicTag($scope, $scope._._.input_content), ($scope) => $scope._._);
+const $if_content2__setup = $if_content2__input_content;
+const $if_content__if = /*@__PURE__*/ _if("#text/0", "<!><!><!>", "b%", $if_content2__setup);
+const $if_content__input_content = /*@__PURE__*/ _if_closure("#text/2", 0, ($scope) => $if_content__if($scope, $scope._.input_content ? 0 : 1));
+const $if_content__setup = $if_content__input_content;
+const $if = /*@__PURE__*/ _if("#text/2", "<!><!><!>", "b%", $if_content__setup);
+const $open = /*@__PURE__*/ _let("open/6", ($scope) => {
+	_text($scope["#text/1"], $scope.open ? "collapse" : "expand");
+	$if($scope, $scope.open ? 0 : 1);
+});
+const $setup__script = _script("__tests__/tags/menu.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$open($scope, !$scope.open);
+}));
+function $setup$1($scope) {
+	$open($scope, true);
+	$setup__script($scope);
+}
+const $input = ($scope, input) => $input_content($scope, input.content);
+const $input_content__closure = /*@__PURE__*/ _closure($if_content2__input_content);
+const $input_content = /*@__PURE__*/ _const("input_content", ($scope) => {
+	$if_content__input_content($scope);
+	$input_content__closure($scope);
+});
+var menu_default = /*@__PURE__*/ _template("__tests__/tags/menu.marko", $template$1, $walks$1, $setup$1, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => `/${_w0}&b`)($walks$1);
+const PEOPLE = [
+	"alice",
+	"bob",
+	"carol"
+];
+const $for_content__person = ($scope, person) => _text($scope["#text/0"], person);
+const $for_content__$params = ($scope, $params2) => $for_content__person($scope, $params2[0]);
+const $menu_content__for = /*@__PURE__*/ _for_of("#text/0", "<div>person: <!></div>", "Db%", 0, $for_content__$params);
+const $menu_content__setup = ($scope) => $menu_content__for($scope, [PEOPLE]);
+const $menu_content = _content_resume("__tests__/template.marko_1*content", "<!><!><!>", "b%", $menu_content__setup);
+function $setup($scope) {
+	$setup$1($scope["#childScope/0"]);
+	$input_content($scope["#childScope/0"], $menu_content($scope));
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/dom.bundle.js
@@ -1,0 +1,25 @@
+// tags/menu.marko
+const $if_content2__dynamicTag = /*@__PURE__*/ _dynamic_tag(0);
+const $if_content2__input_content = /*@__PURE__*/ _closure_get(7, ($scope) => $if_content2__dynamicTag($scope, $scope._._.f), ($scope) => $scope._._);
+const $if_content__if = /*@__PURE__*/ _if(0, "<!><!><!>", "b%", $if_content2__input_content);
+const $if_content__input_content = /*@__PURE__*/ _if_closure(2, 0, ($scope) => $if_content__if($scope, $scope._.f ? 0 : 1));
+const $if = /*@__PURE__*/ _if(2, "<!><!><!>", "b%", $if_content__input_content);
+const $open = /*@__PURE__*/ _let(6, ($scope) => {
+	_text($scope.b, $scope.g ? "collapse" : "expand");
+	$if($scope, $scope.g ? 0 : 1);
+});
+const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$open($scope, !$scope.g);
+}));
+
+// template.marko
+const PEOPLE = [
+	"alice",
+	"bob",
+	"carol"
+];
+const $for_content__person = ($scope, person) => _text($scope.a, person);
+const $for_content__$params = ($scope, $params2) => $for_content__person($scope, $params2[0]);
+const $menu_content__for = /*@__PURE__*/ _for_of(0, "<div>person: <!></div>", "Db%", 0, $for_content__$params);
+const $menu_content__setup = ($scope) => $menu_content__for($scope, [PEOPLE]);
+const $menu_content = _content_resume("a0", "<!><!><!>", "b%", $menu_content__setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,52 @@
+// tags/menu.marko
+var menu_default = _template("__tests__/tags/menu.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0), $si__input_content = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const $input_content__closures = new Set();
+	let open = true;
+	_html(`<button>${open ? "collapse" : "expand"}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_if(() => {
+		if (open) {
+			const $scope1_id = _scope_id();
+			_if(() => {
+				if (input.content) {
+					const $scope2_id = _scope_id();
+					_dynamic_tag($scope2_id, "#text/0", input.content, {}, 0, 0, $sg__input_content);
+					_subscribe($si__input_content && $input_content__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/tags/menu.marko", "6:4"));
+					return 0;
+				}
+			}, $scope1_id, "#text/0", $sg__input_content, $sg__input_content, $sg__input_content);
+			writeScope($scope1_id, {}, "__tests__/tags/menu.marko", "5:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/2");
+	_script($scope0_id, "__tests__/tags/menu.marko_0");
+	writeScope($scope0_id, {
+		input_content: input.content,
+		open,
+		"ClosureScopes:input_content": $si__input_content && $input_content__closures
+	}, "__tests__/tags/menu.marko", 0, {
+		input_content: ["input.content"],
+		open: "1:6"
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+const PEOPLE = [
+	"alice",
+	"bob",
+	"carol"
+];
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	menu_default({ content: _content_resume("__tests__/template.marko_1*content", () => {
+		_scope_reason();
+		const $scope1_id = _scope_id();
+		forOf(PEOPLE, (person) => {
+			const $scope2_id = _scope_id();
+			_html(`<div>person: ${_escape(person)}</div>`);
+		});
+	}, $scope0_id) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/html.bundle.js
@@ -1,0 +1,48 @@
+// tags/menu.marko
+var menu_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0), $si__input_content = _serialize_if($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	const $input_content__closures = /* @__PURE__ */ new Set();
+	let open = true;
+	_html(`<button>collapse${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}`);
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			_if(() => {
+				if (input.content) {
+					const $scope2_id = _scope_id();
+					_dynamic_tag($scope2_id, "a", input.content, {}, 0, 0, $sg__input_content);
+					_subscribe($si__input_content && $input_content__closures, writeScope($scope2_id, { _: _scope_with_id($scope1_id) }));
+					return 0;
+				}
+			}, $scope1_id, "a", $sg__input_content, $sg__input_content, $sg__input_content);
+			writeScope($scope1_id, {});
+			return 0;
+		}
+	}, $scope0_id, "c");
+	_script($scope0_id, "b0");
+	writeScope($scope0_id, {
+		f: input.content,
+		g: open,
+		h: $si__input_content && $input_content__closures
+	});
+	_resume_branch($scope0_id);
+});
+
+// template.marko
+const PEOPLE = [
+	"alice",
+	"bob",
+	"carol"
+];
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	menu_default({ content: _content_resume("a0", () => {
+		_scope_reason();
+		_scope_id();
+		forOf(PEOPLE, (person) => {
+			_scope_id();
+			_html(`<div>person: ${_escape(person)}</div>`);
+		});
+	}, _scope_id()) });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/render.debug.md
@@ -1,0 +1,75 @@
+# Render
+```html
+<button>
+  collapse
+</button>
+<div>
+  person: alice
+</div>
+<div>
+  person: bob
+</div>
+<div>
+  person: carol
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  expand
+</button>
+```
+## Change
+```
+UPDATE: button::text "collapse" => "expand"
+REMOVE: button + div
+REMOVE: button + div
+REMOVE: button + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  collapse
+</button>
+<div>
+  person: alice
+</div>
+<div>
+  person: bob
+</div>
+<div>
+  person: carol
+</div>
+```
+## Change
+```
+UPDATE: button::text "expand" => "collapse"
+INSERT: button + div
+INSERT: div:nth-of-type(1) + div
+INSERT: div:nth-of-type(2) + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  expand
+</button>
+```
+## Change
+```
+UPDATE: button::text "collapse" => "expand"
+REMOVE: button + div
+REMOVE: button + div
+REMOVE: button + div
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/render.md
@@ -1,0 +1,75 @@
+# Render
+```html
+<button>
+  collapse
+</button>
+<div>
+  person: alice
+</div>
+<div>
+  person: bob
+</div>
+<div>
+  person: carol
+</div>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  expand
+</button>
+```
+## Change
+```
+UPDATE: button::text "collapse" => "expand"
+REMOVE: button + div
+REMOVE: button + div
+REMOVE: button + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  collapse
+</button>
+<div>
+  person: alice
+</div>
+<div>
+  person: bob
+</div>
+<div>
+  person: carol
+</div>
+```
+## Change
+```
+UPDATE: button::text "expand" => "collapse"
+INSERT: button + div
+INSERT: div:nth-of-type(1) + div
+INSERT: div:nth-of-type(2) + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  expand
+</button>
+```
+## Change
+```
+UPDATE: button::text "collapse" => "expand"
+REMOVE: button + div
+REMOVE: button + div
+REMOVE: button + div
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/writes.debug.html
@@ -1,0 +1,18 @@
+<button>collapse<!--M_*2 #text/1--></button><!--M_*2 #button/0--><!--M_[-->
+<div>person: alice</div>
+<div>person: bob</div>
+<div>person: carol</div><!--M_]2 #text/2 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      input_content: _(1,
+        "packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/template.marko_1*content"
+        ),
+      open: !0
+    }, 1, {
+      _: _(3)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/tags/menu.marko_0 2"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<button>collapse<!--M_*2 b--></button><!--M_*2 a--><!--M_[-->
+<div>person: alice</div>
+<div>person: bob</div>
+<div>person: carol</div><!--M_]2 c 3-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    f: _(1, "a0"),
+    g: !0
+  }, 1, {
+    _: _(3)
+  }], "b0 2"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 10691,
+        "brotli": 4656
+      },
+      "files": {
+        "tags/menu.marko": 809,
+        "template.marko": 531
+      }
+    }
+  },
+  "html": {
+    "min": 478,
+    "brotli": 304
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/tags/menu.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/tags/menu.marko
@@ -1,0 +1,9 @@
+<let/open=true>
+
+<button onClick() { open = !open; }>${open ? "collapse" : "expand"}</button>
+
+<if=open>
+  <if=input.content>
+    <${input.content} />
+  </if>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/template.marko
@@ -1,0 +1,7 @@
+static const PEOPLE = ["alice", "bob", "carol"];
+
+<menu>
+  <for|person| of=PEOPLE>
+    <div>person: ${person}</div>
+  </for>
+</menu>

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-content-for-closure/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click, click, click],
+};

--- a/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
+++ b/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
@@ -1,5 +1,5 @@
 import { types as t } from "@marko/compiler";
-import { getTagDef } from "@marko/compiler/babel-utils";
+import { isNativeTag } from "@marko/compiler/babel-utils";
 
 import { kNativeTagBinding } from "../visitors/tag/native-tag";
 import { getParentTag } from "./get-parent-tag";
@@ -27,7 +27,7 @@ export function getOnlyChildParentTagName(
   const parentTag = getParentTag(tag);
   return (extra[kOnlyChildInParent] =
     parentTag &&
-    getTagDef(parentTag)?.html &&
+    isNativeTag(parentTag) &&
     parentTag.node.name.type === "StringLiteral" &&
     (tag.parent as t.MarkoTagBody).body.filter(
       (node) => node.type !== "MarkoComment",


### PR DESCRIPTION
A `<for>` or `<if>` that is the only child of a tag reuses that tag's node marker instead of adding its own, but the check for "native parent" only looked at the tag def's `html` flag. A custom tag whose name shadows a native element (e.g. `tags/menu.marko`) keeps that flag, so its body content was compiled against the parent template's `#menu/0` marker. The content renders inside the custom tag's own scope, where that node does not exist, so re-rendering it on the client (here: collapsing and re-expanding the menu) threw on `undefined.nodeType`.

The check now uses the compiler's `isNativeTag`, which also requires the def to have no template or renderer, so the control flow gets its own marker. Covered by a fixture that toggles the menu three times through SSR+resume and CSR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WrxZS9X6gXPFHFP14bzfvo