### PR TITLE
test(runtime-tags): cover the html template's mount and $global validation errors

### DIFF
--- a/packages/runtime-tags/src/__tests__/render-result.test.ts
+++ b/packages/runtime-tags/src/__tests__/render-result.test.ts
@@ -59,6 +59,37 @@ describe("runtime-tags/html render result", () => {
 
   after(() => disposeServer?.());
 
+  describe("render options", () => {
+    it("refuses to mount an html-compiled template", () => {
+      assert.throws(
+        () => (sync as any).mount(),
+        /mount\(\) is not implemented for the HTML compilation/,
+      );
+    });
+
+    it("rejects a runtimeId that is not an identifier", () => {
+      assert.throws(
+        () => sync.render({ $global: { runtimeId: "1bad" } }),
+        /Invalid runtimeId: "1bad"/,
+      );
+    });
+
+    it("rejects a renderId that is not an identifier", () => {
+      assert.throws(
+        () => sync.render({ $global: { renderId: "bad-id" } }),
+        /Invalid renderId: "bad-id"/,
+      );
+    });
+
+    it("takes an identifier-shaped runtimeId and renderId", () => {
+      const result = sync.render({
+        name: "world",
+        $global: { runtimeId: "_R", renderId: "r0" },
+      }) as ServerResult;
+      assertBody(result.toString());
+    });
+  });
+
   describe("toString", () => {
     it("returns the html of a synchronous render", () => {
       assertBody(renderSync().toString());


### PR DESCRIPTION
Adds four cases to the render result tests: `mount()` reporting that it is not implemented for an HTML-compiled template, `$global.runtimeId` and `$global.renderId` each rejecting a value that is not identifier-shaped, and a render that passes both to keep the validation from being exercised only by its failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)