### PR TITLE
fix(runtime-tags): resume an empty placeholder as its own node

### DIFF
--- a/.changeset/witty-pugs-repeat.md
+++ b/.changeset/witty-pugs-repeat.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a placeholder that renders empty resuming as another node when it follows a node with text after it, or starts a section's content

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/__snapshots__/html.bundle.debug.js
@@ -29,7 +29,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, "__tests__/template.marko_0/onClick", $scope0_id) }, _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_html(`${_escape(count)}${_el_resume($scope1_id, "#text/0")}`);
+		_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 		_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2"));
 		_resume_branch($scope1_id);
 	}, $scope0_id));

--- a/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures-interop/interop-event-handler-render-body-tags-to-class/__snapshots__/html.bundle.js
@@ -28,7 +28,7 @@ var template_default = _template("a", (input) => {
 	}, "a0", $scope0_id) }, _content_resume("a1", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_html(`${_escape(count)}${_el_resume($scope1_id, "a")}`);
+		_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "a")}`);
 		_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 		_resume_branch($scope1_id);
 	}, $scope0_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/__snapshots__/html.bundle.debug.js
@@ -7,31 +7,31 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<button>increment</button>${_el_resume($scope0_id, "#button/0")}<p>1 * <!>${_escape(n)}${_el_resume($scope0_id, "#text/1")} = `);
 	_await($scope0_id, "#text/2", multiply(1, n), (result) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope1_id, "#text/0")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 		writeScope($scope1_id, {}, "__tests__/template.marko", "6:16");
 	});
 	_html(`</p><p>2 * <!>${_escape(n)}${_el_resume($scope0_id, "#text/3")} = `);
 	_await($scope0_id, "#text/4", multiply(2, n), (result) => {
 		const $scope2_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope2_id, "#text/0")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope2_id, "#text/0")}`);
 		writeScope($scope2_id, {}, "__tests__/template.marko", "7:16");
 	});
 	_html(`</p><p>3 * <!>${_escape(n)}${_el_resume($scope0_id, "#text/5")} = `);
 	_await($scope0_id, "#text/6", multiply(3, n), (result) => {
 		const $scope3_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope3_id, "#text/0")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 		writeScope($scope3_id, {}, "__tests__/template.marko", "8:16");
 	});
 	_html(`</p><p>4 * <!>${_escape(n)}${_el_resume($scope0_id, "#text/7")} = `);
 	_await($scope0_id, "#text/8", multiply(4, n), (result) => {
 		const $scope4_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope4_id, "#text/0")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope4_id, "#text/0")}`);
 		writeScope($scope4_id, {}, "__tests__/template.marko", "9:16");
 	});
 	_html(`</p><p>5 * <!>${_escape(n)}${_el_resume($scope0_id, "#text/9")} = `);
 	_await($scope0_id, "#text/10", multiply(5, n), (result) => {
 		const $scope5_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope5_id, "#text/0")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope5_id, "#text/0")}`);
 		writeScope($scope5_id, {}, "__tests__/template.marko", "10:16");
 	});
 	_html("</p>");

--- a/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-multi-resolve-in-order-and-update/__snapshots__/html.bundle.js
@@ -7,31 +7,31 @@ var template_default = _template("a", (input) => {
 	_html(`<button>increment</button>${_el_resume($scope0_id, "a")}<p>1 * <!>${_escape(n)}${_el_resume($scope0_id, "b")} = `);
 	_await($scope0_id, "c", multiply(1, n), (result) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope1_id, "a")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope1_id, "a")}`);
 		writeScope($scope1_id, {});
 	});
 	_html(`</p><p>2 * <!>${_escape(n)}${_el_resume($scope0_id, "d")} = `);
 	_await($scope0_id, "e", multiply(2, n), (result) => {
 		const $scope2_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope2_id, "a")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope2_id, "a")}`);
 		writeScope($scope2_id, {});
 	});
 	_html(`</p><p>3 * <!>${_escape(n)}${_el_resume($scope0_id, "f")} = `);
 	_await($scope0_id, "g", multiply(3, n), (result) => {
 		const $scope3_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope3_id, "a")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope3_id, "a")}`);
 		writeScope($scope3_id, {});
 	});
 	_html(`</p><p>4 * <!>${_escape(n)}${_el_resume($scope0_id, "h")} = `);
 	_await($scope0_id, "i", multiply(4, n), (result) => {
 		const $scope4_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope4_id, "a")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope4_id, "a")}`);
 		writeScope($scope4_id, {});
 	});
 	_html(`</p><p>5 * <!>${_escape(n)}${_el_resume($scope0_id, "j")} = `);
 	_await($scope0_id, "k", multiply(5, n), (result) => {
 		const $scope5_id = _scope_id();
-		_html(`${_escape(result)}${_el_resume($scope5_id, "a")}`);
+		_html(`${_escape(result) || "<!>"}${_el_resume($scope5_id, "a")}`);
 		writeScope($scope5_id, {});
 	});
 	_html("</p>");

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_scope_reason();
 		_await($scope1_id, "#text/0", resolveAfter(clickCount), (value) => {
 			const $scope3_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope3_id, "#text/0")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 			writeScope($scope3_id, {}, "__tests__/template.marko", "7:4");
 		});
 		_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "6:2"));

--- a/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-state/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var template_default = _template("a", (input) => {
 		_scope_reason();
 		_await($scope1_id, "a", resolveAfter(clickCount), (value) => {
 			const $scope3_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope3_id, "a")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope3_id, "a")}`);
 			writeScope($scope3_id, {});
 		});
 		_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$item = attrTags($item, { content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(a)}${_el_resume($scope1_id, "#text/0")}:<!>${_escape(v)}${_el_resume($scope1_id, "#text/1")}`);
+			_html(`${_escape(a) || "<!>"}${_el_resume($scope1_id, "#text/0")}:<!>${_escape(v)}${_el_resume($scope1_id, "#text/1")}`);
 			writeScope($scope1_id, {}, "__tests__/template.marko", "3:8");
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-and-static/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var template_default = _template("a", (input) => {
 		$item = attrTags($item, { content: _content("a0", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(a)}${_el_resume($scope1_id, "a")}:<!>${_escape(v)}${_el_resume($scope1_id, "b")}`);
+			_html(`${_escape(a) || "<!>"}${_el_resume($scope1_id, "a")}:<!>${_escape(v)}${_el_resume($scope1_id, "b")}`);
 			writeScope($scope1_id, {});
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.debug.js
@@ -68,7 +68,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				content: _content_resume("__tests__/template.marko_3*content", () => {
 					_scope_reason();
 					const $scope3_id = _scope_id();
-					_html(`${_escape(row)}${_el_resume($scope3_id, "#text/0")}`);
+					_html(`${_escape(row) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 					writeScope($scope3_id, {}, "__tests__/template.marko", "16:18");
 				}, $scope0_id)
 			});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic/__snapshots__/html.bundle.js
@@ -65,7 +65,7 @@ var template_default = _template("a", (input) => {
 				content: _content_resume("a2", () => {
 					_scope_reason();
 					const $scope3_id = _scope_id();
-					_html(`${_escape(row)}${_el_resume($scope3_id, "a")}`);
+					_html(`${_escape(row) || "<!>"}${_el_resume($scope3_id, "a")}`);
 					writeScope($scope3_id, {});
 				}, $scope0_id)
 			});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$item = attrTags($item, { content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(zzz)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(zzz) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			writeScope($scope1_id, {}, "__tests__/template.marko", "3:5");
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-closure/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var template_default = _template("a", (input) => {
 		$item = attrTags($item, { content: _content("a0", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(zzz)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(zzz) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, {});
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.debug.js
@@ -27,7 +27,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			content: _content_resume("__tests__/template.marko_1*content", () => {
 				_scope_reason();
 				const $scope1_id = _scope_id();
-				_html(`${_escape($foo)}${_el_resume($scope1_id, "#text/0")}`);
+				_html(`${_escape($foo) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 				writeScope($scope1_id, {}, "__tests__/template.marko", "4:6");
 			}, $scope0_id)
 		});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler-shadowed/__snapshots__/html.bundle.js
@@ -27,7 +27,7 @@ var template_default = _template("a", (input) => {
 			content: _content_resume("a1", () => {
 				_scope_reason();
 				const $scope1_id = _scope_id();
-				_html(`${_escape($foo)}${_el_resume($scope1_id, "a")}`);
+				_html(`${_escape($foo) || "<!>"}${_el_resume($scope1_id, "a")}`);
 				writeScope($scope1_id, {});
 			}, $scope0_id)
 		});

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/html.bundle.debug.js
@@ -25,7 +25,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$item = attrTags($item, { content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(item * mult)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(item * mult) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($mult__closures, writeScope($scope1_id, {
 				item,
 				_: _scope_with_id($scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-intersection-closure/__snapshots__/html.bundle.js
@@ -25,7 +25,7 @@ var template_default = _template("a", (input) => {
 		$item = attrTags($item, { content: _content("a0", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(item * mult)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(item * mult) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($mult__closures, writeScope($scope1_id, {
 				f: item,
 				_: _scope_with_id($scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var child_default = _template("__tests__/tags/child/index.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_for_of(input.scope, (s) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(s.a)}${_el_resume($scope1_id, "#text/0", $sg__input_scope)}`);
+		_html(`${_escape(s.a) || _sep($sg__input_scope)}${_el_resume($scope1_id, "#text/0", $sg__input_scope)}`);
 		$si__input_scope && writeScope($scope1_id, {}, "__tests__/tags/child/index.marko", "1:2");
 	}, 0, $scope0_id, "#text/0", $sg__input_scope, $sg__input_scope, $sg__input_scope, 0, 1);
 	$si__input_scope && writeScope($scope0_id, {}, "__tests__/tags/child/index.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var child_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	_for_of(input.scope, (s) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(s.a)}${_el_resume($scope1_id, "a", $sg__input_scope)}`);
+		_html(`${_escape(s.a) || _sep($sg__input_scope)}${_el_resume($scope1_id, "a", $sg__input_scope)}`);
 		$si__input_scope && writeScope($scope1_id, {});
 	}, 0, $scope0_id, "a", $sg__input_scope, $sg__input_scope, $sg__input_scope, 0, 1);
 	$si__input_scope && writeScope($scope0_id, {});

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			$item = attrTags($item, { content: _content("__tests__/template.marko_4*content", () => {
 				_scope_reason();
 				const $scope4_id = _scope_id();
-				_html(`${_escape(item.text)}${_el_resume($scope4_id, "#text/0")}`);
+				_html(`${_escape(item.text) || "<!>"}${_el_resume($scope4_id, "#text/0")}`);
 				writeScope($scope4_id, {}, "__tests__/template.marko", "11:14");
 			}, $scope2_id) });
 		});

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-local-member-expression-closure/__snapshots__/html.bundle.js
@@ -18,7 +18,7 @@ var template_default = _template("a", (input) => {
 			$item = attrTags($item, { content: _content("a1", () => {
 				_scope_reason();
 				const $scope4_id = _scope_id();
-				_html(`${_escape(item.text)}${_el_resume($scope4_id, "a")}`);
+				_html(`${_escape(item.text) || "<!>"}${_el_resume($scope4_id, "a")}`);
 				writeScope($scope4_id, {});
 			}, $scope2_id) });
 		});

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				_await($scope2_id, "#text/0", resolveAfter(0, 1), () => {
 					const $scope3_id = _scope_id();
 					_script($scope3_id, "__tests__/template.marko_3_show#2/pending");
-					_html(`${_escape(show)}${_el_resume($scope3_id, "#text/0")}`);
+					_html(`${_escape(show) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 					_script($scope3_id, "__tests__/template.marko_3");
 					writeScope($scope3_id, { _: _scope_with_id($scope2_id) }, "__tests__/template.marko", "9:5");
 					_resume_branch($scope3_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-cleanup/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 				_await($scope2_id, "a", resolveAfter(0, 1), () => {
 					const $scope3_id = _scope_id();
 					_script($scope3_id, "a0");
-					_html(`${_escape(show)}${_el_resume($scope3_id, "a")}`);
+					_html(`${_escape(show) || "<!>"}${_el_resume($scope3_id, "a")}`);
 					_script($scope3_id, "a1");
 					writeScope($scope3_id, { _: _scope_with_id($scope2_id) });
 					_resume_branch($scope3_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_await($scope1_id, "#text/0", resolveAfter(0, 4), () => {
 			const $scope2_id = _scope_id();
 			_script($scope2_id, "__tests__/template.marko_2_value#1/pending");
-			_html(`${_escape(value)}${_el_resume($scope2_id, "#text/0")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope2_id, "#text/0")}`);
 			_script($scope2_id, "__tests__/template.marko_2_value#1");
 			writeScope($scope2_id, { _: _scope_with_id($scope1_id) }, "__tests__/template.marko", "6:3");
 			_resume_branch($scope2_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-closure-function/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var template_default = _template("a", (input) => {
 		_await($scope1_id, "a", resolveAfter(0, 4), () => {
 			const $scope2_id = _scope_id();
 			_script($scope2_id, "a0");
-			_html(`${_escape(value)}${_el_resume($scope2_id, "a")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope2_id, "a")}`);
 			_script($scope2_id, "a1");
 			writeScope($scope2_id, { _: _scope_with_id($scope1_id) });
 			_resume_branch($scope2_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html("<li>");
 		_await($scope1_id, "#text/0", resolveAfter(item.label, 1), (v) => {
 			const $scope2_id = _scope_id();
-			_html(`${_escape(v)}${_el_resume($scope2_id, "#text/0", $sg__input_items)}`);
+			_html(`${_escape(v) || _sep($sg__input_items)}${_el_resume($scope2_id, "#text/0", $sg__input_items)}`);
 			$si__input_items && writeScope($scope2_id, {}, "__tests__/template.marko", "6:8");
 		}, $sg__input_items);
 		_html("</li>");

--- a/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/await-in-for/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var template_default = _template("a", (input) => {
 		_html("<li>");
 		_await($scope1_id, "a", resolveAfter(item.label, 1), (v) => {
 			const $scope2_id = _scope_id();
-			_html(`${_escape(v)}${_el_resume($scope2_id, "a", $sg__input_items)}`);
+			_html(`${_escape(v) || _sep($sg__input_items)}${_el_resume($scope2_id, "a", $sg__input_items)}`);
 			$si__input_items && writeScope($scope2_id, {});
 		}, $sg__input_items);
 		_html("</li>");

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(clickCount)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(clickCount) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2"));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-renderBody/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var template_default = _template("a", (input) => {
 		content: _content("a1", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(clickCount)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(clickCount) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			_html(`${_escape(message.text)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(message.text) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			writeScope($scope1_id, {}, "__tests__/template.marko", "8:2");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-execution-order/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_html(`${_escape(message.text)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(message.text) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, {});
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.bundle.debug.js
@@ -7,7 +7,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html("<div>");
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(item)}${_el_resume($scope1_id, "#text/0")}`);
+		_html(`${_escape(item) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 		writeScope($scope1_id, {}, "__tests__/template.marko", "5:4");
 	}, 0, $scope0_id, "#text/0", 1, 1, 1, 0, 1);
 	_html(`<button id=add>Add</button>${_el_resume($scope0_id, "#button/1")}<button id=remove>Remove</button>${_el_resume($scope0_id, "#button/2")}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-push-pop-list/__snapshots__/html.bundle.js
@@ -7,7 +7,7 @@ var template_default = _template("a", (input) => {
 	_html("<div>");
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(item)}${_el_resume($scope1_id, "a")}`);
+		_html(`${_escape(item) || "<!>"}${_el_resume($scope1_id, "a")}`);
 		writeScope($scope1_id, {});
 	}, 0, $scope0_id, "a", 1, 1, 1, 0, 1);
 	_html(`<button id=add>Add</button>${_el_resume($scope0_id, "b")}<button id=remove>Remove</button>${_el_resume($scope0_id, "c")}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
@@ -39,7 +39,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($x__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2"));
 			_resume_branch($scope1_id);
 		}, $scope0_id)
@@ -52,7 +52,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content("__tests__/template.marko_2*content", () => {
 			_scope_reason();
 			const $scope2_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope2_id, "#text/0")}`);
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope2_id, "#text/0")}`);
 			_subscribe($x__closures, writeScope($scope2_id, {
 				_: _scope_with_id($scope0_id),
 				"ClosureSignalIndex:x": 1

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
@@ -34,7 +34,7 @@ var template_default = _template("a", (input) => {
 		content: _content("a1", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($x__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope1_id);
 		}, $scope0_id)
@@ -47,7 +47,7 @@ var template_default = _template("a", (input) => {
 		content: _content("a2", () => {
 			_scope_reason();
 			const $scope2_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope2_id, "a")}`);
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope2_id, "a")}`);
 			_subscribe($x__closures, writeScope($scope2_id, {
 				_: _scope_with_id($scope0_id),
 				Cd: 1

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.debug.js
@@ -24,7 +24,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(clickCount)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(clickCount) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2"));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/body-content/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 		content: _content("a1", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(clickCount)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(clickCount) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/html.bundle.debug.js
@@ -13,9 +13,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, 0);
 		_html("c");
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_2*content", (error) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__error_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(error.message)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(error.message) || _sep($sg__error_message)}${_el_resume($scope2_id, "#text/0", $sg__error_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "8:4");
 	}, $scope0_id) }) });
 	_html("d");

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-reject-async/__snapshots__/html.bundle.js
@@ -13,9 +13,9 @@ var template_default = _template("a", (input) => {
 		}, 0);
 		_html("c");
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("a0", (error) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__error_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(error.message)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(error.message) || _sep($sg__error_message)}${_el_resume($scope2_id, "a", $sg__error_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}, $scope0_id) }) });
 	_html("d");

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/html.bundle.debug.js
@@ -10,9 +10,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			throw new Error("ERROR!");
 		})())}`);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_2*content", (error) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__error_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(error.message)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(error.message) || _sep($sg__error_message)}${_el_resume($scope2_id, "#text/0", $sg__error_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "4:4");
 	}, $scope0_id) }) });
 	_html("d");

--- a/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/catch-single-throw-sync/__snapshots__/html.bundle.js
@@ -10,9 +10,9 @@ var template_default = _template("a", (input) => {
 			throw new Error("ERROR!");
 		})())}`);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("a0", (error) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__error_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(error.message)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(error.message) || _sep($sg__error_message)}${_el_resume($scope2_id, "a", $sg__error_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}, $scope0_id) }) });
 	_html("d");

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
@@ -32,7 +32,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content_resume("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(count)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:4"));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
@@ -32,7 +32,7 @@ var template_default = _template("a", (input) => {
 		content: _content_resume("a1", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(count)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,17 @@
+// template.marko
+const $template = "<input><!>";
+const $walks = " b%b";
+const $value = /*@__PURE__*/ _let("value/2", ($scope) => {
+	_attr_input_value($scope, "#input/0", $scope.value, $valueChange($scope));
+	_text($scope["#text/1"], $scope.value);
+});
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _attr_input_value_script($scope, "#input/0"));
+function $setup($scope) {
+	$value($scope, undefined);
+	$setup__script($scope);
+}
+const $valueChange = ($scope) => (_new_value) => {
+	$value($scope, _new_value);
+};
+_resume("__tests__/template.marko_0/valueChange", $valueChange);
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $value = /*@__PURE__*/ _let(2, ($scope) => {
+	_attr_input_value($scope, "a", $scope.c, $valueChange($scope));
+	_text($scope.b, $scope.c);
+});
+const $setup__script = _script("a1", ($scope) => _attr_input_value_script($scope, "a"));
+const $valueChange = ($scope) => (_new_value) => {
+	$value($scope, _new_value);
+};
+_resume("a0", $valueChange);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = undefined;
+	_html(`<input${_attr_input_value($scope0_id, "#input/0", value, _resume((_new_value) => {
+		value = _new_value;
+	}, "__tests__/template.marko_0/valueChange", $scope0_id))}>${_el_resume($scope0_id, "#input/0")}${_escape(value) || "<!>"}${_el_resume($scope0_id, "#text/1")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0, { "ControlledHandler:#input/0": ["valueChange"] });
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/html.bundle.js
@@ -1,0 +1,12 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let value = void 0;
+	_html(`<input${_attr_input_value($scope0_id, "a", value, _resume((_new_value) => {
+		value = _new_value;
+	}, "a0", $scope0_id))}>${_el_resume($scope0_id, "a")}${_escape(value) || "<!>"}${_el_resume($scope0_id, "b")}`);
+	_script($scope0_id, "a1");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/render.debug.md
@@ -1,0 +1,58 @@
+# Render
+```html
+<input />
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="w"
+/>
+w
+```
+## Change
+```
+UPDATE: ::text "" => "w"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="wor"
+/>
+wor
+```
+## Change
+```
+UPDATE: ::text "w" => "wor"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="world"
+/>
+world
+```
+## Change
+```
+UPDATE: ::text "wor" => "world"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/render.md
@@ -1,0 +1,58 @@
+# Render
+```html
+<input />
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="w"
+/>
+w
+```
+## Change
+```
+UPDATE: ::text "" => "w"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="wor"
+/>
+wor
+```
+## Change
+```
+UPDATE: ::text "w" => "wor"
+```
+
+# Update
+```js
+const input = document.querySelector("input");
+const window = input.ownerDocument.defaultView;
+input.value = value;
+input.dispatchEvent(new window.Event("input", { bubbles: true }));
+```
+```html
+<input
+  value="world"
+/>
+world
+```
+## Change
+```
+UPDATE: ::text "wor" => "world"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/writes.debug.html
@@ -1,0 +1,13 @@
+<input><!--M_*1 #input/0-->
+<!><!--M_*1 #text/1-->
+  <script>
+    WALKER_RUNTIME("M")("_");
+    M._.r = [_ => [1, {
+        "ControlledHandler:#input/0": _(1,
+          "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/template.marko_0/valueChange"
+          )
+      }],
+      "packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/template.marko_0 1"
+    ];
+    M._.w()
+  </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<input><!--M_*1 a-->
+<!><!--M_*1 b-->
+  <script>
+    WALKER_RUNTIME("M")("_");
+    M._.r = [_ => [1, {
+      Ea: _(1, "a0")
+    }], "a1 1"];
+    M._.w()
+  </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 3623,
+      "brotli": 1748
+    }
+  },
+  "html": {
+    "min": 353,
+    "brotli": 252
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/template.marko
@@ -1,0 +1,3 @@
+let/value
+input value:=value
+-- ${value}

--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-input-value-empty/test.ts
@@ -1,0 +1,14 @@
+import type { TestConfig } from "../../main.test";
+
+function type(value: string) {
+  return (document: Document) => {
+    const input = document.querySelector("input")!;
+    const window = input.ownerDocument.defaultView!;
+    input.value = value;
+    input.dispatchEvent(new window.Event("input", { bubbles: true }));
+  };
+}
+
+export const config: TestConfig = {
+  steps: [{}, type("w"), type("wor"), type("world")],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const Foo = { content: _content("__tests__/template.marko_1*content", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
+		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $sg__input_message = _serialize_guard($scope1_reason, 2), $si__input_bar = _serialize_if($scope1_reason, 1);
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				return 0;
 			} else {
 				const $scope3_id = _scope_id();
-				_html(`${_escape(JSON.stringify(input.message))}${_el_resume($scope3_id, "#text/0", _serialize_guard($scope1_reason, 2))}`);
+				_html(`${_escape(JSON.stringify(input.message)) || _sep($sg__input_message)}${_el_resume($scope3_id, "#text/0", $sg__input_message)}`);
 				_serialize_if($scope1_reason, 0) && writeScope($scope3_id, { _: _serialize_if($scope1_reason, 2) && _scope_with_id($scope1_id) }, "__tests__/template.marko", "4:3");
 				return 1;
 			}

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const Foo = { content: _content("a0", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
+		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $sg__input_message = _serialize_guard($scope1_reason, 2), $si__input_bar = _serialize_if($scope1_reason, 1);
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
@@ -20,7 +20,7 @@ var template_default = _template("a", (input) => {
 				return 0;
 			} else {
 				const $scope3_id = _scope_id();
-				_html(`${_escape(JSON.stringify(input.message))}${_el_resume($scope3_id, "a", _serialize_guard($scope1_reason, 2))}`);
+				_html(`${_escape(JSON.stringify(input.message)) || _sep($sg__input_message)}${_el_resume($scope3_id, "a", $sg__input_message)}`);
 				_serialize_if($scope1_reason, 0) && writeScope($scope3_id, { _: _serialize_if($scope1_reason, 2) && _scope_with_id($scope1_id) });
 				return 1;
 			}

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const Foo = { content: _content_resume("__tests__/template.marko_1*content", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
+		const $scope1_reason = _scope_reason(), $sg__input_message = _serialize_guard($scope1_reason, 2), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				return 0;
 			} else {
 				const $scope3_id = _scope_id();
-				_html(`${_escape(JSON.stringify(input.message))}${_el_resume($scope3_id, "#text/0", _serialize_guard($scope1_reason, 2))}`);
+				_html(`${_escape(JSON.stringify(input.message)) || _sep($sg__input_message)}${_el_resume($scope3_id, "#text/0", $sg__input_message)}`);
 				_serialize_if($scope1_reason, 0) && writeScope($scope3_id, { _: _serialize_if($scope1_reason, 2) && _scope_with_id($scope1_id) }, "__tests__/template.marko", "4:3");
 				return 1;
 			}

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-unknown/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const Foo = { content: _content_resume("a0", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason(), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
+		const $scope1_reason = _scope_reason(), $sg__input_message = _serialize_guard($scope1_reason, 2), $sg__input_bar = _serialize_guard($scope1_reason, 1), $si__input_bar = _serialize_if($scope1_reason, 1);
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
@@ -13,7 +13,7 @@ var template_default = _template("a", (input) => {
 				return 0;
 			} else {
 				const $scope3_id = _scope_id();
-				_html(`${_escape(JSON.stringify(input.message))}${_el_resume($scope3_id, "a", _serialize_guard($scope1_reason, 2))}`);
+				_html(`${_escape(JSON.stringify(input.message)) || _sep($sg__input_message)}${_el_resume($scope3_id, "a", $sg__input_message)}`);
 				_serialize_if($scope1_reason, 0) && writeScope($scope3_id, { _: _serialize_if($scope1_reason, 2) && _scope_with_id($scope1_id) });
 				return 1;
 			}

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.debug.js
@@ -27,7 +27,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content_resume("__tests__/template.marko_1*content", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			_subscribe($value__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:1"));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/destructure-input-with-assignment/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 		content: _content_resume("a1", () => {
 			_scope_reason();
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			_subscribe($value__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope1_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const MyThing = { content: _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_html(`${_escape(count)}${_el_resume($scope1_id, "#text/0")} ${_escape(sideEffect++)}`);
+		_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "#text/0")} ${_escape(sideEffect++)}`);
 		_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "5:1"));
 		_resume_branch($scope1_id);
 	}, $scope0_id) };

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-content-attr/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var template_default = _template("a", (input) => {
 	const MyThing = { content: _content_resume("a0", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_html(`${_escape(count)}${_el_resume($scope1_id, "a")} ${_escape(sideEffect++)}`);
+		_html(`${_escape(count) || "<!>"}${_el_resume($scope1_id, "a")} ${_escape(sideEffect++)}`);
 		_subscribe($count__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 		_resume_branch($scope1_id);
 	}, $scope0_id) };

--- a/packages/runtime-tags/src/__tests__/fixtures/error-for-by-static/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/error-for-by-static/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_for_of(input.items, (item) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(item.id)}${_el_resume($scope1_id, "#text/0", $sg__input_items)}`);
+		_html(`${_escape(item.id) || _sep($sg__input_items)}${_el_resume($scope1_id, "#text/0", $sg__input_items)}`);
 		$si__input_items && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 	}, (item) => item, $scope0_id, "#text/0", $sg__input_items, $sg__input_items, $sg__input_items, 0, 1);
 	$si__input_items && writeScope($scope0_id, {}, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.bundle.debug.js
@@ -28,31 +28,31 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html("<div><div class=by-string>");
 	_for_of(items, ({ text }) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope1_id, "#text/0")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 		writeScope($scope1_id, {}, "__tests__/template.marko", "17:6");
 	}, "id", $scope0_id, "#div/0", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-function>");
 	_for_of(items, ({ text }) => {
 		const $scope2_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope2_id, "#text/0")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope2_id, "#text/0")}`);
 		writeScope($scope2_id, {}, "__tests__/template.marko", "21:6");
 	}, (item) => item.id, $scope0_id, "#div/1", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-string>");
 	_for_of(items, ({ text }) => {
 		const $scope3_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope3_id, "#text/0")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 		writeScope($scope3_id, {}, "__tests__/template.marko", "25:6");
 	}, getStringBy(), $scope0_id, "#div/2", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-function>");
 	_for_of(items, ({ text }) => {
 		const $scope4_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope4_id, "#text/0")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope4_id, "#text/0")}`);
 		writeScope($scope4_id, {}, "__tests__/template.marko", "29:6");
 	}, getFunctionBy(), $scope0_id, "#div/3", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-missing>");
 	_for_of(items, ({ text }) => {
 		const $scope5_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope5_id, "#text/0")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope5_id, "#text/0")}`);
 		writeScope($scope5_id, {}, "__tests__/template.marko", "33:6");
 	}, getMissingBy(), $scope0_id, "#div/4", 1, 1, 1, "</div>", 1);
 	_html(`<button>Rotate</button>${_el_resume($scope0_id, "#button/5")}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-by/__snapshots__/html.bundle.js
@@ -25,31 +25,31 @@ var template_default = _template("a", (input) => {
 	_html("<div><div class=by-string>");
 	_for_of(items, ({ text }) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope1_id, "a")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope1_id, "a")}`);
 		writeScope($scope1_id, {});
 	}, "id", $scope0_id, "a", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-function>");
 	_for_of(items, ({ text }) => {
 		const $scope2_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope2_id, "a")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope2_id, "a")}`);
 		writeScope($scope2_id, {});
 	}, (item) => item.id, $scope0_id, "b", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-string>");
 	_for_of(items, ({ text }) => {
 		const $scope3_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope3_id, "a")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope3_id, "a")}`);
 		writeScope($scope3_id, {});
 	}, getStringBy(), $scope0_id, "c", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-function>");
 	_for_of(items, ({ text }) => {
 		const $scope4_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope4_id, "a")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope4_id, "a")}`);
 		writeScope($scope4_id, {});
 	}, getFunctionBy(), $scope0_id, "d", 1, 1, 1, "</div>", 1);
 	_html("<div class=by-unknown-missing>");
 	_for_of(items, ({ text }) => {
 		const $scope5_id = _scope_id();
-		_html(`${_escape(text)}${_el_resume($scope5_id, "a")}`);
+		_html(`${_escape(text) || "<!>"}${_el_resume($scope5_id, "a")}`);
 		writeScope($scope5_id, {});
 	}, void 0, $scope0_id, "e", 1, 1, 1, "</div>", 1);
 	_html(`<button>Rotate</button>${_el_resume($scope0_id, "f")}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.debug.js
@@ -19,11 +19,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $childScope = _peek_scope_id();
 	let divName = parent_el_default({});
 	_var($scope0_id, "#scopeOffset/1", $childScope, "__tests__/template.marko_0_divName#6/var");
-	_html(`<!>${_escape(divName)}${_el_resume($scope0_id, "#text/2")}</div><span>`);
+	_html(`${_escape(divName) || "<!>"}${_el_resume($scope0_id, "#text/2")}</div><span>`);
 	const $childScope2 = _peek_scope_id();
 	let spanName = parent_el_default({});
 	_var($scope0_id, "#scopeOffset/4", $childScope2, "__tests__/template.marko_0_spanName#7/var");
-	_html(`<!>${_escape(spanName)}${_el_resume($scope0_id, "#text/5")}</span>`);
+	_html(`${_escape(spanName) || "<!>"}${_el_resume($scope0_id, "#text/5")}</span>`);
 	writeScope($scope0_id, {
 		"#childScope/0": _existing_scope($childScope),
 		"#childScope/3": _existing_scope($childScope2)

--- a/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/html-comment-var/__snapshots__/html.bundle.js
@@ -16,11 +16,11 @@ var template_default = _template("a", (input) => {
 	const $childScope = _peek_scope_id();
 	let divName = parent_el_default({});
 	_var($scope0_id, "b", $childScope, "a0");
-	_html(`<!>${_escape(divName)}${_el_resume($scope0_id, "c")}</div><span>`);
+	_html(`${_escape(divName) || "<!>"}${_el_resume($scope0_id, "c")}</div><span>`);
 	const $childScope2 = _peek_scope_id();
 	let spanName = parent_el_default({});
 	_var($scope0_id, "e", $childScope2, "a1");
-	_html(`<!>${_escape(spanName)}${_el_resume($scope0_id, "f")}</span>`);
+	_html(`${_escape(spanName) || "<!>"}${_el_resume($scope0_id, "f")}</span>`);
 	writeScope($scope0_id, {
 		a: _existing_scope($childScope),
 		d: _existing_scope($childScope2)

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-active/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "#text/0")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2");
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-if-closure-update-inactive/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
-			_html(`${_escape(value)}${_el_resume($scope1_id, "a")}`);
+			_html(`${_escape(value) || "<!>"}${_el_resume($scope1_id, "a")}`);
 			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 			return 0;
 		}

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.debug.js
@@ -19,9 +19,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	child_default({
 		value: "Hi",
 		content: _content("__tests__/template.marko_1*content", (x) => {
-			const $scope1_reason = _scope_reason();
+			const $scope1_reason = _scope_reason(), $sg__x = _serialize_guard($scope1_reason, 0);
 			const $scope1_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}`);
+			_html(`${_escape(x) || _sep($sg__x)}${_el_resume($scope1_id, "#text/0", $sg__x)}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 		}, $scope0_id)
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/inert-params-no-serialize/__snapshots__/html.bundle.js
@@ -15,9 +15,9 @@ var template_default = _template("a", (input) => {
 	child_default({
 		value: "Hi",
 		content: _content("a0", (x) => {
-			const $scope1_reason = _scope_reason();
+			const $scope1_reason = _scope_reason(), $sg__x = _serialize_guard($scope1_reason, 0);
 			const $scope1_id = _scope_id();
-			_html(`${_escape(x)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
+			_html(`${_escape(x) || _sep($sg__x)}${_el_resume($scope1_id, "a", $sg__x)}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 		}, _scope_id())
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
@@ -1,19 +1,19 @@
 // template.marko
 var template_default = _template("__tests__/template.marko", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_text = _serialize_guard($scope0_reason, 0), $si__input_text = _serialize_if($scope0_reason, 0);
+	const $scope0_reason = _scope_reason(), $sg__input_text2 = _serialize_guard($scope0_reason, 0), $si__input_text = _serialize_if($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const $input_text__closures = new Set();
 	const Child = { content: _content("__tests__/template.marko_1*content", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(input.text)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 1))} and `);
+		const $scope1_reason = _scope_reason(), $sg__input_text = _serialize_guard($scope1_reason, 1);
+		_html(`${_escape(input.text) || _sep($sg__input_text)}${_el_resume($scope1_id, "#text/0", $sg__input_text)} and `);
 		_dynamic_tag($scope1_id, "#text/1", input.content, {}, 0, 0, _serialize_guard($scope1_reason, 2));
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:1");
 	}, $scope0_id) };
 	const { text } = input;
 	_set_serialize_reason({
-		0: $sg__input_text,
-		1: $sg__input_text
+		0: $sg__input_text2,
+		1: $sg__input_text2
 	});
 	const $childScope = _peek_scope_id();
 	Child.content({
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		content: _content("__tests__/template.marko_2*content", () => {
 			const $scope2_reason = _scope_reason();
 			const $scope2_id = _scope_id();
-			_html(`${_escape(text)}${_el_resume($scope2_id, "#text/0", $sg__input_text)}`);
+			_html(`${_escape(text) || _sep($sg__input_text2)}${_el_resume($scope2_id, "#text/0", $sg__input_text2)}`);
 			$si__input_text && _subscribe($input_text__closures, writeScope($scope2_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "7:1"));
 			_resume_branch($scope2_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
@@ -1,19 +1,19 @@
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason(), $sg__input_text = _serialize_guard($scope0_reason, 0), $si__input_text = _serialize_if($scope0_reason, 0);
+	const $scope0_reason = _scope_reason(), $sg__input_text2 = _serialize_guard($scope0_reason, 0), $si__input_text = _serialize_if($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const $input_text__closures = /* @__PURE__ */ new Set();
 	const Child = { content: _content("a0", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(input.text)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 1))} and `);
+		const $scope1_reason = _scope_reason(), $sg__input_text = _serialize_guard($scope1_reason, 1);
+		_html(`${_escape(input.text) || _sep($sg__input_text)}${_el_resume($scope1_id, "a", $sg__input_text)} and `);
 		_dynamic_tag($scope1_id, "b", input.content, {}, 0, 0, _serialize_guard($scope1_reason, 2));
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}, $scope0_id) };
 	const { text } = input;
 	_set_serialize_reason({
-		0: $sg__input_text,
-		1: $sg__input_text
+		0: $sg__input_text2,
+		1: $sg__input_text2
 	});
 	const $childScope = _peek_scope_id();
 	Child.content({
@@ -21,7 +21,7 @@ var template_default = _template("a", (input) => {
 		content: _content("a1", () => {
 			_scope_reason();
 			const $scope2_id = _scope_id();
-			_html(`${_escape(text)}${_el_resume($scope2_id, "a", $sg__input_text)}`);
+			_html(`${_escape(text) || _sep($sg__input_text2)}${_el_resume($scope2_id, "a", $sg__input_text2)}`);
 			$si__input_text && _subscribe($input_text__closures, writeScope($scope2_id, { _: _scope_with_id($scope0_id) }));
 			_resume_branch($scope2_id);
 		}, $scope0_id)

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
@@ -4,8 +4,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const Foo = { content: _content("__tests__/template.marko_1*content", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(input.foo || "fallback")}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}`);
+		const $scope1_reason = _scope_reason(), $sg__input_foo = _serialize_guard($scope1_reason, 0);
+		_html(`${_escape(input.foo || "fallback") || _sep($sg__input_foo)}${_el_resume($scope1_id, "#text/0", $sg__input_foo)}`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 	}, $scope0_id) };
 	const Bar = { content: _content("__tests__/template.marko_2*content", (input) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
@@ -4,8 +4,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const Foo = { content: _content("a0", (input) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(input.foo || "fallback")}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
+		const $scope1_reason = _scope_reason(), $sg__input_foo = _serialize_guard($scope1_reason, 0);
+		_html(`${_escape(input.foo || "fallback") || _sep($sg__input_foo)}${_el_resume($scope1_id, "a", $sg__input_foo)}`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}, $scope0_id) };
 	({ content: _content("a1", (input) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.bundle.debug.js
@@ -1,10 +1,10 @@
 // template.marko
 var template_default = _template("__tests__/template.marko", (input) => {
-	const $scope0_reason = _scope_reason();
+	const $scope0_reason = _scope_reason(), $sg__input_a = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { a } = input;
 	let b = a * 2;
-	_html(`<button>Increment</button>${_el_resume($scope0_id, "#button/0")}${_escape(a)}${_el_resume($scope0_id, "#text/1", _serialize_guard($scope0_reason, 0))} <!>${_escape(b)}${_el_resume($scope0_id, "#text/2")}`);
+	_html(`<button>Increment</button>${_el_resume($scope0_id, "#button/0")}${_escape(a) || _sep($sg__input_a)}${_el_resume($scope0_id, "#text/1", $sg__input_a)} <!>${_escape(b)}${_el_resume($scope0_id, "#text/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { b }, "__tests__/template.marko", 0, { b: "2:6" });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-derived/__snapshots__/html.bundle.js
@@ -1,10 +1,10 @@
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason();
+	const $sg__input_a = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	const { a } = input;
 	let b = a * 2;
-	_html(`<button>Increment</button>${_el_resume($scope0_id, "a")}${_escape(a)}${_el_resume($scope0_id, "b", _serialize_guard($scope0_reason, 0))} <!>${_escape(b)}${_el_resume($scope0_id, "c")}`);
+	_html(`<button>Increment</button>${_el_resume($scope0_id, "a")}${_escape(a) || _sep($sg__input_a)}${_el_resume($scope0_id, "b", $sg__input_a)} <!>${_escape(b)}${_el_resume($scope0_id, "c")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { g: b });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const y = x + 1;
 	const z = x + 2;
 	const a = y + z;
-	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}${_escape(y)}${_el_resume($scope0_id, "#text/2")} <!>${_escape(z)}${_el_resume($scope0_id, "#text/3")} <!>${_escape(a)}${_el_resume($scope0_id, "#text/4")}`);
+	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}${_escape(y) || "<!>"}${_el_resume($scope0_id, "#text/2")} <!>${_escape(z)}${_el_resume($scope0_id, "#text/3")} <!>${_escape(a)}${_el_resume($scope0_id, "#text/4")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { x }, "__tests__/template.marko", 0, { x: "1:6" });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-with-intersection/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let x = 1;
-	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}${_escape(2)}${_el_resume($scope0_id, "c")} <!>${_escape(3)}${_el_resume($scope0_id, "d")} <!>${_escape(5)}${_el_resume($scope0_id, "e")}`);
+	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}${_escape(2) || "<!>"}${_el_resume($scope0_id, "c")} <!>${_escape(3)}${_el_resume($scope0_id, "d")} <!>${_escape(5)}${_el_resume($scope0_id, "e")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { f: x });
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let x = 1;
 	let y = 1;
-	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}${_escape(y)}${_el_resume($scope0_id, "#text/2")}`);
+	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "#text/1")}</button>${_el_resume($scope0_id, "#button/0")}${_escape(y) || "<!>"}${_el_resume($scope0_id, "#text/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {
 		x,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let x = 1;
 	let y = 1;
-	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}${_escape(y)}${_el_resume($scope0_id, "c")}`);
+	_html(`<button>${_escape(x)}${_el_resume($scope0_id, "b")}</button>${_el_resume($scope0_id, "a")}${_escape(y) || "<!>"}${_el_resume($scope0_id, "c")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {
 		d: x,

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
@@ -4,8 +4,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const A = { content: _content("__tests__/template.marko_1*content", ({ value }) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(value)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}`);
+		const $scope1_reason = _scope_reason(), $sg__value = _serialize_guard($scope1_reason, 0);
+		_html(`${_escape(value) || _sep($sg__value)}${_el_resume($scope1_id, "#text/0", $sg__value)}`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:1");
 	}, $scope0_id) };
 	const B = { content: _content("__tests__/template.marko_2*content", ({ value }) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
@@ -4,8 +4,8 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const A = { content: _content("a0", ({ value }) => {
 		const $scope1_id = _scope_id();
-		const $scope1_reason = _scope_reason();
-		_html(`${_escape(value)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
+		const $scope1_reason = _scope_reason(), $sg__value = _serialize_guard($scope1_reason, 0);
+		_html(`${_escape(value) || _sep($sg__value)}${_el_resume($scope1_id, "a", $sg__value)}`);
 		_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 	}, $scope0_id) };
 	const B = { content: _content("a1", ({ value }) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html("<div>");
 	_for_of(children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-children/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var template_default = _template("a", (input) => {
 	_html("<div>");
 	_for_of(children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {});
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/html.bundle.debug.js
@@ -4,7 +4,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	_for_of(input.children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/move-and-clear-top-level/__snapshots__/html.bundle.js
@@ -4,7 +4,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	_for_of(input.children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {});
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.debug.js
@@ -20,9 +20,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	my_for_default({
 		to: 5,
 		content: _content("__tests__/template.marko_1*content", (i) => {
-			const $scope1_reason = _scope_reason();
+			const $scope1_reason = _scope_reason(), $sg__i = _serialize_guard($scope1_reason, 0);
 			const $scope1_id = _scope_id();
-			_html(`${_escape(i)}${_el_resume($scope1_id, "#text/0", _serialize_guard($scope1_reason, 0))}`);
+			_html(`${_escape(i) || _sep($sg__i)}${_el_resume($scope1_id, "#text/0", $sg__i)}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {}, "__tests__/template.marko", "1:2");
 		}, $scope0_id)
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
@@ -19,9 +19,9 @@ var template_default = _template("a", (input) => {
 	my_for_default({
 		to: 5,
 		content: _content("a0", (i) => {
-			const $scope1_reason = _scope_reason();
+			const $scope1_reason = _scope_reason(), $sg__i = _serialize_guard($scope1_reason, 0);
 			const $scope1_id = _scope_id();
-			_html(`${_escape(i)}${_el_resume($scope1_id, "a", _serialize_guard($scope1_reason, 0))}`);
+			_html(`${_escape(i) || _sep($sg__i)}${_el_resume($scope1_id, "a", $sg__i)}`);
 			_serialize_if($scope1_reason, 0) && writeScope($scope1_id, {});
 		}, _scope_id())
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_dynamic_tag($scope0_id, "#text/5", Parent, {}, _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
-		_html(`${_unescaped(input.value)}${_el_resume($scope1_id, "#text/0", $sg__input_value)}`);
+		_html(`${_unescaped(input.value) || _sep($sg__input_value)}${_el_resume($scope1_id, "#text/0", $sg__input_value)}`);
 		_subscribe($si__input_value && $input_value__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "12:3"));
 		_resume_branch($scope1_id);
 	}, $scope0_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/namespaced-tags/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("a", (input) => {
 	_dynamic_tag($scope0_id, "f", Parent, {}, _content_resume("a2", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_html(`${_unescaped(input.value)}${_el_resume($scope1_id, "a", $sg__input_value)}`);
+		_html(`${_unescaped(input.value) || _sep($sg__input_value)}${_el_resume($scope1_id, "a", $sg__input_value)}`);
 		_subscribe($si__input_value && $input_value__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 		_resume_branch($scope1_id);
 	}, $scope0_id));

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		$item = attrTags($item, { content: _content_resume("__tests__/template.marko_3*content", () => {
 			_scope_reason();
 			const $scope3_id = _scope_id();
-			_html(`${_escape(i)}${_el_resume($scope3_id, "#text/0")}`);
+			_html(`${_escape(i) || "<!>"}${_el_resume($scope3_id, "#text/0")}`);
 			writeScope($scope3_id, {}, "__tests__/template.marko", "11:6");
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 		$item = attrTags($item, { content: _content_resume("a2", () => {
 			_scope_reason();
 			const $scope3_id = _scope_id();
-			_html(`${_escape(i)}${_el_resume($scope3_id, "a")}`);
+			_html(`${_escape(i) || "<!>"}${_el_resume($scope3_id, "a")}`);
 			writeScope($scope3_id, {});
 		}, $scope0_id) });
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/__snapshots__/html.bundle.debug.js
@@ -3,7 +3,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let b = "";
-	_html(`<div><span>s</span><!>${_escape(b)}${_el_resume($scope0_id, "#text/0")}</div><div><!--note--><!>${_escape(b)}${_el_resume($scope0_id, "#text/1")}</div><button>set</button>${_el_resume($scope0_id, "#button/2")}`);
+	_html(`<div><span>s</span>${_escape(b) || "<!>"}${_el_resume($scope0_id, "#text/0")}</div><div><!--note-->${_escape(b) || "<!>"}${_el_resume($scope0_id, "#text/1")}</div><button>set</button>${_el_resume($scope0_id, "#button/2")}`);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-after-node/__snapshots__/html.bundle.js
@@ -3,7 +3,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let b = "";
-	_html(`<div><span>s</span><!>${_escape(b)}${_el_resume($scope0_id, "a")}</div><div><!--note--><!>${_escape(b)}${_el_resume($scope0_id, "b")}</div><button>set</button>${_el_resume($scope0_id, "c")}`);
+	_html(`<div><span>s</span>${_escape(b) || "<!>"}${_el_resume($scope0_id, "a")}</div><div><!--note-->${_escape(b) || "<!>"}${_el_resume($scope0_id, "b")}</div><button>set</button>${_el_resume($scope0_id, "c")}`);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, {});
 	_resume_branch($scope0_id);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+const $template = "<!><!><!><button>fill</button>";
+const $walks = "b%b%b b";
+const $for_content__x = /*@__PURE__*/ _for_closure("#text/1", ($scope) => _text($scope["#text/0"], $scope._.x));
+const $for_content__setup = $for_content__x;
+const $if_content__x = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => _text($scope["#text/0"], $scope._.x));
+const $if_content__setup = $if_content__x;
+const $x = /*@__PURE__*/ _let("x/3", ($scope) => {
+	$if_content__x($scope);
+	$for_content__x($scope);
+});
+const $if = /*@__PURE__*/ _if("#text/0", " ", " ", $if_content__setup);
+const $for = /*@__PURE__*/ _for_of("#text/1", "<!> tail", "%", $for_content__setup);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/2"], "click", function() {
+	$x($scope, "filled");
+}));
+function $setup($scope) {
+	$x($scope, "");
+	$if($scope, true ? 0 : 1);
+	$for($scope, [[1]]);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/dom.bundle.js
@@ -1,0 +1,10 @@
+// template.marko
+const $for_content__x = /*@__PURE__*/ _for_closure(1, ($scope) => _text($scope.a, $scope._.d));
+const $if_content__x = /*@__PURE__*/ _if_closure(0, 0, ($scope) => _text($scope.a, $scope._.d));
+const $x = /*@__PURE__*/ _let(3, ($scope) => {
+	$if_content__x($scope);
+	$for_content__x($scope);
+});
+const $setup__script = _script("a0", ($scope) => _on($scope.c, "click", function() {
+	$x($scope, "filled");
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = "";
+	_if(() => {
+		if (true) {
+			const $scope1_id = _scope_id();
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope1_id, "#text/0")}`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2");
+			return 0;
+		}
+	}, $scope0_id, "#text/0", 1, 0, 0, 0, 1);
+	_for_of([1], (i) => {
+		const $scope2_id = _scope_id();
+		_html(`${_escape(x) || "<!>"}${_el_resume($scope2_id, "#text/0")} tail`);
+		writeScope($scope2_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2");
+	}, 0, $scope0_id, "#text/1", 1, 0, 0);
+	_html(`<button>fill</button>${_el_resume($scope0_id, "#button/2")}`);
+	_script($scope0_id, "__tests__/template.marko_0");
+	writeScope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/html.bundle.js
@@ -1,0 +1,23 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let x = "";
+	_if(() => {
+		{
+			const $scope1_id = _scope_id();
+			_html(`${_escape(x) || "<!>"}${_el_resume($scope1_id, "a")}`);
+			writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
+			return 0;
+		}
+	}, $scope0_id, "a", 1, 0, 0, 0, 1);
+	_for_of([1], (i) => {
+		const $scope2_id = _scope_id();
+		_html(`${_escape(x) || "<!>"}${_el_resume($scope2_id, "a")} tail`);
+		writeScope($scope2_id, { _: _scope_with_id($scope0_id) });
+	}, 0, $scope0_id, "b", 1, 0, 0);
+	_html(`<button>fill</button>${_el_resume($scope0_id, "c")}`);
+	_script($scope0_id, "a0");
+	writeScope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/render.debug.md
@@ -1,0 +1,23 @@
+# Render
+```html
+tail
+<button>
+  fill
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+filledfilled tail
+<button>
+  fill
+</button>
+```
+## Change
+```
+UPDATE: ::text@0 "" => "filled"
+UPDATE: ::text@6 "" => "filled"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/render.md
@@ -1,0 +1,23 @@
+# Render
+```html
+tail
+<button>
+  fill
+</button>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+filledfilled tail
+<button>
+  fill
+</button>
+```
+## Change
+```
+UPDATE: ::text@0 "" => "filled"
+UPDATE: ::text@6 "" => "filled"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/writes.debug.html
@@ -1,0 +1,16 @@
+<!><!--M_*2 #text/0-->
+  <!><!--M_*3 #text/0--> tail<button>fill</button><!--M_*1 #button/2-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ => [1, {
+          "BranchScopes:#text/0": _(2),
+          "BranchScopes:#text/1": _(3)
+        }, {
+          _: _(1)
+        }, {
+          _: _(1)
+        }],
+        "packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/template.marko_0 1"
+      ];
+      M._.w()
+    </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/__snapshots__/writes.html
@@ -1,0 +1,14 @@
+<!><!--M_*2 a-->
+  <!><!--M_*3 a--> tail<button>fill</button><!--M_*1 c-->
+    <script>
+      WALKER_RUNTIME("M")("_");
+      M._.r = [_ => [1, {
+        Aa: _(2),
+        Ab: _(3)
+      }, {
+        _: _(1)
+      }, {
+        _: _(1)
+      }], "a0 1"];
+      M._.w()
+    </script>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2928,
+      "brotli": 1463
+    }
+  },
+  "html": {
+    "min": 409,
+    "brotli": 280
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/template.marko
@@ -1,0 +1,4 @@
+<let/x=""/>
+<if=true>${x}</if>
+<for|i| of=[1]>${x} tail</for>
+<button onClick() { x = "filled" }>fill</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholder-empty-at-section-start/test.ts
@@ -1,0 +1,10 @@
+import type { TestConfig } from "../../main.test";
+
+export const config: TestConfig = {
+  steps: [
+    {},
+    (document: Document) => {
+      document.querySelector("button")!.click();
+    },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders/__snapshots__/html.bundle.debug.js
@@ -2,7 +2,7 @@
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "#text/0", $sg__input_x)}<span>${_escape(input.x)}${_el_resume($scope0_id, "#text/1", $sg__input_x)}<div></div></span><div><div>a</div>${_escape(input.x)}${_el_resume($scope0_id, "#text/2", $sg__input_x)}Hello Text &lt;a/>${_sep($sg__input_x)}${_unescaped(input.x)}${_el_resume($scope0_id, "#text/3", $sg__input_x)}Hello HTML <span>hi</span><script${_attr_nonce()}>${_escape_script(`
+	_html(`${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "#text/0", $sg__input_x)}<span>${_escape(input.x)}${_el_resume($scope0_id, "#text/1", $sg__input_x)}<div></div></span><div><div>a</div>${_escape(input.x) || _sep($sg__input_x)}${_el_resume($scope0_id, "#text/2", $sg__input_x)}Hello Text &lt;a/>${_sep($sg__input_x)}${_unescaped(input.x)}${_el_resume($scope0_id, "#text/3", $sg__input_x)}Hello HTML <span>hi</span><script${_attr_nonce()}>${_escape_script(`
     ${_to_text("'Hello <b> <\/script>'")}
   `)}<\/script><style${_attr_nonce()}>${_escape_style(`
     ${_to_text(".test { content: 'Hello <b> </style>' }")}

--- a/packages/runtime-tags/src/__tests__/fixtures/placeholders/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/placeholders/__snapshots__/html.bundle.js
@@ -2,7 +2,7 @@
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_html(`${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "a", $sg__input_x)}<span>${_escape(input.x)}${_el_resume($scope0_id, "b", $sg__input_x)}<div></div></span><div><div>a</div>${_escape(input.x)}${_el_resume($scope0_id, "c", $sg__input_x)}Hello Text &lt;a/>${_sep($sg__input_x)}${_unescaped(input.x)}${_el_resume($scope0_id, "d", $sg__input_x)}Hello HTML <span>hi</span><script${_attr_nonce()}>${_escape_script(`
+	_html(`${_sep($sg__input_x)}${_escape(input.x)}${_el_resume($scope0_id, "a", $sg__input_x)}<span>${_escape(input.x)}${_el_resume($scope0_id, "b", $sg__input_x)}<div></div></span><div><div>a</div>${_escape(input.x) || _sep($sg__input_x)}${_el_resume($scope0_id, "c", $sg__input_x)}Hello Text &lt;a/>${_sep($sg__input_x)}${_unescaped(input.x)}${_el_resume($scope0_id, "d", $sg__input_x)}Hello HTML <span>hi</span><script${_attr_nonce()}>${_escape_script(`
     ${_to_text("'Hello <b> <\/script>'")}
   `)}<\/script><style${_attr_nonce()}>${_escape_style(`
     ${_to_text(".test { content: 'Hello <b> </style>' }")}

--- a/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html("<div>");
 	_for_of(children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "#text/0", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {}, "__tests__/template.marko", "3:4");
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/remove-and-add-rows/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var template_default = _template("a", (input) => {
 	_html("<div>");
 	_for_of(children, (child) => {
 		const $scope1_id = _scope_id();
-		_html(`${_escape(child.text)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
+		_html(`${_escape(child.text) || _sep($sg__input_children)}${_el_resume($scope1_id, "a", $sg__input_children)}`);
 		$si__input_children && writeScope($scope1_id, {});
 	}, function(c) {
 		return c.id;

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/html.bundle.debug.js
@@ -1,11 +1,11 @@
 // template.marko
 var template_default = _template("__tests__/template.marko", (input) => {
-	const $scope0_reason = _scope_reason();
+	const $scope0_reason = _scope_reason(), $sg__input_note = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	let reveal = false;
 	_html(`<button>reveal</button>${_el_resume($scope0_id, "#button/0")}`);
 	_show_start(reveal, 1);
-	_html(`${_escape(input.note)}${_el_resume($scope0_id, "#text/2", _serialize_guard($scope0_reason, 0))}`);
+	_html(`${_escape(input.note) || _sep($sg__input_note)}${_el_resume($scope0_id, "#text/2", $sg__input_note)}`);
 	_show_end($scope0_id, "#text/4", reveal);
 	_script($scope0_id, "__tests__/template.marko_0");
 	writeScope($scope0_id, { reveal }, "__tests__/template.marko", 0, { reveal: "1:6" });

--- a/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/show-tag-empty-body/__snapshots__/html.bundle.js
@@ -1,11 +1,11 @@
 // template.marko
 var template_default = _template("a", (input) => {
-	const $scope0_reason = _scope_reason();
+	const $sg__input_note = _serialize_guard(_scope_reason(), 0);
 	const $scope0_id = _scope_id();
 	let reveal = false;
 	_html(`<button>reveal</button>${_el_resume($scope0_id, "a")}`);
 	_show_start(reveal, 1);
-	_html(`${_escape(input.note)}${_el_resume($scope0_id, "c", _serialize_guard($scope0_reason, 0))}`);
+	_html(`${_escape(input.note) || _sep($sg__input_note)}${_el_resume($scope0_id, "c", $sg__input_note)}`);
 	_show_end($scope0_id, "e", reveal);
 	_script($scope0_id, "a0");
 	writeScope($scope0_id, { i: reveal });

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/html.bundle.debug.js
@@ -25,9 +25,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_html("LOADING...");
 		}, $scope0_id) }),
 		catch: attrTag({ content: _content_resume("__tests__/template.marko_3*content", (err) => {
-			const $scope3_reason = _scope_reason();
+			const $scope3_reason = _scope_reason(), $sg__err = _serialize_guard($scope3_reason, 0);
 			const $scope3_id = _scope_id();
-			_html(`${_escape(err)}${_el_resume($scope3_id, "#text/0", _serialize_guard($scope3_reason, 0))}`);
+			_html(`${_escape(err) || _sep($sg__err)}${_el_resume($scope3_id, "#text/0", $sg__err)}`);
 			_serialize_if($scope3_reason, 0) && writeScope($scope3_id, {}, "__tests__/template.marko", "17:4");
 		}, $scope0_id) })
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-async/__snapshots__/html.bundle.js
@@ -25,9 +25,9 @@ var template_default = _template("a", (input) => {
 			_html("LOADING...");
 		}, $scope0_id) }),
 		catch: attrTag({ content: _content_resume("a1", (err) => {
-			const $scope3_reason = _scope_reason();
+			const $scope3_reason = _scope_reason(), $sg__err = _serialize_guard($scope3_reason, 0);
 			const $scope3_id = _scope_id();
-			_html(`${_escape(err)}${_el_resume($scope3_id, "a", _serialize_guard($scope3_reason, 0))}`);
+			_html(`${_escape(err) || _sep($sg__err)}${_el_resume($scope3_id, "a", $sg__err)}`);
 			_serialize_if($scope3_reason, 0) && writeScope($scope3_id, {});
 		}, $scope0_id) })
 	});

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/html.bundle.debug.js
@@ -16,9 +16,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "4:2"));
 		_resume_branch($scope1_id);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_2*content", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err) || _sep($sg__err)}${_el_resume($scope2_id, "#text/0", $sg__err)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "12:4");
 	}, $scope0_id) }) });
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch-state/__snapshots__/html.bundle.js
@@ -14,9 +14,9 @@ var template_default = _template("a", (input) => {
 		_subscribe($clickCount__closures, writeScope($scope1_id, { _: _scope_with_id($scope0_id) }));
 		_resume_branch($scope1_id);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err) || _sep($sg__err)}${_el_resume($scope2_id, "a", $sg__err)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}, $scope0_id) }) });
 	writeScope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/html.bundle.debug.js
@@ -12,9 +12,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_script($scope1_id, "__tests__/template.marko_1");
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "2:2");
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_2*content", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err.message)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err.message) || _sep($sg__err_message)}${_el_resume($scope2_id, "#text/0", $sg__err_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "7:4");
 	}, $scope0_id) }) });
 	_html(`<div></div>${_el_resume($scope0_id, "#div/2")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-effects-catch/__snapshots__/html.bundle.js
@@ -12,9 +12,9 @@ var template_default = _template("a", (input) => {
 		_script($scope1_id, "a2");
 		writeScope($scope1_id, { _: _scope_with_id($scope0_id) });
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err.message)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err.message) || _sep($sg__err_message)}${_el_resume($scope2_id, "a", $sg__err_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}, $scope0_id) }) });
 	_html(`<div></div>${_el_resume($scope0_id, "c")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/html.bundle.debug.js
@@ -10,9 +10,9 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			throw new Error("ERROR!");
 		})())}`);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("__tests__/template.marko_2*content", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err.message)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err.message) || _sep($sg__err_message)}${_el_resume($scope2_id, "#text/0", $sg__err_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {}, "__tests__/template.marko", "5:3");
 	}, $scope0_id) }) });
 	_html("After");

--- a/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-single-throw-sync/__snapshots__/html.bundle.js
@@ -10,9 +10,9 @@ var template_default = _template("a", (input) => {
 			throw new Error("ERROR!");
 		})())}`);
 	}, $scope0_id), { catch: attrTag({ content: _content_resume("a0", (err) => {
-		const $scope2_reason = _scope_reason();
+		const $scope2_reason = _scope_reason(), $sg__err_message = _serialize_guard($scope2_reason, 0);
 		const $scope2_id = _scope_id();
-		_html(`${_escape(err.message)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		_html(`${_escape(err.message) || _sep($sg__err_message)}${_el_resume($scope2_id, "a", $sg__err_message)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {});
 	}, $scope0_id) }) });
 	_html("After");

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
@@ -21,8 +21,8 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id) };
 	const Message = { content: _content("__tests__/template.marko_2*content", (input) => {
 		const $scope2_id = _scope_id();
-		const $scope2_reason = _scope_reason();
-		_html(`${_escape(input.before + input.after)}${_el_resume($scope2_id, "#text/0", _serialize_guard($scope2_reason, 0))}`);
+		const $scope2_reason = _scope_reason(), $sg__input_before__OR__input_after = _serialize_guard($scope2_reason, 0);
+		_html(`${_escape(input.before + input.after) || _sep($sg__input_before__OR__input_after)}${_el_resume($scope2_id, "#text/0", $sg__input_before__OR__input_after)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {
 			input_before: _serialize_if($scope2_reason, 2) && input.before,
 			input_after: _serialize_if($scope2_reason, 1) && input.after

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
@@ -17,8 +17,8 @@ var template_default = _template("a", (input) => {
 	}, $scope0_id) };
 	const Message = { content: _content("a2", (input) => {
 		const $scope2_id = _scope_id();
-		const $scope2_reason = _scope_reason();
-		_html(`${_escape(input.before + input.after)}${_el_resume($scope2_id, "a", _serialize_guard($scope2_reason, 0))}`);
+		const $scope2_reason = _scope_reason(), $sg__input_before__OR__input_after = _serialize_guard($scope2_reason, 0);
+		_html(`${_escape(input.before + input.after) || _sep($sg__input_before__OR__input_after)}${_el_resume($scope2_id, "a", $sg__input_before__OR__input_after)}`);
 		_serialize_if($scope2_reason, 0) && writeScope($scope2_id, {
 			d: _serialize_if($scope2_reason, 2) && input.before,
 			e: _serialize_if($scope2_reason, 1) && input.after

--- a/packages/runtime-tags/src/translator/visitors/constants/sibling-text.ts
+++ b/packages/runtime-tags/src/translator/visitors/constants/sibling-text.ts
@@ -1,9 +1,6 @@
 export const None = 0;
 export const Before = 1;
 export const After = 2;
-// A non-text node (element/comment) directly precedes: no text to merge
-// with, but resume must not claim that node when the text renders empty.
-export const NodeBefore = 3;
 
 type Self = typeof import("./sibling-text");
 export type Value = Self[keyof Self];

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -38,11 +38,13 @@ import { scopeIdentifier } from "./program";
 
 const kNodeBinding = Symbol("placeholder node binding");
 const kSiblingText = Symbol("placeholder has sibling text");
+const kSeparateWhenEmpty = Symbol("placeholder must resume as its own node");
 type SiblingText = SiblingText.Value;
 declare module "@marko/compiler/dist/types" {
   export interface MarkoPlaceholderExtra {
     [kNodeBinding]?: Binding;
     [kSiblingText]?: SiblingText;
+    [kSeparateWhenEmpty]?: true;
   }
 }
 
@@ -162,22 +164,27 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     const markerSerializeReason =
       nodeBinding && getSerializeReason(section, nodeBinding);
 
-    if (isHTML && markerSerializeReason) {
-      if (siblingText === SiblingText.Before) {
-        writeSeparator(write, section, markerSerializeReason);
-      } else if (siblingText === SiblingText.NodeBefore) {
-        // A preceding element/comment would be claimed as the text node when
-        // the value serializes empty, so it gets the same protective separator.
-        writeSeparator(write, section, markerSerializeReason);
-      }
-    }
-
     if (isHTML) {
-      write`${
+      let text =
         method === "_escape"
           ? buildEscapedTextExpression(value)
-          : callRuntime(method as HTMLMethod | DOMMethod, value)
-      }`;
+          : callRuntime(method as HTMLMethod | DOMMethod, value);
+
+      if (markerSerializeReason) {
+        if (siblingText === SiblingText.Before) {
+          // Sibling text merges into this node, so it always needs separating.
+          write`${buildSeparator(section, markerSerializeReason)}`;
+        } else if (extra[kSeparateWhenEmpty]) {
+          // A sibling node is only claimed when there is no text node at all.
+          text = t.logicalExpression(
+            "||",
+            text,
+            buildSeparator(section, markerSerializeReason),
+          );
+        }
+      }
+
+      write`${text}`;
       if (nodeBinding) {
         writer.markNode(placeholder, nodeBinding, markerSerializeReason);
       }
@@ -254,23 +261,18 @@ function buildEscapedTextExpression(value: t.Expression): t.Expression {
   }
 }
 
-// The `<!>` separator keeps resume from claiming the previous node as the
-// placeholder's text node when the serialized text is empty.
-function writeSeparator(
-  write: ReturnType<typeof writer.writeTo>,
+// An empty comment for resume to replace with the placeholder's own text node.
+function buildSeparator(
   section: Section,
   reason: Exclude<ReturnType<typeof getSerializeReason>, undefined | false>,
 ) {
-  if (reason === true || reason.state) {
-    write`<!>`;
-  } else {
-    write`${callRuntime("_sep", getSerializeGuard(section, reason, true))}`;
-  }
+  return reason === true || reason.state
+    ? t.stringLiteral("<!>")
+    : callRuntime("_sep", getSerializeGuard(section, reason, true));
 }
 
 function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
   const placeholderExtra = placeholder.node.extra!;
-  let hasNodeBefore = false;
   let prev = placeholder.getPrevSibling();
   let prevParent: t.NodePath = placeholder.parentPath;
   for (;;) {
@@ -298,12 +300,19 @@ function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     ) {
       return (placeholderExtra[kSiblingText] = SiblingText.Before);
     } else {
-      hasNodeBefore = true;
+      placeholderExtra[kSeparateWhenEmpty] = true;
       break;
     }
   }
-  if (!prev.node && prevParent.isProgram()) {
-    return (placeholderExtra[kSiblingText] = SiblingText.Before);
+  if (!prev.node) {
+    if (prevParent.isProgram()) {
+      return (placeholderExtra[kSiblingText] = SiblingText.Before);
+    }
+    // A section's content is resumed as its own range, so its first node
+    // cannot be borrowed from whatever the section was rendered against.
+    if (prevParent.node.extra?.section) {
+      placeholderExtra[kSeparateWhenEmpty] = true;
+    }
   }
   let next = placeholder.getNextSibling();
   let nextParent: t.NodePath = placeholder.parentPath;
@@ -337,9 +346,7 @@ function analyzeSiblingText(placeholder: t.NodePath<t.MarkoPlaceholder>) {
     return (placeholderExtra[kSiblingText] = SiblingText.After);
   }
 
-  return (placeholderExtra[kSiblingText] = hasNodeBefore
-    ? SiblingText.NodeBefore
-    : SiblingText.None);
+  return (placeholderExtra[kSiblingText] = SiblingText.None);
 }
 
 // Returns the owner tag when `parent` is the body of a tag that inlines its


### PR DESCRIPTION
### Cause

#3143 stopped serializing `&zwj;` for empty placeholder text. That text had guaranteed a text node existed at the placeholder's position; without it, resume's visit for the placeholder's marker claims whatever node happens to precede that marker instead. #3143's follow-up added the `<!>` separator for the case where an element or comment directly precedes, but two positions were left uncovered.

**A preceding node with text after it.** The finding was stored in `SiblingText` — the enum for which sibling text merges with the placeholder — so the scan for a following text sibling overwrote it, and `After` writes no separator. `<input value:=value/>` followed by `${value}` at the end of a template served `<input><!--marker #input/0--><!--marker #text/1-->`, and the text signal bound to the input's own resume marker, so the value never appeared and never updated. Same for `<div>a</div>${x}text`.

**The start of a section's content.** `<if=true>${x}</if>` or `<for|i| of=[1]>${x} tail</for>` at the top level of a template: the section is resumed as its own range, so its first node cannot be borrowed from whatever the section was rendered against. Neither scan finds a sibling here, so nothing was written and the branch resumed with no node of its own.

### Fix

`SiblingText` goes back to meaning only what merges with the placeholder; the two positions that need a node of their own are tracked apart from it.

They also need their separator at a different time. Sibling text merges into the placeholder's node, so it always needs its own. The other two are only claimed when there is no text node at all, so their separator now falls out of the serialized text (`_escape(x) || "<!>"`, reusing the existing `_sep` when guarded) and is written only when the placeholder renders empty — which also drops the unconditional separator `placeholder-empty-after-node` and `html-comment-var` were paying for on every render.

Translator only. No runtime change, every bundle size is unchanged, and the only serialized output that differs from `main` is the two newly covered empty cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)