### PR TITLE
Make the parallel runner the default `pnpm test`

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,16 +45,22 @@ pnpm run @ci:test
 pnpm run report
 ```
 
-While developing you can run a single test group and use [grep](https://mochajs.org/#-g---grep-pattern) to filter the tests:
+`pnpm test` runs the whole suite across all CPU cores, without coverage. This is the recommended way to run the tests:
+
+```
+pnpm test
+```
+
+While developing, a single test group can be selected with [grep](https://mochajs.org/#-g---grep-pattern):
 
 ```
 pnpm test -- --grep=lifecycle
 ```
 
-To run the whole suite quickly (without coverage), `pnpm run test:parallel` fans the tests across your CPU cores:
+The same run in a single process, which bails at the first failure and streams its output, is `pnpm run test:serial`:
 
 ```
-pnpm run test:parallel
+pnpm run test:serial -- --grep=lifecycle
 ```
 
 ### Adding tests
@@ -98,7 +104,7 @@ Expected failures won't cause [Travis CI](https://travis-ci.org/marko-js/marko) 
 If you need to dig a bit deeper into a failing test, use the `--inspect-brk` flag, open Chrome DevTools, and click on the green nodejs icon (<img height="16" src="https://user-images.githubusercontent.com/1958812/37050480-d53e4276-2128-11e8-8c7a-f5d842956c98.png"/>) to start debugging. Learn more about [debugging node](https://www.youtube.com/watch?v=Xb_0awoShR8&t=103s) from this video.
 
 ```
-pnpm test -- --grep=test-name --inspect-brk
+pnpm run test:serial -- --grep=test-name --inspect-brk
 ```
 
 In addition to [setting breakpoints](https://developers.google.com/web/tools/chrome-devtools/javascript/breakpoints), you can also add [`debugger;`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/debugger) statements in both your JavaScript files and Marko templates:
@@ -112,10 +118,11 @@ $ debugger;
 
 A number of the test suites make use snapshot comparisons. For example, the `render` tests compare the rendered html against a stored snapshot. Similarly, the `compiler` tests compare the generated JavaScript module againt a stored snapshot. Any changes compared to the snapshot should be looked at closely, but there are some cases where it is fine that the output has changed and the snapshot needs to be updated.
 
-To update a snapshot, you can copy the contents from the `actual` file to the `expected` file in the fixture directory. You can also use the `UPDATE_EXPECTATIONS` env variable to cause the test runner to update the `expected` file for all currently failing tests in a suite:
+To update a snapshot, you can copy the contents from the `actual` file to the `expected` file in the fixture directory. You can also run `pnpm run test:update`, which sets the `UPDATE_EXPECTATIONS` env variable so the test runner writes the `expected` file for every currently failing test:
 
 ```
-UPDATE_EXPECTATIONS=1 pnpm test
+pnpm run test:update                      # whole suite, across CPU cores
+pnpm run test:update -- --grep=lifecycle  # one group
 ```
 
 ## Tackling an existing issue

--- a/.mocharc.all.cjs
+++ b/.mocharc.all.cjs
@@ -1,4 +1,4 @@
-// `pnpm test`: the base config plus every package's spec glob. A `.cjs`
+// `pnpm run test:serial`: the base config plus every package's spec glob. A `.cjs`
 // because mocha's JSON configs do not honour `extends` (the node options,
 // bail, and timeout of `.mocharc.json` were silently dropped, and the ssr
 // fixtures then failed with `vm.SourceTextModule is not a constructor`).

--- a/.mocharc.parallel.cjs
+++ b/.mocharc.parallel.cjs
@@ -1,4 +1,4 @@
-// `test:parallel` workers: the base config without bail (every worker reports
+// `pnpm test` workers: the base config without bail (every worker reports
 // all of its failures), room for a slice's slowest fixture, and the handoff
 // module that keeps a worker inside its memory budget.
 const base = require("./.mocharc.json");

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,9 +15,10 @@ A "translator" is the Babel-plugin half of a runtime package; the compiler loads
 All from repo root. Tests and tooling run directly from TS source (native Node type stripping plus the `~ts` resolve hook for extensionless imports; package `exports` point at `src/` until publish), so no build step is needed to iterate.
 
 ```sh
-pnpm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run; bail: stops at first failure
-pnpm exec mocha <file.test.ts>                            # one file; `pnpm test -- <file>` still unions with the suite glob
-pnpm run test:parallel                                    # whole suite fanned across CPU cores (~3x faster than a serial pnpm test)
+pnpm test                                                 # whole suite fanned across CPU cores (~3x faster than serial)
+pnpm test -- --grep "runtime-tags/translator <fixture> "  # scoped test run
+pnpm run test:serial -- --grep "..."                      # same run in one process: bail at first failure, live output, --inspect-brk
+pnpm exec mocha <file.test.ts>                            # one file; a file passed to `pnpm test` instead runs in every worker
 pnpm run test:update -- --grep "..."                      # regenerate snapshots (review the diff!)
 pnpm run compile -- -o dom -d foo.marko                   # compiled output -> foo.marko.js (-o html for SSR; omit -d for optimized)
 pnpm run build                                            # all packages -> dist/ + .d.ts
@@ -35,7 +36,7 @@ pnpm run change                                           # add a changeset (req
 
 - **Dependencies are patched.** `patches/` (applied by pnpm patchedDependencies on install) adds Marko AST node types to `@babel/types`/`traverse`/`generator`, and makes mocha print the `require()` error it otherwise drops when its `import()` fallback rescues a spec. Import Babel only via `@marko/compiler/internal/babel` and helpers via `@marko/compiler/babel-utils`, never `@babel/*` directly. Bumping any patched dependency requires regenerating its patch.
 - **Bundle size is a feature.** The pre-commit hook runs lint-staged, a full build, and `build:sizes`, staging `.sizes.json`/`.sizes/` — that diff is the size impact of the change. Commits are slow by design. Lint rules whose fix rewrites runtime code into larger output stay off in `.oxlintrc.json` (`unicorn/prefer-string-starts-ends-with`, `unicorn/no-new-array`); enabling one means checking `build:sizes` first.
-- **Snapshots and sizes are generated.** Never hand-edit _or delete_ `__snapshots__/**`, fixture `sizes.json`, or `.sizes*`; regenerate with `pnpm run test:update` (which also prunes stale snapshots) and the commit hook.
+- **Snapshots and sizes are generated.** Never hand-edit _or delete_ `__snapshots__/**`, fixture `sizes.json`, or `.sizes*`; regenerate with `pnpm run test:update` (which also prunes stale snapshots after a green run) and the commit hook.
 - **CI** (`.github/workflows/ci.yml`): build + lint on Node 26; tests on Node 22/24/26 (zcov coverage). Releases go out via changesets on push to `main`.
 
 ## Conventions

--- a/agent-feedback/README.md
+++ b/agent-feedback/README.md
@@ -58,13 +58,13 @@ Repro:
 Guard tests:
 
 - Fold into existing fixture families under `packages/*/src/__tests__/fixtures*`; no one-off test files.
-- Snapshots: `pnpm run test:update -- --grep "..."` per fixture; `pnpm run test:update:parallel` repo-wide (plain `test:update` bails at the first failure and skips the rest).
+- Snapshots: `pnpm run test:update -- --grep "..."` per fixture; `pnpm run test:update` repo-wide.
 - Compile errors: `error_compiler: true` + snapshot. Runtime dev errors: snapshot under `## Console` with `skip_optimize: true`. SSR-only errors: `error_html: true, skip_csr: true`.
 - Debug-only diagnostics (`MARKO_DEBUG` `console.error`) must not change optimized output; match the controllable-select diagnostic pattern.
 
 Pre-ship:
 
-- `pnpm run test:parallel`.
+- `pnpm test`.
 - Runtime changes: `pnpm run build && pnpm run build:sizes`. Bundle size is a feature; report any non-zero delta before committing. Then `git checkout -- .sizes*`; the pre-commit hook regenerates them.
 - Pre-commit is slow by design (lint-staged, full build, tsc, sizes). On hook failure grep its output for `error TS`.
 - Changeset only for user-facing changes: write `.changeset/<name>.md` directly, verify with `pnpm exec changeset status`.

--- a/agent-feedback/items/2026-08-30-measure-optimize-sizes-without-bundling-the-runtime.md
+++ b/agent-feedback/items/2026-08-30-measure-optimize-sizes-without-bundling-the-runtime.md
@@ -17,5 +17,5 @@ Measuring a chunk's shared-runtime share once per process and adding it to the
 fixture's own tree-shaken bytes would let that build take the external too.
 
 Check: in `createBuilds`, extend `externalRuntimePlugin` to the optimize dom
-build and time `pnpm run test:parallel`; the fixture `sizes.json` assertions are
+build and time `pnpm test`; the fixture `sizes.json` assertions are
 what fail.

--- a/agent-feedback/items/2026-09-01-pipeline-fixture-builds-into-worker-idle.md
+++ b/agent-feedback/items/2026-09-01-pipeline-fixture-builds-into-worker-idle.md
@@ -7,7 +7,7 @@ site: packages/runtime-tags/src/__tests__/main.test.ts › ssrRunner
 
 # Pipeline the next fixture build into the worker's idle time
 
-A `--cpu-prof` of one `test:parallel` worker running `main.test.ts` alone
+A `--cpu-prof` of one `pnpm test` worker running `main.test.ts` alone
 spends 32% of its wall time in `(idle)`: `createServerRunner` awaits rolldown,
 whose work runs on native threads while the JS thread has nothing to do. With
 one worker per core the other workers absorb some of that, but the run still

--- a/agent-feedback/items/2026-09-08-run-only-the-spec-files-passed-to-pnpm-test.md
+++ b/agent-feedback/items/2026-09-08-run-only-the-spec-files-passed-to-pnpm-test.md
@@ -1,0 +1,20 @@
+---
+type: dx
+impact: med
+effort: low
+site: scripts/test-parallel.js › runProcess
+---
+
+# Run only the spec files passed to `pnpm test`
+
+Now that the parallel runner is `pnpm test`, a spec file passed on the command
+line is appended to every worker's mocha args, so it runs once per worker on top
+of the full suite instead of on its own. Splitting positional args from flags in
+`main` and, when any are present, packing only those files into bins would make
+`pnpm test -- <file>` the single-file run it reads as, and drop the workaround
+line in `AGENTS.md` that points at `pnpm exec mocha` instead.
+
+Check: `MARKO_TEST_WORKERS=2 pnpm test -- packages/runtime-tags/src/__tests__/evaluate.test.ts`
+reports 28 more passing than `MARKO_TEST_WORKERS=2 pnpm test` alone, because that
+file's 28 tests run a second time in the worker that does not already own it. Each
+additional worker adds another copy; `pnpm exec mocha` on the same file reports 28.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "@ci:release": "pnpm run build && node scripts/pkg-override && changeset publish && pnpm run @ci:release-alias && node scripts/pkg-override && pnpm install --frozen-lockfile",
     "@ci:release-alias": "node -r ~ts scripts/publish-alias.mts",
     "@ci:test": "zcov -- pnpm run @ci:test:fast",
-    "@ci:test:fast": "pnpm run test:parallel",
+    "@ci:test:fast": "pnpm run test",
     "@ci:version": "changeset version && oxfmt \"**/package.json\" && pnpm install --lockfile-only",
     "audit": "pnpm audit --prod",
     "build": "pnpm -r --if-present run build && pnpm run build:types",
@@ -19,10 +19,10 @@
     "lint": "oxlint && oxfmt --check --with-node-modules .",
     "prepare": "husky && pnpm --filter @marko/compiler run build-babel-types",
     "report": "zcov report -r html && open ./coverage/index.html",
-    "test": "mocha --config .mocharc.all.cjs",
-    "test:parallel": "node scripts/test-parallel.js",
-    "test:update": "UPDATE_EXPECTATIONS=1 mocha --config .mocharc.all.cjs",
-    "test:update:parallel": "cross-env UPDATE_EXPECTATIONS=1 node scripts/test-parallel.js"
+    "test": "node scripts/test-parallel.js",
+    "test:serial": "mocha --config .mocharc.all.cjs",
+    "test:update": "cross-env UPDATE_EXPECTATIONS=1 node scripts/test-parallel.js",
+    "test:update:serial": "cross-env UPDATE_EXPECTATIONS=1 mocha --config .mocharc.all.cjs"
   },
   "devDependencies": {
     "@babel/cli": "^7.28.6",

--- a/packages/runtime-class/AGENTS.md
+++ b/packages/runtime-class/AGENTS.md
@@ -88,8 +88,10 @@ fixtures/<name>/
 
 ### Running tests
 
+From the repo root:
+
 ```sh
-npm test # all tests
-npm test -- --grep "<fixture> " # specific fixture
-npm run test:update # update snapshots
+pnpm test # all tests
+pnpm test -- --grep "<fixture> " # specific fixture
+pnpm run test:update # update snapshots
 ```

--- a/packages/runtime-tags/AGENTS.md
+++ b/packages/runtime-tags/AGENTS.md
@@ -78,13 +78,16 @@ export default {
 
 Fixture-based snapshot tests driven by `src/__tests__/main.test.ts`. Fixtures live in `src/__tests__/fixtures/`, plus `fixtures-interop/` (Marko 5 ↔ 6 mixing, suite name `translator-interop`). A dir suffixed `.skip` is ignored.
 
+From the repo root:
+
 ```sh
-npm test -- --grep "runtime-tags/translator <fixture> "  # one fixture (note trailing space)
-npm run test:update -- --grep "runtime-tags/translator <fixture> "  # regenerate its snapshots
-npm test -- --grep "translator-interop"                  # interop suite (run after base suite passes)
+pnpm test                                                            # whole suite, fanned across CPU cores
+pnpm test -- --grep "runtime-tags/translator <fixture> "             # one fixture (note trailing space)
+pnpm run test:update -- --grep "runtime-tags/translator <fixture> "  # regenerate its snapshots
+pnpm test -- --grep "translator-interop"                             # interop suite (run after base suite passes)
 ```
 
-Run scoped; the full suite is slow and `bail: true` stops everything at the first failure anyway.
+Iterate scoped, then run `pnpm test` for everything; it fans across cores and reports every failure. Repeating a grep as `pnpm run test:serial -- --grep "..."` runs it in one process, with `bail: true` and live output, for a debugger or a clean stack trace.
 
 ### Fixture anatomy
 
@@ -116,11 +119,11 @@ To add a fixture: create the dir + `template.marko` (+ `test.ts` with steps exer
 1. `translator/core/<tag>.ts` + register in `core/index.ts` (and `util/is-core-tag.ts`).
 2. Runtime helpers in `src/dom/` / `src/html/`, exported from `src/dom.ts` / `src/html.ts`; add to `util/runtime.ts` lists as needed.
 3. Several small fixtures covering static values, dynamic updates, nesting, and interaction with `<for>`/`<if>`.
-4. `npm run change` — user-facing changes need a changeset.
+4. `pnpm run change` — user-facing changes need a changeset.
 5. Update `cheatsheet.md` (the LLM syntax reference shipped in the published package) when the change affects user-facing syntax, idioms, or guidance.
 6. Expect broad snapshot/`sizes.json` churn and an update to `packages/runtime-class/test/taglib-lookup/fixtures/getTagsSorted/expected.json` (interop taglib lookup).
 
-**Changing generated output**: iterate with `npm run compile -- -o dom -d file.marko` (and `-o html`), then `test:update` and audit snapshot diffs — output shape changes ripple through hundreds of fixtures; verify a sample by hand, don't rubber-stamp.
+**Changing generated output**: iterate with `pnpm run compile -- -o dom -d file.marko` (and `-o html`), then `test:update` and audit snapshot diffs — output shape changes ripple through hundreds of fixtures; verify a sample by hand, don't rubber-stamp.
 
 **Changing runtime behavior**: find the covering fixtures by grepping `__tests__/fixtures` for the runtime helper or syntax; extend `steps` before touching the runtime so the mutation log captures the before/after.
 

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -92,8 +92,9 @@ export type TestConfig = {
 // `scripts/test-parallel` fans the fixtures across CPU cores by giving each
 // worker a subset of round-robin "slots" via the env below: a fixture runs here
 // when `index % slotTotal` is one of this worker's slots. Round-robin keeps the
-// expensive fixtures spread evenly across workers. With no env set (a plain
-// `pnpm test`, or a scoped `--grep`) `slots` is null and every fixture runs.
+// expensive fixtures spread evenly across workers. With no env set (any run
+// outside that script, such as `pnpm run test:serial`) `slots` is null and
+// every fixture runs.
 const slotTotal = Number(process.env.MARKO_TEST_SLOT_TOTAL) || 1;
 const slots = process.env.MARKO_TEST_SLOTS
   ? new Set(process.env.MARKO_TEST_SLOTS.split(",").map(Number))

--- a/scripts/test-parallel.js
+++ b/scripts/test-parallel.js
@@ -6,13 +6,14 @@
 // one mocha worker per core: every slotted worker loads all sliced files but
 // only runs its own slice of their fixtures.
 //
-// A plain `pnpm test` is untouched — it stays serial, which is what a scoped
-// `--grep` dev run wants. This is the "run everything, fast" path used by CI.
+// This is what `pnpm test` runs, and what CI runs; a scoped `--grep` works here
+// too. `pnpm run test:serial` keeps the single-process mocha run for when bail,
+// live output or a debugger matters more than throughput.
 //
 // Plain CommonJS because it needs no types and is spawned directly by `node`;
 // the mocha workers it spawns get `~ts` via `.mocharc.parallel.cjs`.
 //
-// Usage: node scripts/test-parallel.js [extra mocha args...]
+// Usage: pnpm test [-- extra mocha args...]
 //        MARKO_TEST_WORKERS=8 node scripts/test-parallel.js
 const { spawn } = require("node:child_process");
 const fs = require("node:fs");


### PR DESCRIPTION
`pnpm test` now runs `scripts/test-parallel.js`, fanning the suite across CPU cores instead of running mocha in one process. The single-process run stays available as `test:serial` (and `test:update:serial`) for when bail, live output, or attaching a debugger matters more than throughput, and `test:update` regenerates snapshots through the parallel runner.

Docs across the repo agent files, `CONTRIBUTING.md`, and `agent-feedback/README.md` follow the rename: scoped `--grep` runs go through `pnpm test`, which is as fast as the serial run for a single fixture. The package agent files also switch their commands from npm to pnpm and say to run them from the repo root, since neither package defines a `test` script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)