### PR TITLE
test: bound suite memory and cut runtime-class resolution cost

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -4,9 +4,7 @@
   "node-option": [
     "no-warnings",
     "enable-source-maps",
-    "experimental-vm-modules",
-    "max-old-space-size=8192",
-    "max-semi-space-size=128"
+    "experimental-vm-modules"
   ],
   "require": ["~ts"]
 }

--- a/.mocharc.parallel.cjs
+++ b/.mocharc.parallel.cjs
@@ -1,0 +1,11 @@
+// `test:parallel` workers: the base config without bail (every worker reports
+// all of its failures), room for a slice's slowest fixture, and the handoff
+// module that keeps a worker inside its memory budget.
+const base = require("./.mocharc.json");
+
+module.exports = {
+  ...base,
+  bail: false,
+  timeout: 30000,
+  require: [...base.require, "./scripts/test-parallel-worker.cjs"],
+};

--- a/.mocharc.parallel.json
+++ b/.mocharc.parallel.json
@@ -1,8 +1,0 @@
-{
-  "bail": false,
-  "timeout": 30000,
-  "no-warnings": true,
-  "enable-source-maps": true,
-  "experimental-vm-modules": true,
-  "require": ["~ts"]
-}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,7 @@ pnpm run change                                           # add a changeset (req
 - **Dependencies are patched.** `patches/` (applied by pnpm patchedDependencies on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`, and makes mocha print the `require()` error it otherwise drops when its `import()` fallback rescues a spec. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping any patched dependency requires regenerating its patch.
 - **Bundle size is a feature.** The pre-commit hook runs lint-staged, a full build, and `build:sizes`, staging `.sizes.json`/`.sizes/` — that diff is the size impact of the change. Commits are slow by design. Lint rules whose fix rewrites runtime code into larger output stay off in `.oxlintrc.json` (`unicorn/prefer-string-starts-ends-with`, `unicorn/no-new-array`); enabling one means checking `build:sizes` first.
 - **Snapshots and sizes are generated.** Never hand-edit _or delete_ `__snapshots__/**`, fixture `sizes.json`, or `.sizes*`; regenerate with `pnpm run test:update` (which also prunes stale snapshots) and the commit hook.
-- **CI** (`.github/workflows/ci.yml`): build + lint on Node 26; tests on Node 22/24/26 (`MARKO_DEBUG=1`, zcov coverage). Releases go out via changesets on push to `main`.
+- **CI** (`.github/workflows/ci.yml`): build + lint on Node 26; tests on Node 22/24/26 (zcov coverage). Releases go out via changesets on push to `main`.
 
 ## Conventions
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ci:release": "pnpm run build && node scripts/pkg-override && changeset publish && pnpm run @ci:release-alias && node scripts/pkg-override && pnpm install --frozen-lockfile",
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.mts",
     "@ci:test": "zcov -- pnpm run @ci:test:fast",
-    "@ci:test:fast": "cross-env NODE_OPTIONS=\"--max-old-space-size=8192 --max-semi-space-size=128\" MARKO_DEBUG=1 pnpm run test:parallel",
+    "@ci:test:fast": "pnpm run test:parallel",
     "@ci:version": "changeset version && oxfmt \"**/package.json\" && pnpm install --lockfile-only",
     "audit": "pnpm audit --prod",
     "build": "pnpm -r --if-present run build && pnpm run build:types",

--- a/packages/runtime-class/test/__util__/jsdom-require/index.js
+++ b/packages/runtime-class/test/__util__/jsdom-require/index.js
@@ -9,6 +9,10 @@ const { resolveSync } = require("resolve-sync");
 
 exports.createBrowser = createBrowser;
 
+// Every browser resolves the same way against the same files, so the cache is
+// shared by the process instead of being rebuilt per fixture.
+const resolveCache = new Map();
+
 /**
  * Creates a jsdom instance with a `require` that loads CommonJS modules into
  * the jsdom vm context. The loader owns its own registry and never touches
@@ -147,7 +151,6 @@ class ContextLoader {
     this.entryDir = dir;
     this.hooks = hooks || {};
     this.registry = new Map();
-    this.resolveCache = new Map();
     this.extensions = [
       ...new Set([...Object.keys(this.hooks), ".js", ".cjs", ".json"]),
     ];
@@ -190,7 +193,7 @@ class ContextLoader {
 
     const from = parentFilename || path.join(this.entryDir, "__entry__.js");
     const cacheKey = `${from}\0${request}`;
-    let resolved = this.resolveCache.get(cacheKey);
+    let resolved = resolveCache.get(cacheKey);
     if (!resolved) {
       resolved = resolveSync(request, {
         from,
@@ -207,7 +210,7 @@ class ContextLoader {
         );
       }
       resolved = fs.realpathSync(resolved);
-      this.resolveCache.set(cacheKey, resolved);
+      resolveCache.set(cacheKey, resolved);
     }
 
     return resolved;

--- a/packages/runtime-tags/src/__tests__/utils/snap.ts
+++ b/packages/runtime-tags/src/__tests__/utils/snap.ts
@@ -118,7 +118,7 @@ if (UPDATE) {
 
 export function allTestsPassed(suite: Mocha.Suite): boolean {
   return (
-    suite.tests.every((test) => test.pending || test.state === "passed") &&
+    suite.tests.every((test) => test.state === "passed") &&
     suite.suites.every(allTestsPassed)
   );
 }

--- a/scripts/test-parallel-worker.cjs
+++ b/scripts/test-parallel-worker.cjs
@@ -1,0 +1,60 @@
+"use strict";
+
+// Some runs pin memory per fixture (precise coverage keeps every counted script
+// alive): past the budget, unstarted suites go to a fresh process.
+// Suites run in a fixed order, so the handoff is just how many are finished.
+const fs = require("fs");
+const v8 = require("v8");
+const { PerformanceObserver, constants } = require("perf_hooks");
+
+const RECYCLE_EXIT_CODE = 75;
+const skipped = Number(process.env.MARKO_TEST_SKIPPED) || 0;
+const heapBudget = v8.getHeapStatistics().heap_size_limit / 2;
+const rssBudget = Number(process.env.MARKO_TEST_WORKER_MEM) || Infinity;
+// Pruning stale snapshots needs one complete run, so an update never hands off.
+const canRecycle = !process.env.UPDATE_EXPECTATIONS;
+let liveHeap = 0;
+let recycling = false;
+let current;
+let running = false;
+let seen = 0;
+let ran = 0;
+
+// The heap is mostly garbage between collections, so only its size right after
+// a major GC says what the process is actually keeping.
+new PerformanceObserver((list) => {
+  for (const entry of list.getEntries()) {
+    if (entry.detail?.kind === constants.NODE_PERFORMANCE_GC_MAJOR) {
+      liveHeap = v8.getHeapStatistics().used_heap_size;
+    }
+  }
+}).observe({ entryTypes: ["gc"] });
+
+exports.mochaHooks = {
+  beforeEach() {
+    const suite = this.currentTest.parent;
+    if (suite !== current) {
+      current = suite;
+      running = ++seen > skipped && !recycling;
+      if (running) ran++;
+    }
+    if (!running) this.skip();
+  },
+  afterEach() {
+    if (
+      running &&
+      canRecycle &&
+      (liveHeap > heapBudget || process.memoryUsage.rss() > rssBudget)
+    ) {
+      recycling = true;
+    }
+  },
+};
+
+process.on("exit", () => {
+  if (!recycling || !ran) return;
+  // Written synchronously (mocha's --exit would drop a buffered pipe write),
+  // and the exit code makes a lost marker fail the run instead of skipping it.
+  fs.writeSync(1, `\nMARKO_TEST_RECYCLE ${skipped + ran}\n`);
+  process.exitCode = RECYCLE_EXIT_CODE;
+});

--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -3,26 +3,30 @@
 // single file in one process. This slices those suites into round-robin
 // "slots" (see `MARKO_TEST_SLOT_*` in runtime-tags' main.test.ts and the
 // mocha-autotest patch) and packs the slots plus every other spec file into
-// one mocha process per core: every slotted worker loads all sliced files but
+// one mocha worker per core: every slotted worker loads all sliced files but
 // only runs its own slice of their fixtures.
 //
 // A plain `pnpm test` is untouched — it stays serial, which is what a scoped
 // `--grep` dev run wants. This is the "run everything, fast" path used by CI.
 //
 // Plain CommonJS because it needs no types and is spawned directly by `node`;
-// the mocha workers it spawns get `~ts` via `.mocharc.parallel.json`.
+// the mocha workers it spawns get `~ts` via `.mocharc.parallel.cjs`.
 //
 // Usage: node scripts/test-parallel.js [extra mocha args...]
 //        MARKO_TEST_WORKERS=8 node scripts/test-parallel.js
 const { spawn } = require("node:child_process");
+const fs = require("node:fs");
 const os = require("node:os");
 const path = require("node:path");
+const { setTimeout: sleep } = require("node:timers/promises");
 
 const glob = require("tiny-glob");
 
 const ROOT = path.resolve(__dirname, "..");
 const MOCHA = require.resolve("mocha/bin/mocha.js");
-const CONFIG = path.join(ROOT, ".mocharc.parallel.json");
+const CONFIG = path.join(ROOT, ".mocharc.parallel.cjs");
+// Exit code a worker uses when it handed its remaining suites off.
+const RECYCLE_EXIT_CODE = 75;
 const SPEC_GLOB = "packages/*/@(src|test)/**/*.test.@(js|ts)";
 
 // Suites big enough to be worth splitting across workers, with rough
@@ -45,10 +49,17 @@ const SLICE_SUITES = [...SLICED_FILES.keys()]
 // Everything else shares one small default hint.
 const DEFAULT_FILE_MS = 2_000;
 
-const WORKERS = Math.max(
+const CORES = os.availableParallelism();
+const WORKERS = Math.max(1, Number(process.env.MARKO_TEST_WORKERS) || CORES);
+// Memory a worker may grow to (enforced by test-parallel-worker.cjs). Runs on
+// a machine share one slot per core (and per 2GB) through files in tmpdir.
+const WORKER_MEM = 2 * 1024 ** 3;
+const SLOT_DIR = path.join(os.tmpdir(), "marko-test-parallel");
+const SLOT_COUNT = Math.max(
   1,
-  Number(process.env.MARKO_TEST_WORKERS) || os.availableParallelism(),
+  Math.min(CORES, Math.floor(os.totalmem() / WORKER_MEM)),
 );
+const SLOT_POLL_MS = 1000;
 // Many slots per worker (not one) so the packer can hand a worker that also
 // carries a slow spec file proportionally fewer fixtures. Slots are just env
 // numbers — more of them costs nothing (still one process per worker), it only
@@ -83,12 +94,10 @@ async function main(mochaArgs) {
   const started = Date.now();
   console.log(
     `Running ${files.length} spec files across ${bins.length} workers ` +
-      `(${os.availableParallelism()} cores)…\n`,
+      `(${CORES} cores, ${(process.availableMemory() / 1024 ** 3).toFixed(0)}GB free)…\n`,
   );
 
-  const results = await Promise.all(
-    bins.map((bin, i) => runBin(bin, i, slicedFiles, mochaArgs)),
-  );
+  const results = await runBins(bins, slicedFiles, mochaArgs);
 
   let passing = 0;
   let failing = 0;
@@ -136,12 +145,113 @@ function packBins(slotTotal, slicedTotalMs, otherFiles) {
   return bins.filter((bin) => bin.slots.length || bin.files.length);
 }
 
-function runBin(bin, index, slicedFiles, mochaArgs) {
+// A bin holds a slot while it runs; the slot file names the runner so one left
+// by a dead runner can be reclaimed.
+async function runBins(bins, slicedFiles, mochaArgs) {
+  const results = [];
+  const running = new Set();
+  fs.mkdirSync(SLOT_DIR, { recursive: true });
+  for (const [i, bin] of bins.entries()) {
+    const slot = await acquireSlot(running);
+    const run = runBin(bin, i, slicedFiles, mochaArgs)
+      .finally(() => releaseSlot(slot))
+      .then((result) => {
+        results[i] = result;
+        running.delete(run);
+      });
+    running.add(run);
+  }
+  await Promise.all(running);
+  return results;
+}
+
+const heldSlots = new Set();
+process.on("exit", () => heldSlots.forEach(releaseSlot));
+
+async function acquireSlot(running) {
+  for (;;) {
+    for (let i = 0; i < SLOT_COUNT; i++) {
+      const slot = path.join(SLOT_DIR, `slot-${i}`);
+      try {
+        fs.writeFileSync(slot, String(process.pid), { flag: "wx" });
+        heldSlots.add(slot);
+        return slot;
+      } catch (err) {
+        if (err.code !== "EEXIST") throw err;
+        if (isStale(slot)) reclaimSlot(slot);
+      }
+    }
+    await Promise.race([sleep(SLOT_POLL_MS), ...running]);
+  }
+}
+
+function releaseSlot(slot) {
+  heldSlots.delete(slot);
+  fs.rmSync(slot, { force: true });
+}
+
+function isStale(slot) {
+  try {
+    process.kill(Number(fs.readFileSync(slot, "utf8")), 0);
+    return false;
+  } catch (err) {
+    return err.code !== "EPERM";
+  }
+}
+
+// Renaming first is atomic, so of two runners that both found the slot stale
+// only one removes it and neither deletes the other's fresh claim.
+function reclaimSlot(slot) {
+  const stale = `${slot}.${process.pid}`;
+  try {
+    fs.renameSync(slot, stale);
+    fs.rmSync(stale, { force: true });
+  } catch {}
+}
+
+async function runBin(bin, index, slicedFiles, mochaArgs) {
+  const started = Date.now();
+  const result = {
+    code: 0,
+    passing: 0,
+    failing: 0,
+    crashed: false,
+    output: "",
+  };
+  let processes = 0;
+  let skipped;
+  do {
+    const r = await runProcess(bin, index, slicedFiles, mochaArgs, skipped);
+    processes++;
+    result.passing += r.passing;
+    result.failing += r.failing;
+    result.output += r.output;
+    if (r.code !== 0 && !r.recycled) result.code = r.code;
+    result.crashed = r.crashed;
+    skipped = r.recycled ? r.recycleAt : undefined;
+  } while (skipped);
+
+  const secs = ((Date.now() - started) / 1000).toFixed(1);
+  const label = bin.slots.length
+    ? `slices[${bin.slots.length}/${SLOT_TOTAL}]${bin.files.length ? ` +${bin.files.length} files` : ""}`
+    : `${bin.files.length} files`;
+  console.log(
+    `  worker ${index + 1}: ${label} — ${result.passing} passing` +
+      (result.failing ? `, ${result.failing} failing` : "") +
+      (result.crashed ? `, crashed (exit code ${result.code})` : "") +
+      ` in ${secs}s` +
+      (processes > 1 ? ` (${processes} processes)` : ""),
+  );
+  return result;
+}
+
+function runProcess(bin, index, slicedFiles, mochaArgs, skipped) {
   // `--exit` so a stray timer/handle leaked by a test can't wedge the worker
   // (and with it the whole run) after its suite finishes.
   const args = [MOCHA, "--config", CONFIG, "--reporter", "dot", "--exit"];
   args.push(...mochaArgs);
-  const env = { ...process.env };
+  const env = { ...process.env, MARKO_TEST_WORKER_MEM: String(WORKER_MEM) };
+  if (skipped) env.MARKO_TEST_SKIPPED = String(skipped);
   if (bin.slots.length) {
     args.push(...slicedFiles);
     env.MARKO_TEST_SLOTS = bin.slots.join(",");
@@ -150,7 +260,6 @@ function runBin(bin, index, slicedFiles, mochaArgs) {
   }
   args.push(...bin.files);
 
-  const started = Date.now();
   const child = spawn(process.execPath, args, { cwd: ROOT, env });
   let output = "";
   child.stdout.on("data", (d) => (output += d));
@@ -175,21 +284,15 @@ function runBin(bin, index, slicedFiles, mochaArgs) {
         /(\d+) (?:unexpectedly )?failing(?! as expected)/.exec(output)?.[1] ??
           0,
       );
+      // The worker stopped after this many suites and left the rest for a
+      // fresh process (see test-parallel-worker.cjs); its exit code says so.
+      const recycleAt = Number(/^MARKO_TEST_RECYCLE (\d+)$/m.exec(output)?.[1]);
+      const recycled = code === RECYCLE_EXIT_CODE && recycleAt > 0;
       // Non-zero exit with no parsed failures means the worker died without
       // finishing its suite (crash, OOM, load error) — don't let it show up
       // as "0 failing".
-      const crashed = code !== 0 && !failing;
-      const secs = ((Date.now() - started) / 1000).toFixed(1);
-      const label = bin.slots.length
-        ? `slices[${bin.slots.length}/${SLOT_TOTAL}]${bin.files.length ? ` +${bin.files.length} files` : ""}`
-        : `${bin.files.length} files`;
-      console.log(
-        `  worker ${index + 1}: ${label} — ${passing} passing` +
-          (failing ? `, ${failing} failing` : "") +
-          (crashed ? `, crashed (exit code ${code})` : "") +
-          ` in ${secs}s`,
-      );
-      resolve({ code, passing, failing, crashed, output });
+      const crashed = code !== 0 && !failing && !recycled;
+      resolve({ code, passing, failing, crashed, recycled, recycleAt, output });
     }
   });
 }

--- a/scripts/ts-hooks/index.js
+++ b/scripts/ts-hooks/index.js
@@ -4,6 +4,10 @@
 globalThis.MARKO_DEBUG = true;
 require("complain").silence = true;
 
+// Every fixture compiles unique sources into its own vm context, so V8's
+// compilation cache never hits but pins each context (jsdom windows, bundles).
+require("v8").setFlagsFromString("--no-compilation-cache");
+
 const { registerHooks } = require("module");
 const { fileURLToPath, pathToFileURL } = require("url");
 const { resolveSync } = require("resolve-sync");


### PR DESCRIPTION
Test workers grew to ~3GB each: V8's compilation cache pinned every fixture's vm context (jsdom windows, bundles) even though unique-per-fixture sources mean it never hits, and an 8GB heap limit let garbage pile up rather than be collected. The test bootstrap now disables the cache and the old 8GB heap flags are gone (mocha's node-option overrode the CI script's copy anyway).

Coverage runs retain memory for real — precise coverage keeps every counted script alive, and flushing/restarting it drops block-level data — so instead of a bigger heap, each worker watches its own live heap after major GCs and its RSS against the 2GB the runner budgets per worker; past either, it skips suites it has not started, reports how many it finished (suites run in a fixed order, so that count is the whole handoff) and exits with a dedicated code, and the runner resumes the rest in a fresh process. Coverage totals are unchanged; nothing recycles on a normal 16-worker run; snapshot updates never hand off because pruning needs a complete run. `test-parallel` also shares the machine with other runs (any checkout) through one slot per core in tmpdir — a bin holds a slot file while it runs, and one left by a dead runner is reclaimed — so simultaneous runs use the footprint of one and finish in the time of running them back to back.

The runtime-class jsdom loader re-resolved the whole runtime module graph for every fixture's browser; its resolve cache is now shared across the process (runtime-class suite ~20% faster). `allTestsPassed` no longer treats pending tests as passed, so a partially run fixture never asserts or rewrites sizes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)