### PR TITLE
test(runtime-class): cover the load import's trigger and specifier errors

### DIFF
--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "" }
+        |                                            ^^ The "load" attribute requires "render" or at least one trigger (e.g. "visible.my-element").
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-empty/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-empty/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "idle?bogus=1" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^ Unknown param "bogus" for the "idle" trigger. Supported params: "timeout".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-bad-param/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "idle?bogus=1" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "idle.foo" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "idle.foo" }
+        |                                            ^^^^^^^^^^ Selector is not supported for the "idle" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-idle-selector/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "idle.foo" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "media" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "media" }
+        |                                            ^^^^^^^ A media query is required for the "media" trigger. (e.g. "media(max-width:768px)")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-media-no-query/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "media" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import { Tag } from "./tag.marko" with { load: "visible.x" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:10
+    > 1 | import { Tag } from "./tag.marko" with { load: "visible.x" }
+        |          ^^^ Invalid load import, only a default specifier is allowed.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-named-specifier/template.marko
@@ -1,0 +1,2 @@
+import { Tag } from "./tag.marko" with { load: "visible.x" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import "./tag.marko" with { load: "visible.x" };
+<div/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:1
+    > 1 | import "./tag.marko" with { load: "visible.x" }
+        | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid load import, a default specifier is required.
+      2 | <div/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-no-default-specifier/template.marko
@@ -1,0 +1,2 @@
+import "./tag.marko" with { load: "visible.x" }
+<div/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "onClick.x?a=1" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+        |                                            ^^^^^^^^^^^^^^^ Params are not supported for the "on-click" trigger.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-params-unsupported/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "onClick.x?a=1" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "render|visible.x" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "render|visible.x" }
+        |                                            ^^^^^^^^^^^^^^^^^^ The "render" trigger must be used alone.
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-render-with-trigger/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "render|visible.x" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "visible" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible" }
+        |                                            ^^^^^^^^^ A selector is required for the "visible" trigger. (e.g. "visible.my-element")
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-trigger-no-selector/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "visible" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "bogus.foo" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "bogus.foo" }
+        |                                            ^^^^^^^^^^^ Unknown trigger type "bogus". Supported triggers are "visible", "idle", "media", and "on*".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-unknown-trigger/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "bogus.foo" }
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/cjs-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/cjs-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/generated-expected.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "visible.x?bogus=1" };
+<Tag/>

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/html-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/html-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/htmlProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/htmlProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/hydrate-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/hydrate-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/vdom-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/vdom-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/vdomProduction-error-expected.txt
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/snapshots/vdomProduction-error-expected.txt
@@ -1,0 +1,6 @@
+CompileError: 
+    at __tests__/template.marko:1:44
+    > 1 | import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+        |                                            ^^^^^^^^^^^^^^^^^^^ Unknown param "bogus" for the "visible" trigger. Supported params: "rootMargin".
+      2 | <Tag/>
+      3 |

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/tag.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/tag.marko
@@ -1,0 +1,1 @@
+<div>tag</div>

--- a/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/error-load-visible-bad-param/template.marko
@@ -1,0 +1,2 @@
+import Tag from "./tag.marko" with { load: "visible.x?bogus=1" }
+<Tag/>


### PR DESCRIPTION
The `<load>` import had no translator fixtures, so every diagnostic it raises was untested. Adds eleven, one per error: an unknown trigger type, `render` combined with another trigger, a selector on `idle`, a missing media query, a missing selector, an unknown param on `visible` and on `idle`, params on a trigger that takes none, an empty attribute, a named specifier, and an import with no default specifier.

Previously opened as #4084 against the workspace branch; retargeted to `main` now that its parent has landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)