### PR TITLE
chore(agent-feedback): file pruned babel helpers reachable from user config

### DIFF
--- a/agent-feedback/items/2026-08-27-keep-user-reachable-babel-helpers-in-the-bundled.md
+++ b/agent-feedback/items/2026-08-27-keep-user-reachable-babel-helpers-in-the-bundled.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/compiler/scripts/bundle.mts › pruneHelpers
+---
+
+# Keep user-reachable Babel helpers in the bundled compiler
+
+`pruneHelpers` trims `@babel/helpers`' generated table to the four names in `USED_HELPERS` on the premise that nothing else can request one, but that premise only covers the compiler's own transforms: `getBaseBabelConfig` (`packages/compiler/src/index.js`) enables `babelrc`/`configFile` discovery for translated output, so an app's own presets run inside the bundled Babel and can request any of the other 118 helpers. A targetless `@babel/preset-env` assumes ES5 targets, its computed-properties transform requests `defineProperty`, and compilation fails with `ReferenceError: Unknown helper defineProperty` — surfacing far from Babel (e.g. as a route-loading error in apps that compile via `@marko/compiler/register`). Affected apps cannot pin around it: the Marko 5 vdom translator imports `decodeHTML` from `@marko/compiler/babel-utils`, which shipped after the prune, so no compiler version has both the full helper table and that export. Direction: stop applying `pruneHelpers` in the `dist/babel.js` (node) build, where config-file discovery makes the reachable helper set open; the full table costs ~112 KB of the prune's 458 KB saving, and the `dist/babel.web.js` prune can stay.
+
+Check: in a scratch app with `marko@^5.39`, `@babel/preset-env`, and a `.babelrc` of `{"presets": ["@babel/preset-env"]}` (no targets), `require("@marko/compiler").compileFileSync(file, { output: "html" })` on a template whose generated module contains a computed object property throws `Unknown helper defineProperty`; `grep -c ': helper('` on the published `dist/babel.js` finds 4 entries where `@babel/helpers`' `helpers-generated.js` has 122.


### PR DESCRIPTION
Files an agent-feedback item against `packages/compiler/scripts/bundle.mts › pruneHelpers`: the bundled Babel's helper table was trimmed to the four helpers the compiler's own transforms request, but `getBaseBabelConfig` enables `.babelrc`/`configFile` discovery for translated output, so user presets running inside the bundled Babel can request any of the other 118 helpers. A targetless `@babel/preset-env` fails with `Unknown helper defineProperty`, and affected apps cannot pin to an older compiler because the Marko 5 vdom translator needs the newer `decodeHTML` babel-utils export. The item records the failure, the no-pin-escape coupling, and a direction (restore the full table in the node bundle, ~112 KB); no fix is included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BeRtP7upctHWzWpWe8Esrp