### PR TITLE
test: cover the serializer's channel mutations and the compiler's taglib loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,11 @@ jobs:
         uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          # zcov merges every worker's `coverage-v8` dump into this one lcov; a
+          # search also ships those dumps, which codecov cannot parse.
+          files: ./coverage/lcov.info
+          disable_search: true
+          fail_ci_if_error: true
   release:
     runs-on: ubuntu-latest
     needs: [build, test]

--- a/agent-feedback/items/2026-09-02-drop-the-serializer-s-unreachable-boundary-guards.md
+++ b/agent-feedback/items/2026-09-02-drop-the-serializer-s-unreachable-boundary-guards.md
@@ -1,0 +1,12 @@
+---
+type: cleanup
+impact: low
+effort: low
+site: packages/runtime-tags/src/html/serializer.ts › writePromise
+---
+
+# Drop the serializer's unreachable boundary guards
+
+`writePromise`, `writeReadableStream` and `writeAsyncGenerator` each bail with `if (!boundary) return false`, treating the value as unserializable. `State#boundary` is only ever `undefined` before the first write, and the single entry point that reaches these — `Serializer#stringifyScopes(flushes, boundary, channel)` — takes `boundary` as a required `Boundary` and assigns it before delegating, so no call can reach a write with no boundary. `writeReadableStream`'s guard is `!boundary || val.locked`, where the `val.locked` half is live and tested.
+
+Check: coverage over the full suite leaves the taken side of `writePromise`'s and `writeAsyncGenerator`'s `if (!boundary)` unhit (`writeReadableStream`'s reads as covered only because `val.locked` is always evaluated after the dead disjunct); `Serializer#stringifyScopes` has no overload that omits `boundary`.

--- a/agent-feedback/items/2026-09-02-drop-the-unreachable-taglib-id-fallback-and-shorthand.md
+++ b/agent-feedback/items/2026-09-02-drop-the-unreachable-taglib-id-fallback-and-shorthand.md
@@ -1,0 +1,14 @@
+---
+type: cleanup
+impact: low
+effort: low
+site: packages/compiler/src/taglib/loader/loadTaglibFromProps.js › TaglibLoader#load
+---
+
+# Drop the unreachable taglib-id fallback and shorthand re-check
+
+`TaglibLoader#load` guards its package.json lookup with `if (!taglib.id)` — the fix for #73 that reads a sibling `package.json` and uses its `name` as the taglib id, falling back to the file path. `Taglib`'s constructor already runs `this.filePath = this.path = this.id = filePath`, so `taglib.id` is always truthy by then and the whole block is dead: the id is the file path, never the package name.
+
+The same file's `"*"` handler in `loadTagFromProps.js` (`TagLoader#"*"`) has a second dead spot: the first pass over `parts` returns `false` for any part that starts with neither `@` nor `<`, so the identical `else { return false; }` in the second pass cannot run.
+
+Check: coverage over the full suite leaves `loadTaglibFromProps.js` lines 74-88 and `loadTagFromProps.js` line 270 unhit; a fresh `taglib._loader.createTaglib(p)` reports `id === p` before any props load.

--- a/agent-feedback/items/2026-09-02-prune-the-tag-model-methods-nothing-calls.md
+++ b/agent-feedback/items/2026-09-02-prune-the-tag-model-methods-nothing-calls.md
@@ -1,0 +1,14 @@
+---
+type: cleanup
+impact: low
+effort: low
+site: packages/compiler/src/taglib/loader/Tag.js › Tag
+---
+
+# Prune the tag-model methods nothing calls
+
+`Tag#toString`, `Tag#hasAttribute`, `Tag#hasNestedTags`, `Tag#toJSON` and `Tag#setTaglib` have no caller in this repo — `Tag#getAttribute` and `Tag#forEachAttribute` do (via `packages/runtime-class/src/translator/tag/util.js` and `tag/attribute/index.js`), which is what makes the unused half easy to miss. `Taglib#getAttribute` is in the same position.
+
+These objects are handed to compiler plugins and to @marko/language-tools, so whether they are removable is a question about external consumers rather than about this repo; confirming that is the work.
+
+Check: `rg -n '\.setTaglib\(|\.hasNestedTags\(|\.hasAttribute\(' packages/*/src` returns no hit against a taglib `Tag`, and coverage over the full suite leaves each of those methods unhit.

--- a/agent-feedback/items/2026-09-02-route-a-taglib-level-pattern-attribute-into-patternattributes.md
+++ b/agent-feedback/items/2026-09-02-route-a-taglib-level-pattern-attribute-into-patternattributes.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: med
+effort: low
+site: packages/compiler/src/taglib/loader/Taglib.js › Taglib#addAttribute
+---
+
+# Route a taglib-level pattern attribute into `patternAttributes`
+
+`Tag#addAttribute` (`packages/compiler/src/taglib/loader/Tag.js`) pushes an attribute carrying a `pattern` onto `patternAttributes` and everything else onto `attributes`; `Taglib#addAttribute` skips that split and always writes `this.attributes[attribute.key]`. `Lookup` only ever matches patterns out of `patternAttributes` (`packages/compiler/src/taglib/lookup/index.js` › `Lookup#getAttribute` › `findAttributeForTag`, and `Lookup#forEachAttribute`), and `Lookup#addTaglib` merges `patternAttributes: taglib.patternAttributes` — permanently `[]`. So a global `"@data-*": { "pattern": true }` in a `marko.json` compiles its regexp, is stored under the literal key `"data-*"`, and then never matches anything. A tag-level `"@data-*"` works, which is what hides it. `Taglib#getAttribute` has the same pattern loop and no callers at all, so nothing in-repo notices.
+
+Check: register a taglib with `{"@data-*": {"pattern": true, "type": "string"}, "<a-tag>": {"@x": "string"}}`, then `taglib.buildLookup(dir, "@marko/runtime-tags/translator")` — `getAttribute("a-tag", "x")` resolves and `getAttribute("a-tag", "data-id")` is `undefined`, with `lookup.merged.patternAttributes` empty.

--- a/packages/compiler/test/taglib-loader.test.js
+++ b/packages/compiler/test/taglib-loader.test.js
@@ -1,0 +1,294 @@
+import assert from "assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { taglib } from "@marko/compiler";
+
+const {
+  clearCache,
+  createTaglib,
+  loadTag,
+  loadTaglibFromFile,
+  loadTaglibFromProps,
+} = taglib._loader;
+
+// Loading is keyed by file path, so every case writes into a fresh directory.
+let dir;
+
+function write(rel, data) {
+  const file = path.join(dir, rel);
+  fs.mkdirSync(path.dirname(file), { recursive: true });
+  fs.writeFileSync(
+    file,
+    typeof data === "string" ? data : JSON.stringify(data),
+  );
+  return file;
+}
+
+function fromProps(props) {
+  const loaded = createTaglib(path.join(dir, "marko.json"));
+  loadTaglibFromProps(loaded, props);
+  return loaded;
+}
+
+const message = (fn) => {
+  try {
+    fn();
+    assert.fail("expected a failure");
+  } catch (err) {
+    return err.message;
+  }
+};
+
+describe("compiler/taglib-loader", () => {
+  beforeEach(() => {
+    dir = fs.mkdtempSync(path.join(os.tmpdir(), "marko-taglib-loader-"));
+  });
+  afterEach(() => {
+    clearCache();
+    fs.rmSync(dir, { force: true, recursive: true });
+  });
+
+  describe("tag properties", () => {
+    it("renames the tag through the name property", () =>
+      assert.equal(
+        loadTag({ name: "renamed" }, "/x/marko.json").name,
+        "renamed",
+      ));
+
+    it("reads a shorthand nested tag declared as a bare type", () => {
+      const tag = loadTag({ "<item>": "string" }, "/x/marko.json");
+      assert.equal(tag.nestedTags.item.type, "string");
+      assert.equal(tag.attributes.item.type, "object");
+    });
+
+    it("names the target property after the first attribute of the shorthand", () => {
+      const leading = loadTag({ "@a <item>": {} }, "/x/marko.json");
+      assert.equal(leading.nestedTags.item.targetProperty, "a");
+      const trailing = loadTag({ "<item> @a": {} }, "/x/marko.json");
+      assert.equal(trailing.nestedTags.item.targetProperty, "item");
+    });
+
+    it("ignores a shorthand value that is neither an object nor a type", () =>
+      assert.equal(
+        loadTag({ "@a": 5 }, "/x/marko.json").attributes.a.type,
+        null,
+      ));
+
+    it("rejects a property supported by neither the tag nor its attribute", () =>
+      assert.match(
+        message(() => loadTag({ "@a": { bogusProp: 1 } }, "/x/marko.json")),
+        /Unsupported properties of \[bogusProp\]/,
+      ));
+
+    it("rejects a key that is not an attribute or a nested tag", () =>
+      assert.match(
+        message(() => loadTag({ "not-a-tag-or-attr": 1 }, "/x/marko.json")),
+        /Invalid option: not-a-tag-or-attr/,
+      ));
+
+    it("ignores empty attribute groups", () =>
+      assert.equal(
+        loadTag({ attributeGroups: null }, "/x/marko.json").attributeGroups,
+        undefined,
+      ));
+
+    it("takes a list of transforms", () =>
+      assert.deepEqual(
+        loadTag(
+          { transform: ["./a", "./b"] },
+          "/x/marko.json",
+        ).transformers.map((hook) => hook.path),
+        ["./a", "./b"],
+      ));
+
+    it("routes the deprecated hook spellings to their replacements", () => {
+      const tag = loadTag(
+        {
+          migrator: "./m",
+          codeGenerator: "./c",
+          nodeFactory: "./n",
+          transformer: "./t",
+        },
+        "/x/marko.json",
+      );
+      assert.deepEqual(
+        tag.migrators.map((hook) => hook.path),
+        ["./m"],
+      );
+      assert.deepEqual(
+        tag.transformers.map((hook) => hook.path),
+        ["./t"],
+      );
+      assert.equal(tag.translator.path, "./c");
+      assert.equal(tag.parser.path, "./n");
+    });
+
+    it("reports a template that does not exist", () =>
+      assert.match(
+        message(() => loadTag({ template: "./nope.marko" }, "/x/marko.json")),
+        /Template at path "[^"]*nope\.marko" does not exist/,
+      ));
+
+    it("resolves a relative types path and leaves a bare one alone", () => {
+      assert.equal(
+        loadTag({ types: "./types.d.marko" }, "/x/marko.json").types,
+        path.resolve("/x/types.d.marko"),
+      );
+      assert.equal(
+        loadTag({ types: "pkg/types.d.marko" }, "/x/marko.json").types,
+        "pkg/types.d.marko",
+      );
+    });
+  });
+
+  describe("attribute properties", () => {
+    const attr = (props) =>
+      loadTag({ "@a": props }, "/x/marko.json").attributes.a;
+
+    it("takes a declaration with no properties at all", () => {
+      assert.equal(attr(null).name, "a");
+      assert.equal(attr(null).type, null);
+    });
+
+    it("only builds a pattern when the property is exactly true", () => {
+      const patterned = loadTag({ "@a-*": { pattern: true } }, "/x/marko.json");
+      assert.equal(patterned.patternAttributes.length, 1);
+      assert.equal(patterned.getAttribute("a-1").name, "a-*");
+      assert.equal(attr({ pattern: "a-*" }).pattern, null);
+    });
+
+    it("only ignores an attribute when the property is exactly true", () => {
+      assert.equal(attr({ ignore: true }).ignore, true);
+      assert.equal(attr({ ignore: "yes" }).ignore, undefined);
+    });
+
+    it("carries the properties tooling reads off an attribute", () => {
+      assert.equal(
+        attr({ "set-context-flag": "myFlag" }).setContextFlag,
+        "myFlag",
+      );
+      assert.equal(attr({ deprecated: "use b" }).deprecated, "use b");
+    });
+  });
+
+  describe("taglib properties", () => {
+    it("rejects a key that is neither a tag nor an attribute", () =>
+      assert.match(
+        message(() => fromProps({ bogus: 1 })),
+        /Invalid option: bogus/,
+      ));
+
+    it("takes a translate hook", () =>
+      assert.equal(fromProps({ translate: "./t" }).translator.path, "./t"));
+
+    it("serializes the parts a lookup consumes", () =>
+      assert.deepEqual(Object.keys(fromProps({ "<a>": {} }).toJSON()), [
+        "path",
+        "tags",
+        "attributes",
+        "patternAttributes",
+        "imports",
+      ]));
+
+    it("keys a global attribute by its shorthand name", () => {
+      const loaded = fromProps({ "@plain": "string" });
+      assert.equal(loaded.attributes.plain.type, "string");
+      assert.equal(loaded.attributes.plain.key, "plain");
+    });
+
+    it("requires a name on a tag", () =>
+      assert.match(
+        message(() => fromProps({}).addTag({})),
+        /"tag\.name" is required/,
+      ));
+
+    it("requires a name or a pattern on a global attribute", () =>
+      assert.match(
+        message(() => fromProps({}).addAttribute({ key: "x" })),
+        /Invalid attribute/,
+      ));
+  });
+
+  describe("imports", () => {
+    it("pulls in the tags of an imported taglib", () => {
+      write("dep/marko.json", { "<dep-tag>": {} });
+      const loaded = loadTaglibFromFile(
+        write("marko.json", { "taglib-imports": ["./dep/marko.json"] }),
+      );
+      assert.deepEqual(Object.keys(loaded.imports[0].tags), ["dep-tag"]);
+    });
+
+    it("reports an import it cannot resolve", () => {
+      const file = write("marko.json", {
+        "taglib-imports": ["./nope/marko.json"],
+      });
+      assert.match(
+        message(() => loadTaglibFromFile(file)),
+        /Import not found: \.\/nope\/marko\.json/,
+      );
+    });
+
+    it("skips an entry that is not a path", () =>
+      assert.equal(
+        loadTaglibFromFile(write("marko.json", { "taglib-imports": [123] }))
+          .imports,
+        null,
+      ));
+
+    it("imports every dependency taglib of a package.json", () => {
+      write("node_modules/dep-a/marko.json", { "<dep-a-tag>": {} });
+      write("node_modules/dep-a/package.json", { name: "dep-a" });
+      write("node_modules/dep-b/package.json", { name: "dep-b" });
+      write("package.json", {
+        name: "root",
+        dependencies: { "dep-a": "*", "dep-b": "*" },
+      });
+      const loaded = loadTaglibFromFile(
+        write("marko.json", { "taglib-imports": ["./package.json"] }),
+      );
+      assert.equal(loaded.imports.length, 1);
+      assert.deepEqual(Object.keys(loaded.imports[0].tags), ["dep-a-tag"]);
+    });
+
+    it("imports each taglib once, transitively", () => {
+      write("a/marko.json", { "<a-tag>": {} });
+      write("b/marko.json", {
+        "<b-tag>": {},
+        "taglib-imports": ["../a/marko.json"],
+      });
+      const loaded = loadTaglibFromFile(
+        write("marko.json", {
+          "taglib-imports": ["./a/marko.json", "./b/marko.json"],
+        }),
+      );
+      assert.deepEqual(
+        loaded.imports.map((imported) => Object.keys(imported.tags)[0]).sort(),
+        ["a-tag", "b-tag"],
+      );
+    });
+
+    it("gives a taglib imported from within the package the package's name", () => {
+      write("inner/marko.json", { "<inner-tag>": {} });
+      const file = write("marko.json", {
+        "taglib-imports": ["./inner/marko.json"],
+      });
+      const loaded = loadTaglibFromFile(file, false, "outer-pkg");
+      assert.equal(loaded.imports[0].packageName, "outer-pkg");
+      assert.equal(
+        loaded.imports[0].tags["inner-tag"].packageName,
+        "outer-pkg",
+      );
+    });
+
+    it("leaves a taglib imported from outside the package alone", () => {
+      write("outside/marko.json", { "<outside-tag>": {} });
+      const file = write("pkg/marko.json", {
+        "taglib-imports": ["../outside/marko.json"],
+      });
+      const loaded = loadTaglibFromFile(file, false, "outer-pkg");
+      assert.equal(loaded.imports[0].packageName, undefined);
+    });
+  });
+});

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -78,6 +78,8 @@ describe("serializer", () => {
         ));
       it("surrogate pairs stay raw", () =>
         assertStringify("a\u{1F600}b", `"a\u{1F600}b"`));
+      it("surrogate pairs stay raw alongside an escaped character", () =>
+        assertStringify("<a\u{1F600}b", `"\\x3Ca\u{1F600}b"`));
       it("lone surrogates escaped", () => {
         assertStringify("bad\uD800end", `"bad\\ud800end"`);
         assertStringify("bad\uDC00end", `"bad\\udc00end"`);
@@ -251,6 +253,18 @@ describe("serializer", () => {
       );
     });
 
+    it("gives an id to a map holding a symbol key", () =>
+      assertStringify(
+        new Map([[Symbol.for("s"), 1]]),
+        `new Map(_.a=[[Symbol.for("s"),1]])`,
+      ));
+
+    it("gives an id to a map holding a registered function", () => {
+      const mapFn = register("mapFn", function mapFn() {});
+      const map = new Map<unknown, unknown>([[1, mapFn]]);
+      assertStringify(map, `new Map(_.a=[[1,_._.mapFn]])`, { _: { mapFn } });
+    });
+
     it("dedupe value and keys across flushes", () => {
       const serializer = assertSerializer();
       const objA = { a: 1 };
@@ -377,6 +391,58 @@ describe("serializer", () => {
       assert.deepEqual(
         [...rt.map.keys()].map((k) => (k === rt ? "root" : k)),
         ["a", "root", "b"],
+      );
+    });
+
+    it("large Map value is an ancestor", () => {
+      const parent: any = { name: "p" };
+      parent.map = createPaddedMap();
+      parent.map.set("self", parent);
+      const rt = deserialize(parent);
+      assert.equal(rt.map.size, 26);
+      assert.equal(rt.map.get("self"), rt);
+    });
+
+    it("large Map key is an ancestor", () => {
+      const parent: any = { name: "p" };
+      parent.map = createPaddedMap();
+      parent.map.set(parent, "self");
+      const rt = deserialize(parent);
+      assert.equal(rt.map.size, 26);
+      assert.equal(rt.map.get(rt), "self");
+    });
+
+    it("preserves large Map key order around a deferred entry", () => {
+      const parent: any = { name: "p" };
+      parent.map = createPaddedMap();
+      parent.map.set(parent, "self");
+      parent.map.set("after", 1);
+      const rt = deserialize(parent);
+      const keys = [...rt.map.keys()];
+      assert.deepEqual(
+        keys.slice(-2).map((k: unknown) => (k === rt ? "parent" : k)),
+        ["parent", "after"],
+      );
+    });
+
+    it("defers a Map entry whose value is undefined", () => {
+      const parent: any = {};
+      parent.map = new Map([[parent, undefined]]);
+      const rt = deserialize(parent);
+      assert.equal(rt.map.size, 1);
+      assert.equal(rt.map.has(rt), true);
+      assert.equal(rt.map.get(rt), undefined);
+    });
+
+    it("aborts on an unserializable member that follows a deferred one", () => {
+      const { boundary, aborted } = abortingBoundary();
+      const parent: any = {};
+      parent.set = new Set([parent, function unserializable() {}]);
+      new Serializer().stringifyScopes([[1, {}, parent]], boundary);
+      assert.equal(aborted.length, 1);
+      assert.match(
+        String(aborted[0]),
+        /Unable to serialize \(reading set\[1\]\)/,
       );
     });
 
@@ -1217,6 +1283,17 @@ describe("serializer", () => {
       assert.equal(rt.getFloat64(0), 1.5);
     });
 
+    it("view reaching the end of the buffer omits the length", () => {
+      const buf = new ArrayBuffer(8);
+      assert.equal(
+        serialize(new DataView(buf, 4)),
+        `new DataView(new ArrayBuffer(8),4)`,
+      );
+      const rt = deserialize(new DataView(buf, 4));
+      assert.equal(rt.byteOffset, 4);
+      assert.equal(rt.byteLength, 4);
+    });
+
     it("is unserializable over a SharedArrayBuffer rather than emitting a hole", () => {
       if (typeof SharedArrayBuffer === "undefined") return;
       const dv = new DataView(new SharedArrayBuffer(8), 0, 2);
@@ -1614,6 +1691,18 @@ describe("serializer", () => {
       assertStringify(new RegExp("a\ud800b"), `/a\\ud800b/`));
     it("leaves a paired surrogate intact", () =>
       assertStringify(new RegExp("a\u{1f600}b", "u"), `/a\u{1f600}b/u`));
+    it("keeps the flags on the constructor form", () =>
+      assertStringify(new RegExp("a<b", "gi"), `RegExp("a\\x3Cb","gi")`));
+    it("leaves an unrelated escape alone while escaping a raw NUL", () =>
+      assertStringify(
+        new RegExp("\\d" + String.fromCharCode(0)),
+        `/\\d\\x00/`,
+      ));
+    it("leaves an escaped paired surrogate intact", () =>
+      assertStringify(
+        new RegExp("\\\u{1f600}" + String.fromCharCode(0)),
+        `/\\\u{1f600}\\x00/`,
+      ));
   });
 
   describe("function", () => {
@@ -1753,6 +1842,89 @@ describe("serializer", () => {
       serializer.assertStringify(obj, `{a:{b:1}}`);
       serializer.assertStringify({ c: nested }, `{c:_.a=_(1).value.a}`);
       serializer.assertStringify({ d: nested }, `{d:_.a}`);
+    });
+  });
+
+  describe("channel mutations", () => {
+    it("holds back a mutation queued for another ready channel", () => {
+      const { boundary } = abortingBoundary();
+      const serializer = new Serializer();
+      const a = new Set();
+      const b = new Set();
+      serializer.writeCall(1, a, "add", { readyId: "a" });
+      serializer.writeCall(2, b, "add", { readyId: "b" });
+
+      assert.equal(serializer.pending({ readyId: "a" }), true);
+      assert.deepEqual(serializer.pendingReadyChannel(), { readyId: "a" });
+      assert.equal(
+        serializer.stringifyScopes([[1, {}, { a, b }]], boundary, {
+          readyId: "a",
+        }),
+        `_=>(_([1,{a:_.a=new Set,b:new Set}]),(_.a).add(1),0)`,
+      );
+
+      assert.equal(serializer.pending({ readyId: "b" }), true);
+    });
+
+    it("assigns a binding to a mutated object seen for the first time", () => {
+      const { boundary } = abortingBoundary();
+      const serializer = new Serializer();
+      const set = new Set();
+      serializer.writeCall(1, set, "add", undefined);
+      assert.equal(
+        serializer.stringifyScopes([[1, {}, {}]], boundary),
+        `_=>((_.a=new Set).add(1),0)`,
+      );
+    });
+
+    it("aborts when a mutated object or value cannot be serialized", () => {
+      const { boundary, aborted } = abortingBoundary();
+      const serializer = new Serializer();
+      serializer.writeCall(
+        function value() {},
+        function object() {},
+        "add",
+        undefined,
+      );
+      serializer.stringifyScopes([[1, {}, {}]], boundary);
+      assert.equal(aborted.length, 2);
+      for (const err of aborted) {
+        assert.match(String(err), /Unable to serialize\./);
+      }
+    });
+
+    it("aborts when a value is shared between independent ready channels", () => {
+      const { boundary, aborted } = abortingBoundary();
+      const serializer = new Serializer();
+      const shared = { x: 1 };
+      serializer.stringifyScopes([[1, {}, { shared }]], boundary, {
+        readyId: "a",
+      });
+      serializer.stringifyScopes([[2, {}, { shared }]], boundary, {
+        readyId: "b",
+      });
+      assert.equal(aborted.length, 1);
+      assert.match(
+        String(aborted[0]),
+        /shared between independently lazy loaded content/,
+      );
+    });
+
+    it("reaches a value serialized by an ancestor ready channel", () => {
+      const { boundary, aborted } = abortingBoundary();
+      const serializer = new Serializer();
+      const parent = { readyId: "a" };
+      const shared = { x: 1 };
+      serializer.stringifyScopes([[1, {}, { shared }]], boundary, parent);
+      assert.equal(
+        serializer.stringifyScopes([[2, {}, { shared }]], boundary, {
+          readyId: "b",
+          parent,
+        }),
+        `_=>[2,{shared:_.a=_(1).shared}]`,
+      );
+      assert.deepEqual([...serializer.takeChannelDeps()!], ["a"]);
+      assert.deepEqual(aborted, []);
     });
   });
 
@@ -1908,6 +2080,44 @@ describe("serializer", () => {
         returned: undefined,
       });
     });
+    it("stops following the iterator once the boundary aborts", async () => {
+      const { boundary, signal } = abortingBoundary();
+      const serializer = new Serializer();
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => (release = resolve));
+      const iter = (async function* () {
+        yield 1;
+        await gate;
+        yield 2;
+      })();
+
+      serializer.stringifyScopes([[1, {}, { iter }]], boundary);
+      await tick();
+      assert.equal(serializer.stringifyScopes([], boundary), `_=>(_.a.f(1),0)`);
+
+      signal.aborted = true;
+      release();
+      await tick();
+      assert.equal(serializer.stringifyScopes([], boundary), "");
+    });
+
+    it("partially consumed resumes as an exhausted async generator", async () => {
+      const iter = (async function* () {
+        yield 1;
+        yield 2;
+      })();
+      await iter.next();
+      const [result] = assertSerializer().assertStringify(
+        iter,
+        `(async function*(){}())`,
+      ) as [AsyncGenerator];
+      assert.equal(typeof result[Symbol.asyncIterator], "function");
+      assert.deepEqual(await consumeIterator(result), {
+        yielded: [],
+        returned: undefined,
+        errored: undefined,
+      });
+    });
   });
 
   describe("readable stream", () => {
@@ -2013,6 +2223,30 @@ describe("serializer", () => {
         returned: undefined,
         errored,
       });
+    });
+  });
+
+  describe("aborted boundary", () => {
+    it("stops reading a ReadableStream", async () => {
+      const { boundary, signal } = abortingBoundary();
+      const serializer = new Serializer();
+      let ctrl!: ReadableStreamDefaultController<Uint8Array>;
+      const stream = new ReadableStream<Uint8Array>({
+        start: (c) => (ctrl = c),
+      });
+
+      serializer.stringifyScopes([[1, {}, { stream }]], boundary);
+      ctrl.enqueue(new Uint8Array([1]));
+      await tick();
+      assert.equal(
+        serializer.stringifyScopes([], boundary),
+        `_=>(_.a.f(_.b=new Uint8Array([1])),0)`,
+      );
+
+      signal.aborted = true;
+      ctrl.enqueue(new Uint8Array([2]));
+      await tick();
+      assert.equal(serializer.stringifyScopes([], boundary), "");
     });
   });
 
@@ -2163,6 +2397,14 @@ describe("serializer", () => {
       assertStringify(
         { res: res, headers: res.headers },
         `{res:_.b=new Response(null,{headers:{a:"1",b:"2"}}),headers:_.a=_.b.headers}`,
+      );
+    });
+
+    it("headers serialized before their response", () => {
+      const res = new Response(null, { headers: { a: "1", b: "2" } });
+      assertStringify(
+        { headers: res.headers, res },
+        `{headers:_.a=new Headers({a:"1",b:"2"}),res:new Response(null,{headers:_.a})}`,
       );
     });
 
@@ -2706,6 +2948,27 @@ function hasSymbolIterator(
   value: unknown,
 ): value is { [Symbol.iterator](): IterableIterator<unknown> } {
   return Symbol.iterator in (value as any);
+}
+
+function tick() {
+  return new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function abortingBoundary() {
+  const aborted: unknown[] = [];
+  const signal = { aborted: false };
+  return {
+    aborted,
+    signal,
+    boundary: {
+      signal,
+      abort(err: unknown) {
+        aborted.push(err);
+      },
+      startAsync() {},
+      endAsync() {},
+    } as any as Boundary,
+  };
 }
 
 function abortedStringifying(scopes: ScopeFlush[]) {


### PR DESCRIPTION
Adds tests for two areas the suite reached only incidentally, and fixes what was keeping codecov from reporting at all.

`serializer.test.ts` covers the channel-mutation paths behind `Serializer#writeCall` — a mutation held back for another ready channel, a binding assigned to a mutated object on first sight, and the aborts raised when a mutated value or a value shared between independent ready channels cannot be serialized — plus deferred collection-call args, the large-`Map` ancestor path, boundary aborts mid-stream and mid-async-generator, and a few escaping edges (a surrogate pair beside an escaped character, regexp flags on the constructor form, a `DataView` that reaches the end of its buffer).

`taglib-loader.test.js` is new and drives `taglib._loader` directly over temp taglib JSON: the tag property handlers (shorthand nested tags, the deprecated hook spellings, a missing template, relative `types`), the attribute property handlers, and `taglib-imports` — including a package.json import, transitive dedupe, and the package-name inheritance an import from inside the package gets.

The codecov step had no file filter, so it searched the working directory and uploaded `coverage/lcov.info` alongside all 30 of zcov's raw `coverage-v8` dumps — ~70MB per run of input files codecov has no parser for, and the head commit's report never processed. It now uploads the one merged lcov and fails loudly if that file goes missing.

Writing the tests turned up four things that are out of scope here and are filed under `agent-feedback/`: a global `"@x-*"` pattern attribute never reaches the lookup, and three sites that no longer have a reachable path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)