### PR TITLE
fix(runtime-tags): register tag vars before setup calls so synchronous returns reach later tags

### DIFF
--- a/.changeset/register-tag-var-before-setup.md
+++ b/.changeset/register-tag-var-before-setup.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a custom tag's returned value not reaching a later tag's variable in the browser when an earlier tag returns synchronously during setup (eg `<child/value/>` feeding `<Wrapper/wrapped=value/>`).

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-instance-switch/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-content-instance-switch/__snapshots__/dom.bundle.debug.js
@@ -30,9 +30,9 @@ const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($sc
 }));
 function $setup($scope) {
 	_var($scope, "#childScope/0", $a);
+	_var($scope, "#childScope/2", $b);
 	$setup$1($scope["#childScope/0"]);
 	$input_n($scope["#childScope/0"], 1);
-	_var($scope, "#childScope/2", $b);
 	$setup$1($scope["#childScope/2"]);
 	$input_n($scope["#childScope/2"], 2);
 	$sel($scope, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope-calls-only/__snapshots__/dom.bundle.debug.js
@@ -29,8 +29,8 @@ const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&0${_w1}&`)("", " b");
 const $api_getter = /*@__PURE__*/ _hoist("api");
 const $setup__script = _script("__tests__/template.marko_0", ($scope) => $api_getter($scope)().setHtml("works"));
 function $setup($scope) {
-	$input($scope["#childScope/0"], { action: $action($scope) });
 	_var($scope, "#childScope/1", $api);
+	$input($scope["#childScope/0"], { action: $action($scope) });
 	$setup$1($scope["#childScope/1"]);
 	$setup__script($scope);
 }

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-custom-tag-var-same-scope/__snapshots__/dom.bundle.debug.js
@@ -22,8 +22,8 @@ const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)("", $template$1);
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&0${_w1}&`)("", " b");
 const $setHtml_getter = _hoist_resume("__tests__/template.marko_0_setHtml#3/hoist", "setHtml");
 function $setup($scope) {
-	$input_value($scope["#childScope/0"], $setHtml_getter($scope));
 	_var($scope, "#childScope/1", $setHtml);
+	$input_value($scope["#childScope/0"], $setHtml_getter($scope));
 	$setup$1($scope["#childScope/1"]);
 }
 const $setHtml = /*@__PURE__*/ _const("setHtml", ($scope) => _assert_hoist($scope.setHtml));

--- a/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/hoist-return-ref/__snapshots__/dom.bundle.debug.js
@@ -23,8 +23,8 @@ const $template = /*@__PURE__*/ ((_w0, _w1) => `${_w0}${_w1}`)($template$2, "");
 const $walks = /*@__PURE__*/ ((_w0, _w1) => `/${_w0}&0${_w1}&`)(" b", "");
 const $x_getter = _hoist_resume("__tests__/template.marko_0_x#3/hoist", "x");
 function $setup($scope) {
-	$input($scope["#childScope/0"], { y: $x_getter($scope) });
 	_var($scope, "#childScope/1", $x);
+	$input($scope["#childScope/0"], { y: $x_getter($scope) });
 	$setup$1($scope["#childScope/1"]);
 }
 const $x = /*@__PURE__*/ _const("x", ($scope) => _assert_hoist($scope.x));

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/dom.bundle.debug.js
@@ -15,8 +15,8 @@ const $walks = /*@__PURE__*/ ((_w0, _w1) => `D0${_w0}& lD0${_w1}& l`)(" b", " b"
 const $divName = _var_resume("__tests__/template.marko_0_divName#6/var", ($scope, divName) => _text($scope["#text/2"], divName));
 function $setup($scope) {
 	_var($scope, "#childScope/0", $divName);
-	$setup$1($scope["#childScope/0"]);
 	_var($scope, "#childScope/3", $spanName);
+	$setup$1($scope["#childScope/0"]);
 	$setup$1($scope["#childScope/3"]);
 }
 const $spanName = _var_resume("__tests__/template.marko_0_spanName#7/var", ($scope, spanName) => _text($scope["#text/5"], spanName));

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,31 @@
+// tags/child.marko
+const $template$1 = "";
+const $walks$1 = "";
+function $setup$1($scope) {
+	_return($scope, "foo");
+}
+var child_default = /*@__PURE__*/ _template("__tests__/tags/child.marko", "", "", $setup$1);
+
+// template.marko
+const $template = "<button>Toggle</button><!><!>";
+const $walks = " b%c";
+const $if_content__value = ($scope, value) => $Wrapper_content__input_value($scope["#childScope/2"], value);
+const $if_content__setup = ($scope) => {
+	_var($scope, "#childScope/0", $if_content__value);
+	_var($scope, "#childScope/2", $if_content__wrapped);
+	$setup$1($scope["#childScope/0"]);
+};
+const $if_content__wrapped = _var_resume("__tests__/template.marko_2_wrapped#6/var", ($scope, wrapped) => _text($scope["#text/4"], wrapped));
+const $Wrapper_content__input_value = /*@__PURE__*/ _const("input_value", ($scope) => _return($scope, $scope.input_value));
+const $Wrapper_content__$params = ($scope, $params2) => $Wrapper_content__input($scope, $params2[0]);
+const $Wrapper_content__input = ($scope, input) => $Wrapper_content__input_value($scope, input.value);
+const $if = /*@__PURE__*/ _if("#text/1", /*@__PURE__*/ ((_w0) => `<!>${_w0}<div>Value: <!></div>`)(""), /*@__PURE__*/ ((_w0) => `b0${_w0}&0&Db%l`)(""), $if_content__setup);
+const $open = /*@__PURE__*/ _let("open/2", ($scope) => $if($scope, $scope.open ? 0 : 1));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$open($scope, !$scope.open);
+}));
+function $setup($scope) {
+	$open($scope, false);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/dom.bundle.js
@@ -1,0 +1,19 @@
+// tags/child.marko
+function $setup($scope) {
+	_return($scope, "foo");
+}
+
+// template.marko
+const $if_content__value = ($scope, value) => $Wrapper_content__input_value($scope.c, value);
+const $if_content__setup = ($scope) => {
+	_var($scope, 0, $if_content__value);
+	_var($scope, 2, $if_content__wrapped);
+	$setup($scope.a);
+};
+const $if_content__wrapped = _var_resume("a1", ($scope, wrapped) => _text($scope.e, wrapped));
+const $Wrapper_content__input_value = /*@__PURE__*/ _const(2, ($scope) => _return($scope, $scope.c));
+const $if = /*@__PURE__*/ _if(1, /*@__PURE__*/ ((_w0) => `<!>${_w0}<div>Value: <!></div>`)(""), /*@__PURE__*/ ((_w0) => `b0${_w0}&0&Db%l`)(""), $if_content__setup);
+const $open = /*@__PURE__*/ _let(2, ($scope) => $if($scope, $scope.c ? 0 : 1));
+const $setup__script = _script("a2", ($scope) => _on($scope.a, "click", function() {
+	$open($scope, !$scope.c);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,36 @@
+// tags/child.marko
+var child_default = _template("__tests__/tags/child.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $return = "foo";
+	return $return;
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const Wrapper = { content: _content("__tests__/template.marko_1*content", (input) => {
+		const $scope1_id = _scope_id();
+		const $scope1_reason = _scope_reason();
+		const $return = input.value;
+		return $return;
+	}, $scope0_id) };
+	let open = false;
+	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/0")}`);
+	_if(() => {
+		if (open) {
+			const $scope2_id = _scope_id();
+			let value = child_default({});
+			const $childScope = _peek_scope_id();
+			let wrapped = Wrapper.content({ value });
+			_var($scope2_id, "#scopeOffset/3", $childScope, "__tests__/template.marko_2_wrapped#6/var");
+			_html(`<div>Value: ${_sep()}${_escape(wrapped)}${_el_resume($scope2_id, "#text/4")}</div>`);
+			writeScope($scope2_id, { "#childScope/2": _existing_scope($childScope) }, "__tests__/template.marko", "7:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/1");
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, { open }, "__tests__/template.marko", 0, { open: "5:6" });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/html.bundle.js
@@ -1,0 +1,23 @@
+// tags/child.marko
+var child_default = _template("b", (input) => {
+	_scope_reason();
+	_scope_id();
+	return "foo";
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	_content("a0", (input) => {
+		_scope_id();
+		_scope_reason();
+		return input.value;
+	}, $scope0_id);
+	let open = false;
+	_html(`<button>Toggle</button>${_el_resume($scope0_id, "a")}`);
+	_if(() => {}, $scope0_id, "b");
+	_script($scope0_id, "a2");
+	writeScope($scope0_id, { c: open });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/render.debug.md
@@ -1,0 +1,56 @@
+# Render
+```html
+<button>
+  Toggle
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+<div>
+  Value: foo
+</div>
+```
+## Change
+```
+INSERT: button + div
+UPDATE: div::text@7 "" => "foo"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+```
+## Change
+```
+REMOVE: button + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+<div>
+  Value: foo
+</div>
+```
+## Change
+```
+INSERT: button + div
+UPDATE: div::text@7 "" => "foo"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/render.md
@@ -1,0 +1,56 @@
+# Render
+```html
+<button>
+  Toggle
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+<div>
+  Value: foo
+</div>
+```
+## Change
+```
+INSERT: button + div
+UPDATE: div::text@7 "" => "foo"
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+```
+## Change
+```
+REMOVE: button + div
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  Toggle
+</button>
+<div>
+  Value: foo
+</div>
+```
+## Change
+```
+INSERT: button + div
+UPDATE: div::text@7 "" => "foo"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/writes.debug.html
@@ -1,0 +1,10 @@
+<button>Toggle</button><!--M_*1 #button/0--><!--M_]1 #text/1-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      open: !1
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/__snapshots__/writes.html
@@ -1,0 +1,8 @@
+<button>Toggle</button><!--M_*1 a--><!--M_]1 b-->
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: !1
+  }], "a2 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/sizes.json
@@ -1,0 +1,18 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "total": {
+        "min": 6266,
+        "brotli": 2883
+      },
+      "files": {
+        "tags/child.marko": 93,
+        "template.marko": 832
+      }
+    }
+  },
+  "html": {
+    "min": 358,
+    "brotli": 250
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/tags/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/tags/child.marko
@@ -1,0 +1,1 @@
+<return="foo"/>

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/template.marko
@@ -1,0 +1,11 @@
+<define/Wrapper|input|>
+  <return=input.value/>
+</define>
+
+<let/open=false/>
+<button onClick() { open = !open }>Toggle</button>
+<if=open>
+  <child/value/>
+  <Wrapper/wrapped=value/>
+  <div>Value: ${wrapped}</div>
+</if>

--- a/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-in-conditional-through-define/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function clickToggle(document: Document) {
+  document.querySelector<HTMLButtonElement>("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, clickToggle, clickToggle, clickToggle],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/returns-within-define-tag/__snapshots__/dom.bundle.debug.js
@@ -23,8 +23,8 @@ const $clickTwiceCount = /*@__PURE__*/ _let("clickTwiceCount/10", ($scope) => {
 });
 function $setup($scope) {
 	_var($scope, "#childScope/0", $onClickOnce2);
-	$Once_content__setup._($scope["#childScope/0"], $scope);
 	_var($scope, "#childScope/4", $onClickTwice2);
+	$Once_content__setup._($scope["#childScope/0"], $scope);
 	$Twice_content__setup._($scope["#childScope/4"], $scope);
 	$clickOnceCount($scope, 0);
 	$clickTwiceCount($scope, 0);

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -365,7 +365,7 @@ export function knownTagTranslateDOM(
       return t.callExpression(importRuntime("_var_change"), changeArgs);
     };
     addStatement(
-      "render",
+      "prepare",
       tagSection,
       undefined,
       t.expressionStatement(

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -85,6 +85,9 @@ export interface Signal {
   /** Signals this one forwards into: they must declare first when the
    * forward simplifies to a bare, eagerly evaluated reference. */
   forwards: Opt<Signal>;
+  /** Runs before `render`: registrations (eg `_var`) that an earlier tag's
+   * synchronous `_return` may reach before the registering tag's own setup. */
+  prepare: t.Statement[];
   render: t.Statement[];
   effect: t.Statement[];
   hasHTMLEffect: boolean;
@@ -298,6 +301,7 @@ export function getSignal(
         values: [],
         intersection: undefined,
         forwards: undefined,
+        prepare: [],
         render: [],
         effect: [],
         hasHTMLEffect: false,
@@ -456,6 +460,7 @@ export function signalHasStatements(signal: Signal): boolean {
   if (
     signal.extraArgs ||
     signal.forcePersist ||
+    signal.prepare.length ||
     signal.render.length ||
     signal.effect.length ||
     signal.hasHTMLEffect ||
@@ -732,11 +737,15 @@ export function getSignalFn(signal: Signal): t.Expression {
     signal.hasSideEffect = true;
   }
 
+  const render = signal.prepare.length
+    ? signal.prepare.concat(signal.render)
+    : signal.render;
+
   if (!signal.hasSideEffect) {
-    if (isValue && signal.render.length === 1) {
-      const render = signal.render[0];
-      if (render.type === "ExpressionStatement") {
-        const { expression } = render;
+    if (isValue && render.length === 1) {
+      const first = render[0];
+      if (first.type === "ExpressionStatement") {
+        const { expression } = first;
         if (
           expression.type === "CallExpression" &&
           expression.callee.type === "Identifier" &&
@@ -755,14 +764,14 @@ export function getSignalFn(signal: Signal): t.Expression {
       isValue
         ? [scopeIdentifier, getSignalValueIdentifier(signal)]
         : [scopeIdentifier],
-      toFirstExpressionOrBlock(signal.render),
+      toFirstExpressionOrBlock(render),
     );
   }
 
-  if (signal.render.length === 1) {
-    const render = signal.render[0];
-    if (render.type === "ExpressionStatement") {
-      const { expression } = render;
+  if (render.length === 1) {
+    const first = render[0];
+    if (first.type === "ExpressionStatement") {
+      const { expression } = first;
       if (expression.type === "CallExpression") {
         const args = expression.arguments;
         if (args.length === 1 && args[0] === scopeIdentifier) {
@@ -781,10 +790,7 @@ export function getSignalFn(signal: Signal): t.Expression {
     }
   }
 
-  return t.arrowFunctionExpression(
-    [scopeIdentifier],
-    t.blockStatement(signal.render),
-  );
+  return t.arrowFunctionExpression([scopeIdentifier], t.blockStatement(render));
 }
 
 const hasTranslatedExtraArgs = new WeakSet<{ extraArgs?: t.Expression[] }>();
@@ -883,7 +889,7 @@ export function replaceNullishAndEmptyFunctionsWith0(
   return args as t.Expression[];
 }
 export function addStatement(
-  type: "render" | "effect",
+  type: "prepare" | "render" | "effect",
   targetSection: Section,
   referencedBindings: ReferencedBindings,
   statement: t.Statement | t.Statement[],


### PR DESCRIPTION
In the browser a custom tag's `<return>` fires synchronously during its setup and forwards straight into any signals that read the tag variable. When that chain reached a *later* tag's variable — eg `<child/value/>` feeding `<Wrapper/wrapped=value/>` — the `_var` registration for `wrapped` had not been emitted yet (each tag emitted its own `_var` directly before its own setup call), so the return was dropped and `wrapped` stayed `undefined`.

The translator now emits every `_var` registration in a section before any setup call. `Signal` gains a `prepare` statement list alongside `render` / `effect`, and `getSignalFn` writes it ahead of `render`; `_var` is the only statement using it. Adds a fixture toggling the failing shape inside an `<if>`.