### PR TITLE
refactor(runtime-tags): record a content section's downstream tag and expose child sections

### DIFF
--- a/packages/runtime-tags/src/translator/util/binding-has-prop.ts
+++ b/packages/runtime-tags/src/translator/util/binding-has-prop.ts
@@ -6,10 +6,10 @@ import type { Section } from "./sections";
 // its renderer elided; references to the renderer must be elided in sync.
 export function isSectionRendererElided(section: Section) {
   return (
-    !!section.downstreamBinding &&
+    !!section.downstream?.binding &&
     !bindingHasProperty(
-      section.downstreamBinding.binding,
-      section.downstreamBinding.properties,
+      section.downstream.binding,
+      section.downstream.properties,
     )
   );
 }

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -1313,7 +1313,7 @@ export function finalizeReferences() {
       // The walk keeps merging through a forced hop: the force decides the
       // reason, but later hops' sources still feed provenance.
       while (currentSection !== sourceSection) {
-        const upstreamReason = currentSection.downstreamBinding
+        const upstreamReason = currentSection.downstream?.binding
           ? getSectionRegisterReasons(currentSection) || undefined
           : !currentSection.upstreamExpression ||
             getSerializeSourcesForExpr(currentSection.upstreamExpression);

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -146,13 +146,15 @@ export interface Section {
   returnSerializeReason: SerializeReason | undefined;
   isHoistThrough: true | undefined;
   upstreamExpression: t.NodeExtra | undefined;
-  downstreamBinding:
+  /** The content's rendering tag (its extra), and the child binding the
+   * content feeds when the child can serialize it. */
+  downstream:
     | {
-        binding: Binding;
+        tag: t.MarkoTagExtra;
+        binding: Binding | undefined;
         properties: Opt<string>;
         exprs: KnownExprs | undefined;
       }
-    | false
     | undefined;
   hasAbortSignal: boolean;
   /** Count of distinct `$signal` expression roots; analyze allocates each
@@ -240,7 +242,7 @@ export function startSection(
       returnSerializeReason: undefined,
       content: getContentInfo(path),
       upstreamExpression: undefined,
-      downstreamBinding: undefined,
+      downstream: undefined,
       hasAbortSignal: false,
       abortSignalExprs: 0,
       readsOwner: false,
@@ -308,6 +310,23 @@ export const [getBranchRendererArgs, setBranchRendererArgs] =
 export function forEachSection(fn: (section: Section) => void) {
   const { sections } = getProgram().node.extra;
   sections?.forEach(fn);
+}
+
+// Direct child sections by parent, grouped once per program after analyze
+// (call at finalize or later).
+const childSections = new WeakMap<Section, Section[]>();
+export function getChildSections(section: Section) {
+  let children = childSections.get(section);
+  if (!children) {
+    for (const child of getProgram().node.extra.sections || []) {
+      childSections.set(child, []);
+    }
+    forEachSection((child) => {
+      if (child.parent) childSections.get(child.parent)!.push(child);
+    });
+    children = childSections.get(section) || [];
+  }
+  return children;
 }
 
 export function forEachSectionReverse(fn: (section: Section) => void) {
@@ -423,17 +442,17 @@ export function getNodeContentType(
 export function getSectionRegisterReasons(section: Section) {
   if (section.isBranch) return false; // Branches handle whether to register their section/renderer.
 
-  const { downstreamBinding } = section;
-  if (downstreamBinding) {
+  const { downstream } = section;
+  if (downstream?.binding) {
     let downstreamReasons = getAllSerializeReasonsForBinding(
-      downstreamBinding.binding,
-      downstreamBinding.properties,
+      downstream.binding,
+      downstream.properties,
     );
     if (downstreamReasons && downstreamReasons !== true) {
       downstreamReasons = mapCrossProgramReason(
         section.program,
         downstreamReasons,
-        downstreamBinding.exprs,
+        downstream.exprs,
       );
     }
     if (!downstreamReasons) return false;
@@ -447,7 +466,7 @@ export function getSectionRegisterReasons(section: Section) {
       return false;
     }
     return downstreamReasons;
-  } else if (downstreamBinding === false) {
+  } else if (downstream) {
     return false;
   }
 
@@ -525,7 +544,7 @@ export function finalizeParamSerializeReasonGroups(section: Section) {
   }
 }
 
-function ensureReasonGroups(reason: Section["serializeReason"]) {
+export function ensureReasonGroups(reason: Section["serializeReason"]) {
   if (isReasonDynamic(reason)) {
     for (const [paramSection, params] of groupParamsBySection(reason.param)) {
       ensureParamReasonGroup(paramSection, params);

--- a/packages/runtime-tags/src/translator/util/set-tag-sections-downstream.ts
+++ b/packages/runtime-tags/src/translator/util/set-tag-sections-downstream.ts
@@ -29,12 +29,13 @@ export function setTagDownstream(
 
 export function finalizeTagDownstreams(section: Section) {
   for (const [tag, { binding, exprs }] of getTagDownstreams(section)) {
-    crawlSectionsAndSetBinding(tag, binding, exprs);
+    crawlSectionsAndSetBinding(tag, tag.node.extra!, binding, exprs);
   }
 }
 
 function crawlSectionsAndSetBinding(
   tag: t.NodePath<t.MarkoTag>,
+  downstreamTag: t.MarkoTagExtra,
   binding: Binding,
   exprs: KnownExprs | undefined,
   properties?: Opt<string>,
@@ -47,12 +48,17 @@ function crawlSectionsAndSetBinding(
       forEach(properties, (property) => {
         target = target?.propertyAliases.get(property);
       });
-      contentSection.downstreamBinding =
+      const serialized = !(
         target &&
         (target.noSerialize ||
           includes(target.noSerializeProperties, "content"))
-          ? false
-          : { binding, properties: concat(properties, "content"), exprs };
+      );
+      contentSection.downstream = {
+        tag: downstreamTag,
+        binding: serialized ? binding : undefined,
+        properties: serialized ? concat(properties, "content") : undefined,
+        exprs: serialized ? exprs : undefined,
+      };
     }
   }
 
@@ -68,12 +74,20 @@ function crawlSectionsAndSetBinding(
         const attrTagMeta = attrTagLookup[getTagName(child)];
         crawlSectionsAndSetBinding(
           child,
+          downstreamTag,
           binding,
           exprs,
           concat(properties, attrTagMeta.name),
         );
       } else {
-        crawlSectionsAndSetBinding(child, binding, exprs, properties, true);
+        crawlSectionsAndSetBinding(
+          child,
+          downstreamTag,
+          binding,
+          exprs,
+          properties,
+          true,
+        );
       }
     }
   }


### PR DESCRIPTION
`Section.downstreamBinding` becomes `Section.downstream`, a fixed-shape record carrying the rendering tag's extra alongside the child binding, properties, and known exprs (those are `undefined` when the child never serializes the content, replacing the bare `false`). Sections also gain a grouped `getChildSections` lookup, and `ensureReasonGroups` is exported. No output change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)