### PR TITLE
test(runtime-tags): add Opt every helper and cover some/every

### DIFF
--- a/packages/runtime-tags/src/__tests__/optional.test.ts
+++ b/packages/runtime-tags/src/__tests__/optional.test.ts
@@ -3,6 +3,7 @@ import * as assert from "assert/strict";
 import {
   addSorted,
   concat,
+  every,
   filter,
   findIndexSorted,
   findSorted,
@@ -10,6 +11,7 @@ import {
   mapToString,
   type Opt,
   push,
+  some,
   Sorted,
   toIter,
 } from "../translator/util/optional";
@@ -197,6 +199,24 @@ describe("runtime-tags/translator/util/optional", () => {
         mapToString([1, 2, 3] as Opt<number>, ",", toStr),
         "0:1,1:2,2:3",
       );
+    });
+
+    it("some finds a match across every Opt shape", () => {
+      const isEven = (n: number) => n % 2 === 0;
+      assert.equal(some(undefined, isEven), false);
+      assert.equal(some(1, isEven), false);
+      assert.equal(some(2, isEven), true);
+      assert.equal(some([1, 3, 4] as Opt<number>, isEven), true);
+      assert.equal(some([1, 3, 5] as Opt<number>, isEven), false);
+    });
+
+    it("every is vacuously true and checks all Opt shapes", () => {
+      const isEven = (n: number) => n % 2 === 0;
+      assert.equal(every(undefined, isEven), true);
+      assert.equal(every(1, isEven), false);
+      assert.equal(every(2, isEven), true);
+      assert.equal(every([2, 4, 6] as Opt<number>, isEven), true);
+      assert.equal(every([2, 3, 4] as Opt<number>, isEven), false);
     });
   });
 });

--- a/packages/runtime-tags/src/translator/util/optional.ts
+++ b/packages/runtime-tags/src/translator/util/optional.ts
@@ -265,6 +265,17 @@ export function some<T>(
     : false;
 }
 
+export function every<T>(
+  data: Opt<T>,
+  cb: (item: T, index: number) => boolean,
+): boolean {
+  return data !== undefined
+    ? Array.isArray(data)
+      ? data.every(cb)
+      : !!cb(data, 0)
+    : true;
+}
+
 export function toArray<T, R>(
   data: Opt<T>,
   cb: (item: T, index: number) => R,


### PR DESCRIPTION
Adds an `every` helper to `util/optional.ts` alongside `some`, handling the `undefined`, single, and array `Opt` shapes (vacuously true when empty), with unit tests for both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)