### PR TITLE
refactor(runtime-tags): keep serialize exprs and provenance on Section and Binding

### DIFF
--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -59,6 +59,7 @@ import {
   isForceSerialized,
   mapDownstreamReason,
   mergeSerializeReasons,
+  type SerializeKey,
   type SerializeReason,
 } from "./serialize-reasons";
 import { finalizeTagDownstreams } from "./set-tag-sections-downstream";
@@ -129,6 +130,11 @@ export interface Binding {
   pruned: boolean | undefined;
   exposed: boolean;
   forcePersist: boolean;
+  /** Binding-side counterpart of `Section.serializePropKeys`, keyed by
+   * accessor prefix (`undefined` is the plain binding key). */
+  serializePropKeys:
+    | Map<AccessorPrefix | symbol | undefined, SerializeKey>
+    | undefined;
   // Extra ids reserved after `id` for derived accessors (eg TagVariableChange).
   reserveSize: number;
 }
@@ -267,6 +273,7 @@ export function createBinding(
     pruned: undefined,
     exposed: false,
     forcePersist: false,
+    serializePropKeys: undefined,
     reserveSize: 0,
   };
 

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -19,6 +19,7 @@ import {
   find,
   findIndexSorted,
   findSorted,
+  type OneMany,
   type Opt,
   Sorted,
 } from "./optional";
@@ -37,6 +38,7 @@ import {
 import {
   isReasonDynamic,
   mapCrossProgramReason,
+  type SerializeKey,
   type SerializeReason,
   type SerializeReasons,
 } from "./serialize-reasons";
@@ -129,6 +131,16 @@ export interface Section {
   /** Reasons any of the section's dom nodes resumes, as the analyzed reasons
    * (not merged) so each one's guard stays buildable. */
   domSerializeReasons: undefined | SerializeReasons;
+  /** Pending serialize exprs, resolved into the reasons (and provenance)
+   * once references finalize. */
+  serializeExprs: Opt<t.NodeExtra>;
+  propSerializeExprs: Map<SerializeKey, OneMany<t.NodeExtra>> | undefined;
+  /** Whose values feed each serialization decision — survives force-`true`
+   * and counts function-body reads; complete after reference finalize. */
+  serializeProvenance: Sources | undefined;
+  propSerializeProvenance: Map<SerializeKey, Sources> | undefined;
+  /** Interned per-prop reason keys for string/symbol props. */
+  serializePropKeys: Map<string | symbol, SerializeKey> | undefined;
   paramReasonGroups: ParamSerializeReasonGroups | undefined;
   returnValueExpr: t.NodeExtra | undefined;
   returnSerializeReason: SerializeReason | undefined;
@@ -218,6 +230,11 @@ export function startSection(
       serializeReason: undefined,
       serializeReasons: new Map(),
       domSerializeReasons: undefined,
+      serializeExprs: undefined,
+      propSerializeExprs: undefined,
+      serializeProvenance: undefined,
+      propSerializeProvenance: undefined,
+      serializePropKeys: undefined,
       paramReasonGroups: undefined,
       returnValueExpr: undefined,
       returnSerializeReason: undefined,

--- a/packages/runtime-tags/src/translator/util/serialize-reasons.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-reasons.ts
@@ -1,10 +1,6 @@
 import { types as t } from "@marko/compiler";
 
-import {
-  type Accessor,
-  AccessorPrefix,
-  AccessorProp,
-} from "../../common/types";
+import { AccessorPrefix, AccessorProp } from "../../common/types";
 import { getAccessorProp } from "./get-accessor-enums";
 import {
   concat,
@@ -34,27 +30,7 @@ export type SerializeReasons = true | OneMany<Sources>;
 
 export const sourcesUtil = new Sorted(compareSources);
 export type SerializeReason = true | Sources;
-type SerializeKey = symbol & { __serialize_key__: 1 };
-
-const scopeExprsBySection = new WeakMap<Section, OneMany<t.NodeExtra>>();
-const propExprsBySection = new WeakMap<
-  Section,
-  Map<SerializeKey, OneMany<t.NodeExtra>>
->();
-// Provenance answers "whose values feed this" where the reason answers
-// "serialize?": it survives force-`true` and counts function-body reads.
-const scopeProvenanceBySection = new WeakMap<Section, Sources>();
-const propProvenanceBySection = new WeakMap<
-  Section,
-  Map<SerializeKey, Sources>
->();
-const serializePropsByBinding = new WeakMap<Binding, SerializeKey>();
-// Param reason groups key this with a per-compile symbol, which the compile
-// cache bounds: recompiling an edited file adds none.
-const serializePropByModifier: Record<
-  Accessor | symbol,
-  WeakMap<Section | Binding, SerializeKey>
-> = {};
+export type SerializeKey = symbol & { __serialize_key__: 1 };
 
 export function isSameReason(
   a: SerializeReason | undefined,
@@ -134,15 +110,8 @@ export function addSerializeExpr(
           forcePropSerialize(section, key);
         }
       } else {
-        let curExpr: Opt<t.NodeExtra>;
-        let curExprs = propExprsBySection.get(section);
-        if (curExprs) {
-          curExpr = curExprs.get(key);
-        } else {
-          curExprs = new Map();
-          propExprsBySection.set(section, curExprs);
-        }
-
+        const curExprs = (section.propSerializeExprs ??= new Map());
+        const curExpr = curExprs.get(key);
         curExprs.set(key, curExpr ? concat(curExpr, expr)! : expr);
       }
     } else if (expr === true) {
@@ -150,8 +119,8 @@ export function addSerializeExpr(
         forceSerialize(section);
       }
     } else {
-      const curExpr = scopeExprsBySection.get(section);
-      scopeExprsBySection.set(section, curExpr ? concat(curExpr, expr)! : expr);
+      const curExpr = section.serializeExprs;
+      section.serializeExprs = curExpr ? concat(curExpr, expr)! : expr;
     }
   }
 }
@@ -205,9 +174,9 @@ export function getSerializeReason(
 }
 
 export function getSerializeSourcesForExpr(expr: t.NodeExtra) {
-  if (isReferencedExtra(expr)) {
-    return getSerializeSourcesForRef(expr.referencedBindings);
-  }
+  return isReferencedExtra(expr)
+    ? getSerializeSourcesForRef(expr.referencedBindings)
+    : undefined;
 }
 
 export function getSerializeSourcesForExprs(exprs: Opt<t.NodeExtra> | boolean) {
@@ -333,9 +302,9 @@ export function mergeSerializeReasons(
 }
 
 export function applySerializeExprs(section: Section) {
-  const propExprs = propExprsBySection.get(section);
+  const propExprs = section.propSerializeExprs;
   if (propExprs) {
-    propExprsBySection.delete(section);
+    section.propSerializeExprs = undefined;
     for (const [key, exprs] of propExprs) {
       addProvenance(section, getProvenanceForExprs(exprs), key);
       const exprReason = getSerializeSourcesForExprs(exprs);
@@ -349,9 +318,9 @@ export function applySerializeExprs(section: Section) {
     }
   }
 
-  const scopeExprs = scopeExprsBySection.get(section);
+  const scopeExprs = section.serializeExprs;
   if (scopeExprs) {
-    scopeExprsBySection.delete(section);
+    section.serializeExprs = undefined;
     addProvenance(section, getProvenanceForExprs(scopeExprs));
     const exprReason = getSerializeSourcesForExprs(scopeExprs);
     if (exprReason) {
@@ -400,7 +369,7 @@ export function finalizeSerializeReason(section: Section) {
   }
 
   // Prop provenance folds into the scope's, mirroring the reason merge.
-  const propProvenance = propProvenanceBySection.get(section);
+  const propProvenance = section.propSerializeProvenance;
   if (propProvenance) {
     for (const provenance of propProvenance.values()) {
       addProvenance(section, provenance);
@@ -416,10 +385,8 @@ export function getSerializeProvenance(
   prefix?: AccessorPrefix | symbol,
 ): Sources | undefined {
   return prop
-    ? propProvenanceBySection
-        .get(section)
-        ?.get(getPropKey(section, prop, prefix))
-    : scopeProvenanceBySection.get(section);
+    ? section.propSerializeProvenance?.get(getPropKey(section, prop, prefix))
+    : section.serializeProvenance;
 }
 
 function addProvenance(
@@ -429,16 +396,13 @@ function addProvenance(
 ) {
   if (!sources) return;
   if (key) {
-    let provenance = propProvenanceBySection.get(section);
-    if (!provenance) {
-      propProvenanceBySection.set(section, (provenance = new Map()));
-    }
+    const provenance = (section.propSerializeProvenance ??= new Map());
     provenance.set(key, mergeSources(provenance.get(key), sources)!);
   } else {
-    scopeProvenanceBySection.set(
-      section,
-      mergeSources(scopeProvenanceBySection.get(section), sources)!,
-    );
+    section.serializeProvenance = mergeSources(
+      section.serializeProvenance,
+      sources,
+    )!;
   }
 }
 
@@ -464,11 +428,11 @@ function getPropKey(
   prefix?: AccessorPrefix | symbol,
 ) {
   if (isStrOrSym(prop)) {
-    const keys = (serializePropByModifier[prop] ||= new WeakMap());
-    let key = keys.get(section);
+    const keys = (section.serializePropKeys ??= new Map());
+    let key = keys.get(prop);
     if (!key) {
       keys.set(
-        section,
+        prop,
         (key = Symbol(
           typeof prop === "symbol" ? `Symbol(${prop.description})` : prop,
         ) as SerializeKey),
@@ -481,15 +445,13 @@ function getPropKey(
 
     return key;
   } else {
-    const keys = prefix
-      ? (serializePropByModifier[prefix] ||= new WeakMap())
-      : serializePropsByBinding;
     const binding = getCanonicalBinding(prop);
+    const keys = (binding.serializePropKeys ??= new Map());
 
-    let key = keys.get(binding);
+    let key = keys.get(prefix);
     if (!key) {
       keys.set(
-        binding,
+        prefix,
         (key = Symbol(
           (prefix
             ? typeof prefix === "symbol"


### PR DESCRIPTION
The per-section serialize expr, provenance, and prop-key tables move from module-level WeakMaps in `serialize-reasons.ts` onto the `Section` and `Binding` they describe, and `SerializeKey` is exported for those fields. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)