### PR TITLE
refactor(runtime-tags): use analyzeTagNameType for the only-child native parent check

### DIFF
--- a/agent-feedback/items/2026-08-26-text-only-check-ignores-shadowing-custom-tag.md
+++ b/agent-feedback/items/2026-08-26-text-only-check-ignores-shadowing-custom-tag.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-tags/src/translator/util/is-non-html-text.ts › isTextOnlyNativeTag
+---
+
+# Gate the text-only check on the tag actually being native
+
+`isTextOnlyNativeTag` decides from `tagDef.html` alone, but a custom tag whose name shadows a native element (`tags/title.marko`, `script`, `style`, `textarea`) keeps that flag on its def. `isNonHTMLText` then tells the text and placeholder visitors to skip the body, so `<title>hello ${name}</title>` compiles to a custom-tag call with no content at all. The same class of bug was fixed for the only-child marker in `is-only-child-in-parent.ts`; apply the same gate here (`analyzeTagNameType(tag) === TagNameType.NativeTag`) before reading the def, keeping the null-def guard for `<${"span"}/>`-style names. Guard fixture: `tags/title.marko` rendering `<${input.content}/>` plus a `<let>` toggled through the shadowed `<title>` body across SSR+resume and CSR.
+
+Check: with `tags/title.marko` beside it, `pnpm run compile -- -o dom -d template.marko` on `<title>hello ${input.name}</title>` emits `_title_input_text($scope["#childScope/0"])` with no content argument and no `_text` for the placeholder.

--- a/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
+++ b/packages/runtime-tags/src/translator/util/is-only-child-in-parent.ts
@@ -1,10 +1,10 @@
 import { types as t } from "@marko/compiler";
-import { isNativeTag } from "@marko/compiler/babel-utils";
 
 import { kNativeTagBinding } from "../visitors/tag/native-tag";
 import { getParentTag } from "./get-parent-tag";
 import { type Binding, BindingType, createBinding } from "./references";
 import type { Section } from "./sections";
+import analyzeTagNameType, { TagNameType } from "./tag-name-type";
 
 const kOnlyChildInParent = Symbol("only child in parent");
 const kNodeRef = Symbol("potential only child node ref");
@@ -27,7 +27,7 @@ export function getOnlyChildParentTagName(
   const parentTag = getParentTag(tag);
   return (extra[kOnlyChildInParent] =
     parentTag &&
-    isNativeTag(parentTag) &&
+    analyzeTagNameType(parentTag) === TagNameType.NativeTag &&
     parentTag.node.name.type === "StringLiteral" &&
     (tag.parent as t.MarkoTagBody).body.filter(
       (node) => node.type !== "MarkoComment",


### PR DESCRIPTION
Follow-up to #4058. The only-child marker check now asks `analyzeTagNameType` whether the parent is native, the same cached question `if`/`show`/`sections` and the tag visitor ask, instead of the compiler's `isNativeTag`. For the string-literal names this check already requires the two agree, so output is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013U6uCLLHvcCNqeRNc7gbCp