### PR TITLE
refactor(runtime-tags): drop the remaining hub.file reads in the translator

### DIFF
--- a/packages/runtime-tags/src/translator/util/module-registrations.ts
+++ b/packages/runtime-tags/src/translator/util/module-registrations.ts
@@ -1,7 +1,7 @@
 import path from "path";
 
 import { types as t } from "@marko/compiler";
-import { importDefault } from "@marko/compiler/babel-utils";
+import { getFile, importDefault } from "@marko/compiler/babel-utils";
 
 import type { ResolvedExport } from "../visitors/function";
 import { getMarkoOpts, isOutputHTML } from "./marko-config";
@@ -14,7 +14,7 @@ import { callRuntime, getRuntimePath } from "./runtime";
  * reserved a register id without registering it.
  */
 export function writeModuleRegistrations(program: t.NodePath<t.Program>) {
-  const { file } = program.hub;
+  const file = getFile();
   const statements: t.Statement[] = [];
   const seen = new Set<string>();
 

--- a/packages/runtime-tags/src/translator/util/statement-tag.ts
+++ b/packages/runtime-tags/src/translator/util/statement-tag.ts
@@ -1,5 +1,9 @@
 import { types as t } from "@marko/compiler";
-import { parseStatements, type Tag } from "@marko/compiler/babel-utils";
+import {
+  getFile,
+  parseStatements,
+  type Tag,
+} from "@marko/compiler/babel-utils";
 
 // `<static>` runs everywhere, so it gets no target and no "on the ..." suffix.
 export function createStatementTag(keyword: "client" | "server" | "static") {
@@ -8,10 +12,8 @@ export function createStatementTag(keyword: "client" | "server" | "static") {
 
   return {
     parse(tag) {
-      const {
-        node,
-        hub: { file },
-      } = tag;
+      const { node } = tag;
+      const file = getFile();
       const rawValue = node.rawValue!;
       const code = rawValue.replace(keywordReg, "");
       const start = node.start! + (rawValue.length - code.length);

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -105,7 +105,7 @@ export default {
       }
 
       (node.extra ??= {}).loadImport = loadImport;
-      const { file } = importDecl.hub;
+      const file = getFile();
 
       const loadFile = tagImport && loadFileForImport(file, value);
       if (!loadFile) {
@@ -141,7 +141,7 @@ export default {
           const binding = importDecl.scope.getBinding(local.name)!;
 
           if (isOutputHTML()) {
-            const { file } = importDecl.hub;
+            const file = getFile();
             const loadFile = loadFileForImport(file, node.source.value)!;
             const wrappedName = getOrCreateHtmlLoadWrapped(
               getReadyId(loadFile)!,
@@ -167,7 +167,7 @@ export default {
             if (allKnownTagReferences) {
               importDecl.remove();
             } else {
-              const { file } = importDecl.hub;
+              const file = getFile();
               const loadFile = loadFileForImport(file, node.source.value)!;
               const resolvedPath = resolveRelativePath(
                 file,

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -169,7 +169,7 @@ function translateHTML(tag: t.NodePath<t.MarkoTag>) {
 
 function translateDOM(tag: t.NodePath<t.MarkoTag>) {
   const { node } = tag;
-  const { file } = tag.hub;
+  const file = getFile();
   const relativePath = getTagRelativePath(tag);
   const programSection = getProgram().node.extra.section!;
   const childFile = loadFileForTag(tag)!;
@@ -350,10 +350,8 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
 }
 
 export function getTagRelativePath(tag: t.NodePath<t.MarkoTag>) {
-  const {
-    node,
-    hub: { file },
-  } = tag;
+  const { node } = tag;
+  const file = getFile();
   let relativePath: string | undefined;
 
   if (t.isStringLiteral(node.name)) {


### PR DESCRIPTION
Replaces the seven remaining `hub.file` reads (statement tags, module registrations, custom tag, import declaration) with `getFile()`, so the translator reaches the current compilation one way, per the AGENTS.md rule. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)