### PR TITLE
refactor(runtime-tags): addAssetImport reads the current file itself

### DIFF
--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -95,7 +95,7 @@ export default {
     const importPath = getStyleImportPath(file, node, names);
     (node.extra ??= {}).styleImportPath = importPath;
     if (importPath) {
-      addAssetImport(file, importPath);
+      addAssetImport(importPath);
     }
 
     if (names) {

--- a/packages/runtime-tags/src/translator/util/asset-imports.ts
+++ b/packages/runtime-tags/src/translator/util/asset-imports.ts
@@ -1,4 +1,5 @@
 import type { types as t } from "@marko/compiler";
+import { getFile } from "@marko/compiler/babel-utils";
 
 declare module "@marko/compiler" {
   export interface MarkoMeta {
@@ -11,8 +12,8 @@ declare module "@marko/compiler" {
   }
 }
 
-export function addAssetImport(file: t.BabelFile, request: string) {
-  (file.metadata.marko.assetImports ??= new Set()).add(request);
+export function addAssetImport(request: string) {
+  (getFile().metadata.marko.assetImports ??= new Set()).add(request);
 }
 
 export function isClientAssetImport(file: t.BabelFile, request: string) {

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -54,7 +54,7 @@ export default {
       t.isProgram(importDecl.parent) &&
       isClientAssetImport(getFile(), value)
     ) {
-      addAssetImport(getFile(), value);
+      addAssetImport(value);
     }
 
     const tagImport = resolveTagImport(importDecl, value);

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -91,7 +91,7 @@ export default {
       const styleFile = getStyleFile(getFile());
       if (styleFile) {
         programExtra.styleFile = styleFile;
-        addAssetImport(getFile(), styleFile);
+        addAssetImport(styleFile);
       }
     },
 


### PR DESCRIPTION
`addAssetImport` now takes only the request and resolves the current compilation through `getFile()`, so call sites in the style tag, import declaration, and program visitors no longer thread a file argument. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)