### PR TITLE
fix: preserve nested implicit component dependencies

### DIFF
--- a/.changeset/quiet-plums-listen.md
+++ b/.changeset/quiet-plums-listen.md
@@ -1,0 +1,5 @@
+---
+"marko": patch
+---
+
+Fix hydration dependencies for components nested under an implicit split component.

--- a/packages/runtime-class/src/translator/util/add-dependencies.js
+++ b/packages/runtime-class/src/translator/util/add-dependencies.js
@@ -115,7 +115,6 @@ export const entryBuilder = {
 
     if (fileMeta.implicitSplitComponent) {
       state.hasComponents = true;
-      return;
     }
 
     if (fileMeta.component) {

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/components/child/component-browser.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/components/child/component-browser.js
@@ -1,0 +1,1 @@
+export function onMount() {}

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/components/child/index.marko
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/components/child/index.marko
@@ -1,0 +1,1 @@
+<div>child</div>

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/cjs-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/cjs-expected.js
@@ -1,0 +1,27 @@
+"use strict";
+
+exports.__esModule = true;
+exports.default = void 0;
+var _index = require("marko/src/runtime/html/index.js");
+var _index2 = _interopRequireDefault(require("./components/child/index.marko"));
+var _renderTag = _interopRequireDefault(require("marko/src/runtime/helpers/render-tag.js"));
+var _dataMarko = _interopRequireDefault(require("marko/src/runtime/html/helpers/data-marko.js"));
+var _renderer = _interopRequireDefault(require("marko/src/runtime/components/renderer.js"));
+var _skipSerialize = _interopRequireDefault(require("marko/src/runtime/helpers/skip-serialize.js"));
+function _interopRequireDefault(e) { return e && e.__esModule ? e : { default: e }; }
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = (0, _index.t)(_marko_componentType);
+var _default = exports.default = _marko_template;
+const _marko_component = {};
+_marko_template._ = (0, _renderer.default)(function (_input, out, _componentDef, _component, state, $global) {
+  const input = (0, _skipSerialize.default)(_input);
+  out.w(`<button${(0, _dataMarko.default)(out, _componentDef, {
+    "onclick": _componentDef.d("click", "emit", false, ["click"])
+  })}>`);
+  (0, _renderTag.default)(_index2.default, {}, out, _componentDef, "1");
+  out.w("</button>");
+}, {
+  t: _marko_componentType,
+  s: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/generated-expected.marko
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/generated-expected.marko
@@ -1,0 +1,3 @@
+<button on-click("emit", "click")>
+  <child/>
+</button>

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/html-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/html-expected.js
@@ -1,0 +1,22 @@
+import { t as _t } from "marko/src/runtime/html/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _child from "./components/child/index.marko";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_props from "marko/src/runtime/html/helpers/data-marko.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+const _marko_component = {};
+import _marko_skip_serialize from "marko/src/runtime/helpers/skip-serialize.js";
+_marko_template._ = _marko_renderer(function (_input, out, _componentDef, _component, state, $global) {
+  const input = _marko_skip_serialize(_input);
+  out.w(`<button${_marko_props(out, _componentDef, {
+    "onclick": _componentDef.d("click", "emit", false, ["click"])
+  })}>`);
+  _marko_tag(_child, {}, out, _componentDef, "1");
+  out.w("</button>");
+}, {
+  t: _marko_componentType,
+  s: true,
+  d: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/htmlProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/htmlProduction-expected.js
@@ -1,0 +1,21 @@
+import { t as _t } from "marko/dist/runtime/html/index.js";
+const _marko_componentType = "KKKBON0",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _child from "./components/child/index.marko";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_props from "marko/dist/runtime/html/helpers/data-marko.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+const _marko_component = {};
+import _marko_skip_serialize from "marko/dist/runtime/helpers/skip-serialize.js";
+_marko_template._ = _marko_renderer(function (_input, out, _componentDef, _component, state, $global) {
+  const input = _marko_skip_serialize(_input);
+  out.w(`<button${_marko_props(out, _componentDef, {
+    "onclick": _componentDef.d("click", "emit", false, ["click"])
+  })}>`);
+  _marko_tag(_child, {}, out, _componentDef, "1");
+  out.w("</button>");
+}, {
+  t: _marko_componentType,
+  s: true
+}, _marko_component);

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/hydrate-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/hydrate-expected.js
@@ -1,0 +1,4 @@
+import { register, init } from "marko/src/runtime/components/index.js";
+import component_0 from "./components/child/component-browser.js";
+register("__tests__/components/child/index.marko", component_0);
+init();

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/vdom-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/vdom-expected.js
@@ -1,0 +1,23 @@
+import { t as _t } from "marko/src/runtime/vdom/index.js";
+const _marko_componentType = "__tests__/template.marko",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _child from "./components/child/index.marko";
+import _marko_tag from "marko/src/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/src/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/src/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.be("button", null, "0", _component, null, 0, {
+    "onclick": _componentDef.d("click", "emit", false, ["click"])
+  });
+  _marko_tag(_child, {}, out, _componentDef, "1");
+  out.ee();
+}, {
+  t: _marko_componentType,
+  s: true,
+  d: true
+}, _marko_component);
+import _marko_defineComponent from "marko/src/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/vdomProduction-expected.js
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/snapshots/vdomProduction-expected.js
@@ -1,0 +1,22 @@
+import { t as _t } from "marko/dist/runtime/vdom/index.js";
+const _marko_componentType = "KKKBON0",
+  _marko_template = _t(_marko_componentType);
+export default _marko_template;
+import _child from "./components/child/index.marko";
+import _marko_tag from "marko/dist/runtime/helpers/render-tag.js";
+import _marko_renderer from "marko/dist/runtime/components/renderer.js";
+import { r as _marko_registerComponent } from "marko/dist/runtime/components/registry.js";
+_marko_registerComponent(_marko_componentType, () => _marko_template);
+const _marko_component = {};
+_marko_template._ = _marko_renderer(function (input, out, _componentDef, _component, state, $global) {
+  out.be("button", null, "0", _component, null, 0, {
+    "onclick": _componentDef.d("click", "emit", false, ["click"])
+  });
+  _marko_tag(_child, {}, out, _componentDef, "1");
+  out.ee();
+}, {
+  t: _marko_componentType,
+  s: true
+}, _marko_component);
+import _marko_defineComponent from "marko/dist/runtime/components/defineComponent.js";
+_marko_template.Component = _marko_defineComponent(_marko_component, _marko_template._);

--- a/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/template.marko
+++ b/packages/runtime-class/test/translator/fixtures/implicit-split-component-with-child/template.marko
@@ -1,0 +1,3 @@
+<button on-click("emit", "click")>
+  <child/>
+</button>


### PR DESCRIPTION
Implicit split components stopped hydrate dependency traversal before their nested interactive components were discovered, causing descendant browser code and styles to be omitted. Continue scanning the template dependency graph while retaining the existing guard that prevents registration of the implicit root placeholder. Adds a translator fixture covering an implicit event-forwarding root with a nested split component.