### PR TITLE
test: ignore the reference analyzer's invariants, cover the babel-utils file accessors

### DIFF
--- a/packages/compiler/test/babel-utils/get-file.test.js
+++ b/packages/compiler/test/babel-utils/get-file.test.js
@@ -1,0 +1,38 @@
+import assert from "assert/strict";
+import path from "path";
+
+import { compileSync } from "@marko/compiler";
+import { getFile, getProgram } from "@marko/compiler/babel-utils";
+
+// `getFile`/`getProgram` read module state that only a running compilation
+// sets, so a plugin reaching for either outside one has to be told.
+const OUTSIDE = /outside of a compilation/;
+
+describe("compiler/babel-utils getFile", () => {
+  it("reports that there is no file outside a compilation", () =>
+    assert.throws(getFile, OUTSIDE));
+
+  it("reports that there is no program outside a compilation", () =>
+    assert.throws(getProgram, OUTSIDE));
+
+  it("resolves both while a compilation is running", () => {
+    let file;
+    let program;
+    compileSync("<div/>", path.join(import.meta.dirname, "probe.marko"), {
+      code: false,
+      translator: {
+        analyze: {
+          Program() {
+            file = getFile();
+            program = getProgram();
+          },
+        },
+        translate: {},
+        taglibs: [],
+        tagDiscoveryDirs: [],
+      },
+    });
+    assert.ok(file);
+    assert.equal(program, file.path);
+  });
+});

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -919,6 +919,7 @@ export function mergeReferences<T extends t.Node>(
         }
       }
     } else if (extra?.pruned) {
+      /* v8 ignore next -- a dropped reference is never merged into another */
       throw new Error("Cannot merged a dropped reference.");
     }
   }
@@ -1669,6 +1670,7 @@ export function createSources(
   param: Sources["param"],
   global?: Sources["global"],
 ): Sources {
+  /* v8 ignore next 6 -- every caller passes at least one source */
   if (!(state || param || global)) {
     throw new Error(
       "Cannot create a serialize reason that does not reference state, a param, or $global.",
@@ -1807,6 +1809,7 @@ export function dropNodes(node: t.Node | t.Node[]) {
 }
 
 function dropExtra(exprExtra: ReferencedExtra) {
+  /* v8 ignore next 3 -- a merged reference is never dropped */
   if (exprExtra.merged) {
     throw new Error("Cannot drop a merged reference");
   }
@@ -2023,6 +2026,7 @@ export function getPrefixedScopeAccessor(
 
 export function getClosureAccessorId(binding: Binding) {
   const id = closureAccessorIds.get(getCanonicalBinding(binding)!);
+  /* v8 ignore next 5 -- analyze reserves an id for every closure binding */
   if (id === undefined) {
     throw new Error(
       `No closure accessor id was reserved for "${binding.name}".`,


### PR DESCRIPTION
Marks four guards in `references.ts` with `v8 ignore`. Each throws on a translator programming error that no template can reach — merging a dropped reference, dropping a merged one, building a serialize reason with no source, and a missing closure accessor id — so they were counting against coverage with no test that could ever reach them.

Adds tests for `babel-utils`' `getFile` and `getProgram`, which look similar but are not: a plugin calling either outside a running compilation is a reachable mistake, and the error is what tells them so. Covers both guards plus a compilation where the two resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)