### PR TITLE
test(runtime-class): cover template.mount and the handle it returns

### DIFF
--- a/packages/runtime-class/test/components-browser/fixtures/template-mount/index.marko
+++ b/packages/runtime-class/test/components-browser/fixtures/template-mount/index.marko
@@ -1,0 +1,11 @@
+class {
+    onCreate() {
+        this.state = { label: "" };
+    }
+
+    onInput(input) {
+        this.state.label = input.label || "none";
+    }
+}
+
+<div key="root">${state.label}</div>

--- a/packages/runtime-class/test/components-browser/fixtures/template-mount/test.js
+++ b/packages/runtime-class/test/components-browser/fixtures/template-mount/test.js
@@ -1,0 +1,31 @@
+var expect = require("chai").expect;
+
+// `template.mount` is the public entry the browser helpers bypass; each
+// position lands the rendered nodes somewhere different relative to the target.
+module.exports = function (helpers) {
+  var template = require("./index.marko");
+  template = template.default || template;
+  var target = helpers.targetEl;
+
+  var textOf = function (el) {
+    return el.textContent;
+  };
+
+  var inside = template.mount({ label: "beforeend" }, target);
+  expect(textOf(target)).to.contain("beforeend");
+
+  template.mount({ label: "afterbegin" }, target, "afterbegin");
+  expect(textOf(target).indexOf("afterbegin")).to.equal(0);
+
+  template.mount({ label: "beforebegin" }, target, "beforebegin");
+  template.mount({ label: "afterend" }, target, "afterend");
+  expect(textOf(target.parentNode)).to.contain("beforebegin");
+  expect(textOf(target.parentNode)).to.contain("afterend");
+
+  // The handle it returns drives the mounted component.
+  inside.update({ label: "updated" });
+  expect(textOf(target)).to.contain("updated");
+
+  inside.destroy();
+  expect(textOf(target)).to.not.contain("updated");
+};


### PR DESCRIPTION
`template.mount(data, reference, position)` is the public entry for putting a rendered template into the DOM, and the browser test helper bypasses it by calling `renderSync().appendTo()` instead — so only the `afterbegin` position was ever reached and the `{ update, destroy }` handle it returns was untested.

Adds a `components-browser` fixture covering each position (`beforeend`, `afterbegin`, `beforebegin`, `afterend`) and driving the mounted component through the returned handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)