### PR TITLE
fix: make `|...args|` the for params binding instead of an undeclared alias

### DIFF
--- a/.changeset/for-rest-params-binding.md
+++ b/.changeset/for-rest-params-binding.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix `<for|...args|>` serializing its params under a generated name nothing declared, which threw a `ReferenceError` at render once a handler read `args`.

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,16 @@
+// template.marko
+const $template = "<!><!><span> </span>";
+const $walks = "b%bD l";
+const $for_content__setup__script = _script("__tests__/template.marko_1", ($scope) => _on($scope["#button/0"], "click", function() {
+	$clicked($scope._, $scope.args.join(","));
+}));
+const $for_content__setup = $for_content__setup__script;
+const $for_content__args_ = ($scope, args_0) => _text($scope["#text/1"], args_0);
+const $for_content__args = /*@__PURE__*/ _const("args", ($scope) => $for_content__args_($scope, $scope.args?.[0]));
+const $clicked = /*@__PURE__*/ _let("clicked/2", ($scope) => _text($scope["#text/1"], $scope.clicked));
+const $for = /*@__PURE__*/ _for_of("#text/0", "<button> </button>", " D ", $for_content__setup, $for_content__args);
+function $setup($scope) {
+	$clicked($scope, "");
+	$for($scope, [["a", "b"]]);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/dom.bundle.js
@@ -1,0 +1,5 @@
+// template.marko
+const $for_content__setup = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$clicked($scope._, $scope.c.join(","));
+}));
+const $clicked = /*@__PURE__*/ _let(2, ($scope) => _text($scope.b, $scope.c));

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicked = "";
+	forOf(["a", "b"], (...args) => {
+		const $scope1_id = _scope_id();
+		_html(`<button>${_escape(args[0])}</button>${_el_resume($scope1_id, "#button/0")}`);
+		_script($scope1_id, "__tests__/template.marko_1");
+		_scope($scope1_id, {
+			args,
+			_: _scope_with_id($scope0_id)
+		}, "__tests__/template.marko", "2:2", { args: "2:6" });
+	});
+	_html(`<span>${_text_resume($scope0_id, "#text/1", clicked)}</span>`);
+	_scope($scope0_id, {}, "__tests__/template.marko", 0);
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/html.bundle.js
@@ -1,0 +1,18 @@
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	let clicked = "";
+	forOf(["a", "b"], (...args) => {
+		const $scope1_id = _scope_id();
+		_html(`<button>${_escape(args[0])}</button>${_el_resume($scope1_id, "a")}`);
+		_script($scope1_id, "a0");
+		_scope($scope1_id, {
+			c: args,
+			_: _scope_with_id($scope0_id)
+		});
+	});
+	_html(`<span>${_text_resume($scope0_id, "b", clicked)}</span>`);
+	_scope($scope0_id, {});
+	_resume_branch($scope0_id);
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/render.debug.md
@@ -1,0 +1,30 @@
+# Render
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<span />
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<span>
+  a,0
+</span>
+```
+## Change
+```
+UPDATE: span::text "" => "a,0"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/render.md
@@ -1,0 +1,30 @@
+# Render
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<span />
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  a
+</button>
+<button>
+  b
+</button>
+<span>
+  a,0
+</span>
+```
+## Change
+```
+UPDATE: span::text "" => "a,0"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/writes.debug.html
@@ -1,0 +1,14 @@
+<button>a</button><!--M_$2 #button/0--><button>b</button><!--M_$3 #button/0--><span><!--M_%1 #text/1--></span>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+      args: ["a", 0],
+      _: _(1)
+    }, {
+      args: ["b", 1],
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/template.marko_1 2 3"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/__snapshots__/writes.html
@@ -1,0 +1,12 @@
+<button>a</button><!--M_$2 a--><button>b</button><!--M_$3 a--><span><!--M_%1 b--></span>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [2, {
+    c: ["a", 0],
+    _: _(1)
+  }, {
+    c: ["b", 1],
+    _: _(1)
+  }], "a0 2 3"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 2541,
+      "brotli": 1303
+    }
+  },
+  "html": {
+    "min": 430,
+    "brotli": 279
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/template.marko
@@ -1,0 +1,5 @@
+<let/clicked=""/>
+<for|...args| of=["a", "b"]>
+  <button onClick() { clicked = args.join(",") }>${args[0]}</button>
+</for>
+<span>${clicked}</span>

--- a/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-rest-params-handler/test.ts
@@ -1,0 +1,9 @@
+import type { TestConfig } from "../../main.test";
+
+function click(document: Document) {
+  document.querySelector("button")!.click();
+}
+
+export const config: TestConfig = {
+  steps: [{}, click],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/dom.bundle.debug.js
@@ -3,11 +3,11 @@ const $template$1 = "<!><!><!>";
 const $walks$1 = "b%c";
 const $setup$1 = () => {};
 const $for_content__dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0", 0, 0, 1);
-const $for_content__input_content__OR__args = /*@__PURE__*/ _or(2, ($scope) => $for_content__dynamicTag($scope, $scope._.input_content, () => [...$scope.$params2]));
+const $for_content__input_content__OR__args = /*@__PURE__*/ _or(2, ($scope) => $for_content__dynamicTag($scope, $scope._.input_content, () => [...$scope.args]));
 const $for_content__input_content = /*@__PURE__*/ _for_closure("#text/0", $for_content__input_content__OR__args);
 const $for_content__setup = $for_content__input_content;
-const $for_content__$params = /*@__PURE__*/ _const("$params2", $for_content__input_content__OR__args);
-const $for = /*@__PURE__*/ _for_to("#text/0", "<!><!><!>", "b%", $for_content__setup, $for_content__$params);
+const $for_content__args = /*@__PURE__*/ _const("args", $for_content__input_content__OR__args);
+const $for = /*@__PURE__*/ _for_to("#text/0", "<!><!><!>", "b%", $for_content__setup, $for_content__args);
 const $input_to = ($scope, input_to) => $for($scope, [
 	input_to,
 	0,

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.debug.js
@@ -6,9 +6,9 @@ var my_for_default = _template("__tests__/tags/my-for.marko", (input) => {
 		const $scope1_id = _scope_id();
 		_dynamic_tag($scope1_id, "#text/0", input.content, [...args], 0, 1, $sg__input_to__OR__input_content);
 		_serialize_if($scope0_reason, 0) && _scope($scope1_id, {
-			$params2: _serialize_if($scope0_reason, 2) && $params2,
+			args: _serialize_if($scope0_reason, 2) && args,
 			_: _scope_with_id($scope0_id)
-		}, "__tests__/tags/my-for.marko", "1:2", { $params2: "1:6" });
+		}, "__tests__/tags/my-for.marko", "1:2", { args: "1:6" });
 	}, 0, $scope0_id, "#text/0", $sg__input_to__OR__input_content, $sg__input_to, $sg__input_to);
 	_serialize_if($scope0_reason, 1) && _scope($scope0_id, { input_content: input.content }, "__tests__/tags/my-for.marko", 0, { input_content: ["input.content"] });
 });

--- a/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/my-for-to/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ var my_for_default = _template("b", (input) => {
 		const $scope1_id = _scope_id();
 		_dynamic_tag($scope1_id, "a", input.content, [...args], 0, 1, $sg__input_to__OR__input_content);
 		_serialize_if($scope0_reason, 0) && _scope($scope1_id, {
-			b: _serialize_if($scope0_reason, 2) && $params2,
+			b: _serialize_if($scope0_reason, 2) && args,
 			_: _scope_with_id($scope0_id)
 		});
 	}, 0, $scope0_id, "a", $sg__input_to__OR__input_content, $sg__input_to, $sg__input_to);

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -426,7 +426,21 @@ export function trackParamsReferences(
 
     for (let i = 0; i < params.length; i++) {
       const param = params[i];
-      if (param.type === "RestElement") {
+      if (
+        i === 0 &&
+        param.type === "RestElement" &&
+        param.argument.type === "Identifier"
+      ) {
+        // `|...args|` names the whole params array, so `args` is that binding.
+        const { argument } = param;
+        paramsBinding.name = argument.name;
+        paramsBinding.declared = true;
+        (argument.extra ??= {}).binding = paramsBinding;
+        trackReferencesForBinding(
+          body.scope.getBinding(argument.name)!,
+          paramsBinding,
+        );
+      } else if (param.type === "RestElement") {
         createBindingsAndTrackReferences(
           param.argument,
           type,


### PR DESCRIPTION
`trackParamsReferences` created one binding for the whole params array under a generated name and aliased a leading rest identifier to it, so reads of `args` in `<for|...args|>` resolved to a name the `(...args) =>` callback never declares. Serializing the loop scope, for example when a handler reads `args`, threw `ReferenceError: $params2 is not defined` at render.

A leading rest identifier is now the params binding itself. `my-for-to` only renames `$params2` to `args`; a new fixture exercises the serialized path with a click.

🤖 Generated with [Claude Code](https://claude.com/claude-code)