### PR TITLE
fix(compiler): normalize custom getTemplateId results

### DIFF
--- a/.changeset/normalize-template-ids.md
+++ b/.changeset/normalize-template-ids.md
@@ -1,0 +1,5 @@
+---
+"@marko/compiler": patch
+---
+
+Normalize custom `getTemplateId` results to the same character set as built-in template ids.

--- a/packages/compiler/src/babel-utils/tags.js
+++ b/packages/compiler/src/babel-utils/tags.js
@@ -296,16 +296,20 @@ function resolveMarkoFile(file, filename) {
 
 const idCache = new WeakMap();
 const templateIdHashOpts = { outputLength: 5 };
-// Only what is unsafe in a string, URL or filesystem context is percent
-// encoded (`%` always is, keeping the encoding reversible).
-const unsafeTemplateIdCharReg = /[\u0000-\u0020\u007f-\uffff"%\\`<>]/g;
-export function getTemplateId(opts, request, child) {
-  if (!child && opts.getTemplateId) return opts.getTemplateId(request);
-
-  const id = relative(root, request).replace(
+// Percent-encode only what is unsafe in string, URL or filesystem contexts;
+// `%` always encodes so the encoding stays reversible (custom ids too).
+const unsafeTemplateIdCharReg = /[\u0000-\u0020\u007f-\uffff"%\\`<>;,]/g;
+const normalizeTemplateId = (id) =>
+  id.replace(
     unsafeTemplateIdCharReg,
     (ch) => "%" + ch.charCodeAt(0).toString(16),
   );
+export function getTemplateId(opts, request, child) {
+  if (!child && opts.getTemplateId) {
+    return normalizeTemplateId(opts.getTemplateId(request));
+  }
+
+  const id = normalizeTemplateId(relative(root, request));
 
   if (opts.optimize) {
     const optimizeKnownTemplates =

--- a/packages/runtime-tags/src/__tests__/translator-api.test.ts
+++ b/packages/runtime-tags/src/__tests__/translator-api.test.ts
@@ -52,6 +52,21 @@ describe("runtime-tags/translator-api", () => {
     });
   });
 
+  it("normalizes a custom getTemplateId like a built-in id", () => {
+    const { code } = compiler.compileSync(
+      "<div/>",
+      path.join(import.meta.dirname, "tmp.marko"),
+      {
+        ...baseConfig,
+        cache: new Map(),
+        output: "html",
+        optimize: true,
+        getTemplateId: () => 'my template;"id"',
+      },
+    );
+    assert.ok(code.includes('"my%20template%3b%22id%22"'), code);
+  });
+
   describe("style blocks with sourceMaps", () => {
     const styleSrc = `<style>\n  .foo { color: red }\n</style>\n<div class="foo"/>\n`;
     const compileWithSourceMaps = (sourceMaps: "both" | "inline" | true) => {


### PR DESCRIPTION
A custom `getTemplateId` result now goes through the same percent-encoding as built-in template ids, so unsafe characters cannot leak into resume markers, css var names, or asset ids. `;` and `,` join the unsafe set so ids stay safe as list delimiters. Includes a translator-api test for the custom id path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)