### PR TITLE
fix(runtime-class): don't inject class on-x events into a dynamic Class child's input

### DIFF
--- a/.changeset/class-dynamic-tag-event-leak.md
+++ b/.changeset/class-dynamic-tag-event-leak.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Only fold a Class parent's `on-x(...)` bindings into a dynamic tag child's input when the child is a Tags API component. Class API children rendered through a dynamic tag were also receiving the injected `onX` handler, which leaked into the DOM as a serialized `on-click="function () {...}"` attribute when the child spread its input onto a native element.

--- a/agent-feedback/items/2026-08-26-move-class-event-bridging-out-of-the-core-dynamic-tag.md
+++ b/agent-feedback/items/2026-08-26-move-class-event-bridging-out-of-the-core-dynamic-tag.md
@@ -1,0 +1,12 @@
+---
+type: perf
+impact: med
+effort: med
+site: packages/runtime-class/src/runtime/helpers/dynamic-tag.js › addTagsEvents
+---
+
+# Move Class event bridging out of the core dynamic-tag helper into tags-compat
+
+`addTagsEvents`, `bindTagsEventHandler`, and `CLASS_EVENT_MARKER` exist only to bridge a Class parent's `on-x(...)` bindings to Tags API children, which are always reached through the wrapper `___runtimeCompat` creates. Yet they live in `dynamic-tag.js`, so every Marko 5 app that uses a dynamic tag bundles them — including pure Class API apps that can never hit the path (the call site guards with `renderer === classRenderer`). Passing `componentDef`/`customEvents` into `___runtimeCompat` and folding events inside the tags-compat wrappers (`tagsToVdom` in `tags-compat/runtime-dom.js` and `runtime-html.js`) removes ~65 lines from the core helper, drops the identity guard, and lets each side keep only its own branch of the `IS_SERVER` conditional; `CLASS_EVENT_MARKER` moves into the two compat files (both ends of the wire format). A prototype of this shape measured ~215 min / ~70 brotli bytes smaller even for interop bundles (e.g. `interop-basic-class-to-tags` sizes.json), with the whole bridge deleted from Class-only bundles.
+
+Check: `grep -n 'addTagsEvents\|bindTagsEventHandler\|CLASS_EVENT_MARKER' packages/runtime-class/src/runtime/helpers/dynamic-tag.js` shows the bridge in the shared helper while its only trigger (`renderer !== classRenderer`) requires tags-compat's `___runtimeCompat` wrapper; `pnpm test -- --grep "interop-event"` covers the behavior a move must preserve.

--- a/packages/runtime-class/src/runtime/helpers/dynamic-tag.js
+++ b/packages/runtime-class/src/runtime/helpers/dynamic-tag.js
@@ -83,6 +83,7 @@ module.exports = function dynamicTag(
         }
       }
 
+      var classRenderer = renderer;
       if (dynamicTag.___runtimeCompat) {
         renderer = dynamicTag.___runtimeCompat(
           renderer,
@@ -94,7 +95,12 @@ module.exports = function dynamicTag(
 
       if (renderer) {
         out.c(componentDef, key, customEvents);
-        renderer(addTagsEvents(attrs, componentDef, customEvents), out);
+        renderer(
+          renderer === classRenderer
+            ? attrs
+            : addTagsEvents(attrs, componentDef, customEvents),
+          out,
+        );
         out.___assignedComponentDef = null;
       } else {
         var isFn = typeof render === "function";

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/custom-tag-parameters-from-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 55522,
-        "brotli": 17639
+        "min": 55532,
+        "brotli": 17663
       },
       "files": {
         "components/custom-tag.marko": 626,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/error-serialize-promise-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64360,
-        "brotli": 20113
+        "min": 64372,
+        "brotli": 20114
       },
       "files": {
         "components/tags-child.marko": 499,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-await-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 66697,
-        "brotli": 20953
+        "min": 66710,
+        "brotli": 20984
       },
       "files": {
         "components/tags-child.marko": 624,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64591,
-        "brotli": 20167
+        "min": 64603,
+        "brotli": 20165
       },
       "files": {
         "components/tags-counter.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-basic-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63831,
-        "brotli": 19894
+        "min": 63843,
+        "brotli": 19913
       },
       "files": {
         "components/class-counter.marko": 1028,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-camel-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63691,
-        "brotli": 19837
+        "min": 63703,
+        "brotli": 19836
       },
       "files": {
         "components/class-widget.marko": 973,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-class-to-tags-import/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64591,
-        "brotli": 20167
+        "min": 64603,
+        "brotli": 20165
       },
       "files": {
         "components/tags-counter.marko": 682,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-duplicate-class-tag-registration/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63871,
-        "brotli": 19902
+        "min": 63883,
+        "brotli": 19869
       },
       "files": {
         "components/class-counter.marko": 1031,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64489,
-        "brotli": 20140
+        "min": 64501,
+        "brotli": 20151
       },
       "files": {
         "components/tags-child.marko": 510,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-dynamic-tag-conditional-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64530,
-        "brotli": 20140
+        "min": 64542,
+        "brotli": 20144
       },
       "files": {
         "components/tags-child.marko": 510,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-inline-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63795,
-        "brotli": 19847
+        "min": 63807,
+        "brotli": 19853
       },
       "files": {
         "components/inline-button.marko": 1094,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-emit-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63914,
-        "brotli": 19898
+        "min": 63925,
+        "brotli": 19938
       },
       "files": {
         "components/split-button/component-browser.js": 373,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-through-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64593,
-        "brotli": 20102
+        "min": 64604,
+        "brotli": 20128
       },
       "files": {
         "components/class-child.marko": 975,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,59 @@
+// components/class-child/component.js
+var require_component = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		emitClick() {
+			this.emit("click");
+		}
+	};
+}));
+
+// components/class-child/index.marko
+var import_vdom = require_vdom();
+var import_merge_attrs = /* @__PURE__ */ __toESM(require_merge_attrs());
+var import_component = /* @__PURE__ */ __toESM(require_component());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType$1 = "__tests__/components/class-child/index.marko", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+(0, import_registry.r)(_marko_componentType$1, () => _marko_template$1);
+const _marko_component2 = import_component.default;
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	const { renderBody, ...attrs } = input;
+	out.be("button", (0, import_merge_attrs.default)({ "id": "child" }, attrs), "0", _component, null, 4, { "onclick": _componentDef.d("click", "emitClick", false) });
+	out.t("child", _component);
+	out.ee();
+}, {
+	t: _marko_componentType$1,
+	d: true
+}, _marko_component2);
+_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component2, _marko_template$1._);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { clicked: 0 };
+	},
+	handleClick() {
+		this.state.clicked++;
+	},
+	getChild() {
+		return _marko_template$1;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", { "id": "count" }, "0", _component, null, 1);
+	out.t(state.clicked, _component);
+	out.ee();
+	(0, import_dynamic_tag.default)(out, _component.getChild(), null, null, null, null, _componentDef, "1", [[
+		"click",
+		"handleClick",
+		false
+	]]);
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/dom.bundle.js
@@ -1,0 +1,54 @@
+// components/class-child/component.js
+var require_component = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		emitClick() {
+			this.emit("click");
+		}
+	};
+}));
+
+// components/class-child/index.marko
+var import_components = require_components();
+var import_vdom = require_vdom();
+var import_merge_attrs = /* @__PURE__ */ __toESM(require_merge_attrs());
+var import_component = /* @__PURE__ */ __toESM(require_component());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+var import_registry = require_registry();
+var import_defineComponent = /* @__PURE__ */ __toESM(require_defineComponent());
+const _marko_componentType$1 = "b", _marko_template$1 = (0, import_vdom.t)(_marko_componentType$1);
+(0, import_registry.r)(_marko_componentType$1, () => _marko_template$1);
+const _marko_component2 = import_component.default;
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	const { renderBody, ...attrs } = input;
+	out.be("button", (0, import_merge_attrs.default)({ "id": "child" }, attrs), "0", _component, null, 4, { "onclick": _componentDef.d("click", "emitClick", false) });
+	out.t("child", _component);
+	out.ee();
+}, { t: _marko_componentType$1 }, _marko_component2);
+_marko_template$1.Component = (0, import_defineComponent.default)(_marko_component2, _marko_template$1._);
+
+// template.marko
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+const _marko_componentType = "a", _marko_template = (0, import_vdom.t)(_marko_componentType);
+(0, import_registry.r)(_marko_componentType, () => _marko_template);
+const _marko_component = {
+	onCreate() {
+		this.state = { clicked: 0 };
+	},
+	handleClick() {
+		this.state.clicked++;
+	},
+	getChild() {
+		return _marko_template$1;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.be("div", { "id": "count" }, "0", _component, null, 1);
+	out.t(state.clicked, _component);
+	out.ee();
+	(0, import_dynamic_tag.default)(out, _component.getChild(), null, null, null, null, _componentDef, "1", [[
+		"click",
+		"handleClick",
+		false
+	]]);
+}, { t: _marko_componentType }, _marko_component);
+_marko_template.Component = (0, import_defineComponent.default)(_marko_component, _marko_template._);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,57 @@
+// components/class-child/component.js
+var require_component = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		emitClick() {
+			this.emit("click");
+		}
+	};
+}));
+
+// components/class-child/index.marko
+var import_html = require_html();
+var import_merge_attrs = /* @__PURE__ */ __toESM(require_merge_attrs());
+var import_component = /* @__PURE__ */ __toESM(require_component());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType$1 = "__tests__/components/class-child/index.marko", _marko_template$1 = (0, import_html.t)(_marko_componentType$1);
+const _marko_component2 = import_component.default;
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	const { renderBody, ...attrs } = input;
+	out.w(`<button${(0, import_merge_attrs.default)({ "id": "child" }, attrs)}>`);
+	out.w("child");
+	out.w("</button>");
+}, {
+	t: _marko_componentType$1,
+	d: true
+}, _marko_component2);
+
+// template.marko
+var import_escape_xml = require_escape_xml();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+const _marko_componentType = "__tests__/template.marko", _marko_template = (0, import_html.t)(_marko_componentType);
+const _marko_component = {
+	onCreate() {
+		this.state = { clicked: 0 };
+	},
+	handleClick() {
+		this.state.clicked++;
+	},
+	getChild() {
+		return _marko_template$1;
+	}
+};
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w("<div id=count>");
+	out.w((0, import_escape_xml.x)(state.clicked));
+	out.w("</div>");
+	(0, import_dynamic_tag.default)(out, _component.getChild(), null, null, null, null, _componentDef, "1", [[
+		"click",
+		"handleClick",
+		false
+	]]);
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, {
+	t: _marko_componentType,
+	d: true
+}, _marko_component);

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/html.bundle.js
@@ -1,0 +1,45 @@
+// components/class-child/component.js
+var require_component = /* @__PURE__ */ __commonJSMin(((exports, module) => {
+	module.exports = class {
+		emitClick() {
+			this.emit("click");
+		}
+	};
+}));
+
+// components/class-child/index.marko
+var import_html = require_html();
+var import_merge_attrs = /* @__PURE__ */ __toESM(require_merge_attrs());
+var import_component = /* @__PURE__ */ __toESM(require_component());
+var import_renderer = /* @__PURE__ */ __toESM(require_renderer());
+const _marko_componentType$1 = "b", _marko_template$1 = (0, import_html.t)(_marko_componentType$1);
+_marko_template$1._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	const { renderBody, ...attrs } = input;
+	out.w(`<button${(0, import_merge_attrs.default)({ "id": "child" }, attrs)}>child</button>`);
+}, { t: _marko_componentType$1 }, import_component.default);
+
+// template.marko
+var import_escape_xml = require_escape_xml();
+var import_dynamic_tag = /* @__PURE__ */ __toESM(require_dynamic_tag());
+var import_init_components_tag = /* @__PURE__ */ __toESM(require_init_components_tag());
+var import_render_tag = /* @__PURE__ */ __toESM(require_render_tag());
+const _marko_componentType = "a", _marko_template = (0, import_html.t)(_marko_componentType);
+_marko_template._ = (0, import_renderer.default)(function(input, out, _componentDef, _component, state, $global) {
+	out.w(`<div id=count>${(0, import_escape_xml.x)(state.clicked)}</div>`);
+	(0, import_dynamic_tag.default)(out, _component.getChild(), null, null, null, null, _componentDef, "1", [[
+		"click",
+		"handleClick",
+		false
+	]]);
+	(0, import_render_tag.default)(import_init_components_tag.default, {}, out, _componentDef, "2");
+}, { t: _marko_componentType }, {
+	onCreate() {
+		this.state = { clicked: 0 };
+	},
+	handleClick() {
+		this.state.clicked++;
+	},
+	getChild() {
+		return _marko_template$1;
+	}
+});

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/render.debug.md
@@ -1,0 +1,55 @@
+# Render
+```html
+<div
+  id="count"
+>
+  0
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+
+# Update
+```js
+(document.querySelector("#child")).click();
+```
+```html
+<div
+  id="count"
+>
+  1
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+## Change
+```
+UPDATE: #count::text "0" => "1"
+```
+
+# Update
+```js
+(document.querySelector("#child")).click();
+```
+```html
+<div
+  id="count"
+>
+  2
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+## Change
+```
+UPDATE: #count::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/render.md
@@ -1,0 +1,55 @@
+# Render
+```html
+<div
+  id="count"
+>
+  0
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+
+# Update
+```js
+(document.querySelector("#child")).click();
+```
+```html
+<div
+  id="count"
+>
+  1
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+## Change
+```
+UPDATE: #count::text "0" => "1"
+```
+
+# Update
+```js
+(document.querySelector("#child")).click();
+```
+```html
+<div
+  id="count"
+>
+  2
+</div>
+<button
+  id="child"
+>
+  child
+</button>
+```
+## Change
+```
+UPDATE: #count::text "1" => "2"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<!--M#s0-->
+<div id=count>0</div><button id=child>child</button><!--M/-->
+<script>
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": [
+      "packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/template.marko"
+    ]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<!--M#s0-->
+<div id=count>0</div><button id=child>child</button><!--M/-->
+<script>
+  $MC = (window.$MC || []).concat({
+    "w": [
+      ["s0", 0, {}, {
+        "f": 1
+      }]
+    ],
+    "t": ["a"]
+  })
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/components/class-child/component.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/components/class-child/component.js
@@ -1,0 +1,5 @@
+module.exports = class {
+  emitClick() {
+    this.emit("click");
+  }
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/components/class-child/index.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/components/class-child/index.marko
@@ -1,0 +1,2 @@
+$ const { renderBody, ...attrs } = input;
+<button id="child" ...attrs on-click("emitClick")>child</button>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/sizes.json
@@ -1,0 +1,19 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 51909,
+        "brotli": 15456
+      },
+      "files": {
+        "components/class-child/component.js": 215,
+        "components/class-child/index.marko": 1219,
+        "template.marko": 968
+      }
+    }
+  },
+  "html": {
+    "min": 155,
+    "brotli": 111
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/template.marko
@@ -1,0 +1,15 @@
+import childTemplate from "./components/class-child/index.marko";
+class {
+  onCreate() {
+    this.state = { clicked: 0 };
+  }
+  handleClick() {
+    this.state.clicked++;
+  }
+  getChild() {
+    return childTemplate;
+  }
+}
+<div id="count">${state.clicked}</div>
+<${component.getChild()} on-click("handleClick")/>
+<init-components/>

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-dynamic-class/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function clickChild(document: Document) {
+  (document.querySelector("#child") as HTMLButtonElement).click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickChild, clickChild],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64642,
-        "brotli": 20185
+        "min": 64654,
+        "brotli": 20181
       },
       "files": {
         "components/tags-pinger.marko": 659,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64114,
-        "brotli": 20052
+        "min": 64126,
+        "brotli": 20042
       },
       "files": {
         "components/my-button.marko": 1048,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64800,
-        "brotli": 20256
+        "min": 64812,
+        "brotli": 20266
       },
       "files": {
         "components/tags-pinger.marko": 659,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-inline-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 65242,
-        "brotli": 20357
+        "min": 65252,
+        "brotli": 20350
       },
       "files": {
         "components/tags-pinger.marko": 736,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-split-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 55685,
-        "brotli": 17687
+        "min": 55697,
+        "brotli": 17689
       },
       "files": {
         "components/tags-pinger.marko": 272,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63747,
-        "brotli": 19807
+        "min": 63758,
+        "brotli": 19824
       },
       "files": {
         "components/class-layout.marko": 1202,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-events-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63740,
-        "brotli": 19817
+        "min": 63752,
+        "brotli": 19859
       },
       "files": {
         "components/class-counter.marko": 1043,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-inert-class-with-stateful-tags-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64247,
-        "brotli": 20053
+        "min": 64259,
+        "brotli": 20046
       },
       "files": {
         "tags/tags-counter.marko": 499,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-boundary-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64044,
-        "brotli": 19961
+        "min": 64056,
+        "brotli": 19966
       },
       "files": {
         "components/split-counter/component-browser.js": 317,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-mixed-inert-and-stateful-tags-to-class/sizes.json
@@ -2,7 +2,7 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63831,
+        "min": 63843,
         "brotli": 19904
       },
       "files": {

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-attr-tags-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64896,
-        "brotli": 20335
+        "min": 64908,
+        "brotli": 20324
       },
       "files": {
         "components/tags-layout.marko": 839,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64568,
-        "brotli": 20133
+        "min": 64580,
+        "brotli": 20178
       },
       "files": {
         "components/tags-layout.marko": 697,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-nested-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64269,
-        "brotli": 20088
+        "min": 64281,
+        "brotli": 20091
       },
       "files": {
         "components/class-layout.marko": 1227,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-reactive-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63773,
-        "brotli": 19850
+        "min": 63785,
+        "brotli": 19844
       },
       "files": {
         "components/split-display/component-browser.js": 182,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-rerender-inert-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63442,
-        "brotli": 19713
+        "min": 63454,
+        "brotli": 19774
       },
       "files": {
         "components/class-display.marko": 856,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-roundtrip-split-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63922,
-        "brotli": 19923
+        "min": 63934,
+        "brotli": 19954
       },
       "files": {
         "components/split-counter/component-browser.js": 228,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-stateless-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63548,
-        "brotli": 19757
+        "min": 63558,
+        "brotli": 19684
       },
       "files": {
         "components/my-button/component-browser.js": 457,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-class-to-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64950,
-        "brotli": 20343
+        "min": 64962,
+        "brotli": 20359
       },
       "files": {
         "components/tags-layout.marko": 913,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tag-params-tags-to-class/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 64635,
-        "brotli": 20267
+        "min": 64647,
+        "brotli": 20230
       },
       "files": {
         "components/class-layout.marko": 1245,

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-tags-to-resumed-class-rerender/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 63946,
-        "brotli": 19976
+        "min": 63958,
+        "brotli": 19916
       },
       "files": {
         "components/message.marko": 835,


### PR DESCRIPTION
Since 5.39.17 (#3399), the dynamic tag helper folded a Class parent's `on-x(...)` bindings into the child's input unconditionally. That bridge is only meant for Tags API children — Class API children already receive these events through `out.c(...)` — so a Class child rendered through a dynamic tag got an extra injected `onX` handler in its input. Components that spread their input onto a native element (a common attribute pass-through pattern) then serialized the wrapper function into the DOM as `onclick="function () {...}"` (or the `$C_e` marker array on the server).

The folding is now gated on `___runtimeCompat` actually wrapping the renderer, which only happens for genuine Tags API children; Class children go back to receiving events solely through the component event channel.

Adds an interop fixture covering a Class parent binding `on-click` on a runtime-dynamic Class child that spreads its input; before the fix it renders the serialized handler attribute (and clicking throws in jsdom), after it the event still fires through the component event channel. Also files an agent-feedback item suggesting the event-bridge machinery move from the core helper into tags-compat for a bundle-size win.

🤖 Generated with [Claude Code](https://claude.com/claude-code)