### PR TITLE
test(runtime-tags): assert debug and optimize render logs agree

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/controllable-select-late-options/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/controllable-select-late-options/test.ts
@@ -3,5 +3,7 @@ import { wait } from "../../utils/resolve";
 
 export const config: TestConfig = {
   equivalent: false,
+  // Debug logs the unmatched controlled `<select>` value diagnostic.
+  skip_parity: true,
   steps: [{}, wait],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/test.ts
@@ -10,6 +10,8 @@ const load = (document: Document) => {
 // server-rendered content stays visible but inert. (CSR rejects through
 // the runtime-managed path instead, which drives `@catch`.)
 export const config: TestConfig = {
+  // Debug intentionally logs the load-failure diagnostic optimize cannot.
+  skip_parity: true,
   equivalent: false,
   reject_load: ["child.mjs"],
   steps: [{ label: "a" }, load, wait],

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-error-nested-placeholder/test.ts
@@ -2,6 +2,8 @@ import type { TestConfig } from "../../main.test";
 import { flush, wait } from "../../utils/resolve";
 
 export const config: TestConfig = {
+  // Debug intentionally logs the load-failure diagnostic optimize cannot.
+  skip_parity: true,
   steps: [{}, flush, wait, flush, wait],
   equivalent: false,
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/test.ts
@@ -10,6 +10,8 @@ const load = (document: Document) => {
 // event reports the failure. (CSR loads through the runtime-managed path
 // instead, which drives `@catch`.)
 export const config: TestConfig = {
+  // Debug intentionally logs the load-failure diagnostic optimize cannot.
+  skip_parity: true,
   equivalent: false,
   reject_load: ["load.mjs"],
   steps: [{ label: "a" }, load, wait],

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/test.ts
@@ -6,4 +6,6 @@ import { wait } from "../../utils/resolve";
 export const config: TestConfig = {
   steps: [{ value: 1 }, wait],
   equivalent: false,
+  // Debug logs the missed lazy-trigger selector diagnostic.
+  skip_parity: true,
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent-conflicting-triggers/test.ts
@@ -1,6 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 export const config: TestConfig = {
+  skip_parity: true,
   steps: [{}],
   equivalent: false,
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/test.ts
@@ -5,5 +5,7 @@ import { after, flush } from "../../utils/resolve";
 // after a flush boundary, so the selector misses and the module loads eagerly.
 export const config: TestConfig = {
   equivalent: false,
+  // Debug logs the missed lazy-trigger selector diagnostic.
+  skip_parity: true,
   steps: [{ value: 1 }, after(1), flush, after(5)],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-svg/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/style-tag-dynamic-svg/test.ts
@@ -7,4 +7,6 @@ function click(document: Document) {
 export const config: TestConfig = {
   equivalent: false,
   steps: [{ color: "red" }, click],
+  // The css var name embeds the template id, which differs by mode.
+  skip_parity: true,
 };

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -73,6 +73,8 @@ export type TestConfig = {
   error_dom?: boolean;
   error_html?: boolean;
   skip_optimize?: boolean;
+  /** Debug intentionally logs a dev-only diagnostic the optimized build cannot. */
+  skip_parity?: boolean;
   skip_dom?: boolean;
   skip_html?: boolean;
   skip_csr?: boolean;
@@ -144,6 +146,8 @@ function testFixtures(interop?: true) {
         ? (require(testFile).config ?? {})
         : {};
       const hasCompilerError = !!config.error_compiler;
+      // Render logs by file, then mode, for the parity check below.
+      const renderLogs = new Map<string, Map<string, string>>();
       const skipHTML = config.skip_html;
       const skipDOM = config.skip_dom;
       const stripFixtureDir = async (str: string | Promise<string>) =>
@@ -242,7 +246,7 @@ function testFixtures(interop?: true) {
             ),
           );
 
-          const snapMode = (
+          const snapMode = async (
             fn: () => unknown,
             file: string,
             expectErr?: boolean,
@@ -250,7 +254,7 @@ function testFixtures(interop?: true) {
           ) => {
             const resolvedFile =
               expectErr && actualFile ? `${actualFile}.error.txt` : file;
-            return snap(
+            const actual = await snap(
               fn,
               fixtureDir,
               optimize
@@ -262,19 +266,24 @@ function testFixtures(interop?: true) {
                   ? actualFile
                   : actualFile.replace(/(\.[^.]+)$/, ".debug$1")),
             );
+            if (resolvedFile.startsWith("render")) {
+              let logs = renderLogs.get(resolvedFile);
+              if (!logs) renderLogs.set(resolvedFile, (logs = new Map()));
+              logs.set(mode, actual);
+            }
           };
 
           const snapCompile = async (output: "html" | "dom") => {
-            if (config.error_compiler) {
+            if (hasCompilerError) {
               await snapMode(
                 () => {
                   // The fix-guide only fires for an agent-driven terminal and a
                   // translator resolved from a specifier, so force both here.
                   const restore = config.fix_guide ? forceCodingAgent() : noop;
                   try {
-                    for (const f of config.error_compiler === true
-                      ? [templateFile]
-                      : (config.error_compiler as string[]).map(resolve)) {
+                    for (const f of Array.isArray(config.error_compiler)
+                      ? config.error_compiler.map(resolve)
+                      : [templateFile]) {
                       compiler.compileFileSync(f, {
                         ...getModeOpts(),
                         ...(config.fix_guide && {
@@ -534,6 +543,24 @@ function testFixtures(interop?: true) {
                 config.error_dom,
                 "csr",
               ));
+        });
+      }
+
+      // A diverging render log means tree shaking or debug-only assertions
+      // changed behavior (silently, since each mode snapshots separately).
+      if (!config.skip_optimize && !config.skip_parity) {
+        after(function parity() {
+          for (const [file, logs] of renderLogs) {
+            const debug = logs.get("debug");
+            const optimize = logs.get("optimize");
+            if (debug !== undefined && optimize !== undefined) {
+              assert.strictEqual(
+                optimize,
+                debug,
+                `${file} diverges between optimize and debug`,
+              );
+            }
+          }
         });
       }
     });

--- a/packages/runtime-tags/src/__tests__/utils/bundle.ts
+++ b/packages/runtime-tags/src/__tests__/utils/bundle.ts
@@ -169,7 +169,7 @@ function createBuilds(
     plugins: [
       virtual.plugin,
       domEntry.plugin,
-      !optimize && externalRuntimePlugin("dom", false),
+      !optimize && externalRuntimePlugin(false),
       optimize && remapDebugPlugin(),
       optimize && interop && remapDistPlugin(),
       markoPlugin({ ...compileOpts, output: "dom" }),
@@ -247,7 +247,7 @@ export function run() { _run(); Object.values(___componentLookup).forEach((c) =>
     experimental: { nativeMagicString: true },
     plugins: [
       virtual.plugin,
-      externalRuntimePlugin("html", optimize),
+      externalRuntimePlugin(optimize),
       optimize && remapDebugPlugin(),
       optimize && interop && remapDistPlugin(),
       markoPlugin({ ...compileOpts, output: "html" }, collectDiagnostics),
@@ -466,17 +466,19 @@ function virtualPlugin(cwd: string): {
 
 // Only the optimize dom bundle is measured, so every other build links one
 // shared runtime instead of re-emitting it into each fixture.
-function externalRuntimePlugin(
-  kind: "dom" | "html",
-  optimize: boolean,
-): Plugin {
+function externalRuntimePlugin(optimize: boolean): Plugin {
   return {
     name: "external-runtime",
     resolveId: {
       filter: { id: runtimeEntryRe },
       async handler(id) {
-        const feature = runtimeEntryRe.exec(id)![2];
-        const dir = await prebuiltRuntime(kind, optimize);
+        // The import's own kind wins over the bundle's, so an html bundle can
+        // link dom `*.feat` assets.
+        const [, importKind, feature] = runtimeEntryRe.exec(id)!;
+        const dir = await prebuiltRuntime(
+          importKind as "dom" | "html",
+          optimize,
+        );
         return {
           id: path.join(dir, feature ? `${feature}.feat.mjs` : "runtime.mjs"),
           external: true,

--- a/packages/runtime-tags/src/__tests__/utils/import-with-context.ts
+++ b/packages/runtime-tags/src/__tests__/utils/import-with-context.ts
@@ -116,14 +116,14 @@ export async function importWithContext<T>(
   function importModuleDynamically(id: string, parent: vm.Module) {
     // Simulate a network-level chunk load failure (e.g. deploy skew) for the
     // matched dynamic import while its siblings resolve normally.
-    if (rejectLoad?.(id)) {
-      return Promise.reject(new Error(`simulated chunk load failure: ${id}`));
-    }
     const from = parent.identifier;
     // The shared debug runtime bundle is linked by absolute path.
     const resolved = path.isAbsolute(id)
       ? id
       : resolveSync(id, { ...resolveOpts, from });
+    if (rejectLoad?.(resolved || id)) {
+      return Promise.reject(new Error(`simulated chunk load failure: ${id}`));
+    }
 
     if (!resolved) {
       throw new Error(

--- a/packages/runtime-tags/src/__tests__/utils/snap.ts
+++ b/packages/runtime-tags/src/__tests__/utils/snap.ts
@@ -13,7 +13,7 @@ export async function snap(
   file: string,
   expectErr?: boolean,
   uniqueName?: string,
-): Promise<void> {
+): Promise<string> {
   const snapdir = dir + path.sep + "__snapshots__";
   const expectedFile = snapdir + path.sep + file;
   let actual: string;
@@ -98,6 +98,7 @@ export async function snap(
     }
     assert.strictEqual(actual, expected);
   }
+  return actual;
 }
 
 if (UPDATE) {


### PR DESCRIPTION
Each fixture already writes a render log per mode (`render*.md` for optimize, `render*.debug.md` for debug), but nothing compared them, so a tree-shaking or debug-only behavior change could snapshot silently. An `after` hook per fixture now asserts the two logs are identical; `skip_parity` opts out the fixtures whose debug build intentionally logs a diagnostic. Also lets simulated chunk load failures match on the resolved path, resolves the shared test runtime by the import's own kind, and reuses `hasCompilerError` in the compile-error branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)