### PR TITLE
agent-feedback: class-translator tag resolution and render-error handling

### DIFF
--- a/agent-feedback/items/2026-09-04-link-tags-compat-when-js-indirection-crosses-interop.md
+++ b/agent-feedback/items/2026-09-04-link-tags-compat-when-js-indirection-crosses-interop.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-class/src/translator/index.js › markInteropBoundary
+---
+
+# Link the tags-compat runtime when JS indirection crosses the interop boundary
+
+`markInteropBoundary` only runs when `loadFileForTag`/`loadFileForImport` resolves a tag's binding to a `.marko` file, and `@marko/compiler`'s `resolveTagImport` resolves only requests ending in `.marko`, so a Class template that reaches a Tags template through any JS module — a barrel re-export, a dependency's JS entry, `import.meta.glob` — compiles without the `runtime/helpers/tags-compat/html*.mjs` side-effect import and SSR throws `TypeError: Cannot read properties of undefined (reading 'boundary')` in `_scope_reason`, because `dynamicTag.___runtimeCompat` and the `htmlCompat` patches were never installed. The break is order-dependent for `<${expr}/>`, which reads `___runtimeCompat` at call time and starts working once any other module in the process imports a Tags template directly, and permanent for `<Tag/>`, which compiles to `render-tag.js` and has no compat hook at all. The same gap silently drops output in the other direction: a Tags parent rendering a Class child through a JS barrel emits nothing for the child. Class→Class indirection through the identical barrel renders correctly, so nothing else about the pattern is unsupported and the failure has no diagnostic. Directions: resolve the boundary through JS re-exports, link the compat runtime from the `has5 && has6` signal already tracked in `packages/runtime-tags/src/translator/interop/index.js` › `patchTranslateProgram`, or at minimum have the Class `dynamic-tag`/`render-tag` helpers raise an actionable `MARKO_DEBUG` error when handed a Tags renderer with no compat installed.
+
+Check: `printf '<let/c=0/>\n' > t.tmp.marko; printf 'export { default } from "./t.tmp.marko";\n' > b.tmp.js; printf '<!-- use class -->\nimport C from "./b.tmp.js";\n<div><${C}/></div>\n' > p.tmp.marko; printf '<!-- use class -->\nimport C from "./t.tmp.marko";\n<div><${C}/></div>\n' > d.tmp.marko; pnpm run compile -- -o html -d -t class p.tmp.marko d.tmp.marko && grep -c tags-compat p.tmp.marko.js d.tmp.marko.js` prints `p.tmp.marko.js:0` and `d.tmp.marko.js:1`.

--- a/agent-feedback/items/2026-09-04-marko-5-named-import-tag-compiles-to-the-module-default.md
+++ b/agent-feedback/items/2026-09-04-marko-5-named-import-tag-compiles-to-the-module-default.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-class/src/translator/index.js › analyze.MarkoTag
+---
+
+# Resolve a Marko 5 custom tag from its imported binding, not the module's default export
+
+`analyze.MarkoTag` treats any capitalized static tag name whose scope binding has `kind === "module"` as a default-export template import: it reads `binding.path.parent.source.value` without ever checking the specifier, stores it as `extra.relativePath` and pushes it into `meta.tags`, and `tag/custom-tag.js` then lets `relativePath` win over its own binding→`dynamicTag` branch and emits `importDefault(file, relativePath, tagName)`. So `import { Card } from "./components.js"` used as `<Card/>` compiles to a second `import _Card from "./components.js"` plus `_marko_tag(_Card, …)`, discarding the binding the template already declared; a barrel or component library with no default export fails at module link time, or under bundler interop inside `runtime/helpers/render-tag.js` on `handler._` with an error that names neither the tag nor the import. Consuming a component library through named exports is the ordinary shape, and it is silent at compile time. The same translator already gets the uncapitalized spelling right (`import { thing } from "./card.marko"` + `<thing/>` misses the `/^[A-Z]/` heuristic and reaches `dynamicTag`), and `packages/runtime-tags/src/translator/util/tag-name-type.ts › analyzeExpressionTagName` gates the equivalent branch on `decl.specifiers.some(t.isImportDefaultSpecifier)`. Gate the class translator's module-binding branch the same way so a named import falls through to the existing binding→`dynamicTag` path and stops being recorded in `meta.tags`. A guard fixture belongs beside the existing class-translator custom-tag fixtures, pinning both the named-import and default-import spellings.
+
+Check: `pnpm run compile -- -o html -d t.marko -t class` on `import { Card } from "./barrel.js";` + `<Card/>` emits `import _Card from "./barrel.js"` and `_marko_tag(_Card, {}, out, …)`; dropping `-t class` emits `_dynamic_tag($scope0_id, "#text/0", Card, {}, …)` against the named binding.

--- a/agent-feedback/items/2026-09-04-reject-a-render-promise-when-the-stream-already-errored.md
+++ b/agent-feedback/items/2026-09-04-reject-a-render-promise-when-the-stream-already-errored.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: low
+site: packages/runtime-class/src/runtime/html/AsyncStream.js › then
+---
+
+# Reject `render(input)`'s promise when the stream already errored
+
+`then` subscribes with `out.on("error", reject)` and `out.on("finish", resolve)`, but `on` replays an already-emitted `finish` to a late listener and never replays a past error, so an error raised during the synchronous render phase — before the caller can attach `then` — is dropped and the documented promise form of `render(input)` resolves with the partial HTML written so far. `error` produces that state by emitting `"error"` and then running `end()` in its `finally`, which fires `finish`; the reachable trigger is `packages/runtime-class/src/runtime/helpers/dynamic-tag.js`'s `out.error("Invalid dynamic tag value")`, so any dynamic tag handed a non-renderer object resolves as success with an element left unclosed. A server that awaits `render(input)` therefore answers 200 with a truncated body and logs nothing, while `renderToString` on the same template rejects because it subscribes before rendering. The same double signal reaches the other documented shapes: `render(input, callback)` fires the callback twice, once with the error and once with the truncated result, and `render(input, stream)` emits a stream error and still ends the stream with the truncated body. Record the error on `_state` so a later `on("error")`/`then` observes it and a `finish` emitted after an error cannot resolve.
+
+Check: Compile `<div>p3 <${obj}/> tail</div>` (with `obj` a plain object) via `pnpm run compile -- -t class -o html -d`, then `await tpl.render({})` resolves to `"<div>p3 "` with nothing logged while `await tpl.renderToString({})` rejects with `"Invalid dynamic tag value"`.

--- a/agent-feedback/items/2026-09-04-stop-aborting-the-process-on-a-render-error-to-a-stream.md
+++ b/agent-feedback/items/2026-09-04-stop-aborting-the-process-on-a-render-error-to-a-stream.md
@@ -1,0 +1,12 @@
+---
+type: bug
+impact: high
+effort: med
+site: packages/runtime-class/src/runtime/html/AsyncStream.js › AsyncStream
+---
+
+# Stop aborting the process when a render error reaches the destination stream
+
+The constructor makes the destination stream itself the event bus (`events = writer && writer.on ? writer : new EventEmitter()`), so a render failure surfaces as `emit("error")` on the caller's `ServerResponse` and nothing installs a default listener. That turns the pattern `docs/rendering.md` (`render(input, stream)`) and `docs/http.md` both demonstrate — `View.render({}, res)` inside `http.createServer`, no handler — into `Unhandled 'error' event` and a dead process, after the client already holds a `200` and a body cut off mid-render. `renderable.js › safeRender` defers the throw through `setImmediate`, so a `try`/`catch` around `render` never sees it; only `out.on("error")`, `res.on("error")` or `out.catch()` avoids the abort and no page in `packages/runtime-class/docs` names any of them, so every template bug reads as the dev server randomly dying. `_doFinish` already guards `state.events !== state.stream` to keep Marko's `finish` off the caller's stream — do the same for `error`, giving the stream target a default that ends the response and reports the failure, and state the required listener in the `render(input, stream)` docs.
+
+Check: `node -r ~ts ./check.tmp.mjs` where the file is `http.createServer((q,res)=>{try{marko.load(process.cwd()+"/x.marko","<div>hi</div>\n$ { throw new Error('boom') }").render({},res)}catch(e){console.log("caught",e.message)}}).listen(0,...)` plus a `fetch` of it — the client logs `STATUS 200`, `caught` never prints, and node exits 1 with `Unhandled 'error' event ... Emitted 'error' event on ServerResponse instance at AsyncStream.error`; expect the render failure to be reportable without a listener the docs never name.

--- a/agent-feedback/items/2026-09-04-warn-when-the-detected-translator-disagrees-with-marko.md
+++ b/agent-feedback/items/2026-09-04-warn-when-the-detected-translator-disagrees-with-marko.md
@@ -1,0 +1,12 @@
+---
+type: dx
+impact: med
+effort: low
+site: packages/compiler/src/config.js › config (default export) (the translator key)
+---
+
+# Warn when the auto-detected translator disagrees with the installed `marko` runtime
+
+The translator is chosen by scanning the nearest `package.json` for a dependency _name_ matching `/^(?:@marko\/|marko-)runtime-/`, and `marko` itself never matches that regex — so an app that depends on `marko@5` and also lists `@marko/runtime-tags` (the state a mid-migration project lands in) silently compiles every template with `@marko/runtime-tags/translator`, the one translator that rejects the Class API, rather than the installed `marko/translator`, which is the interop translator and compiles both APIs. Nothing reports the switch: the only symptom is `class {} component blocks are no longer supported` on every Class template, which names the syntax instead of the dependency that selected the compiler, so the cause is findable only by reading this IIFE. The scan already declines (returns `undefined`) when two `@marko/runtime-*` names disagree, but a `marko` dependency is invisible to that guard, and the decline itself reaches the user as a bare `@marko/compiler: translator must provide a translate visitor object` from `babel-plugin/index.js`. Direction: when the translator was auto-detected rather than configured, compare the resolved translator's `version` (already exposed as `getRuntimeVersion`) against the major of the resolved `marko` package and emit a one-line `console.error` naming the detected dependency and the `translator` option; the same site can give the ambiguous case a message instead of the Babel error.
+
+Check: `mkdir -p tmp-t && printf '{"dependencies":{"marko":"^5","@marko/runtime-tags":"^6"}}' > tmp-t/package.json && (cd tmp-t && node -r ~ts -e 'import("@marko/compiler/config").then(c => console.log(c.default.translator))')` prints `@marko/runtime-tags/translator` with no diagnostic while the installed `marko` is 5.39.38; dropping the `@marko/runtime-tags` entry prints `marko/translator`.


### PR DESCRIPTION
Adds five agent-feedback entries surfaced while driving `@marko/vite` and `@marko/run` through realistic workloads and traced back to this repo.

Three are in the Marko 5 class translator and runtime. A capitalized tag name whose scope binding is any module import is treated as a default-export template, so a named import used as a tag compiles to a synthesized default import and fails at link or render time rather than at compile time — the tags translator already gates the equivalent branch on the specifier kind. Separately, `AsyncStream` never replays a past error to a late listener, so the promise form of `render(input)` resolves with a truncated body after a render error, and because the constructor makes the caller's stream the event bus, the `render(input, stream)` form the docs demonstrate aborts the process with an unhandled `'error'` event after a 200 has been sent.

The fourth covers the tags-compat runtime being linked only when a template imports a tags-API template directly, so JS indirection drops it and rendering fails order-dependently. The fifth asks for a warning when the auto-detected translator disagrees with the installed `marko` runtime, since translator selection keys off a dependency name and silently changes how every template in a project compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)