### PR TITLE
Fix bound PascalCase tag with control-flow child compiling as dynamic tag

### DIFF
--- a/.changeset/known-tag-if-child.md
+++ b/.changeset/known-tag-if-child.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Fix a bound PascalCase tag (eg `<Layout>`) compiling as a dynamic tag when its direct child is a control flow tag such as `<if>`.

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,28 @@
+// components/wrapper.marko
+const $template$1 = "<section><!></section>";
+const $walks$1 = "D%l";
+const $setup$1 = () => {};
+const $input_content_direct = /*@__PURE__*/ _dynamic_tag_content("#text/0");
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $input_content = $dynamicTag;
+const $input = ($scope, input) => $input_content($scope, input.content);
+var wrapper_default = /*@__PURE__*/ _template("__tests__/components/wrapper.marko", $template$1, "D%l", 0, $input);
+
+// template.marko
+const $template = /*@__PURE__*/ ((_w0) => `<button>toggle</button>${_w0}<!>`)($template$1);
+const $walks = /*@__PURE__*/ ((_w0) => ` b/${_w0}&b`)("D%l");
+const $Wrapper_content__if = /*@__PURE__*/ _if("#text/0", "<b>on</b>", 0, 0, "<i>off</i>");
+const $Wrapper_content__on = /*@__PURE__*/ _closure_get("on", ($scope) => $Wrapper_content__if($scope, $scope._.on ? 0 : 1));
+const $Wrapper_content__setup = $Wrapper_content__on;
+const $Wrapper_content = /*@__PURE__*/ _content("__tests__/template.marko_1*content", "<!><!><!>", "b%", $Wrapper_content__setup);
+const $on__closure = /*@__PURE__*/ _closure($Wrapper_content__on);
+const $on = /*@__PURE__*/ _let("on/2", $on__closure);
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$on($scope, !$scope.on);
+}));
+function $setup($scope) {
+	$input_content_direct($scope["#childScope/1"], $Wrapper_content($scope));
+	$on($scope, false);
+	$setup__script($scope);
+}
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/dom.bundle.js
@@ -1,0 +1,7 @@
+// template.marko
+const $Wrapper_content__if = /*@__PURE__*/ _if(0, "<b>on</b>", 0, 0, "<i>off</i>");
+const $Wrapper_content__on = /*@__PURE__*/ _closure_get(3, ($scope) => $Wrapper_content__if($scope, $scope._.c ? 0 : 1));
+const $on = /*@__PURE__*/ _let(2, /* @__PURE__ */ _closure($Wrapper_content__on));
+const $setup__script = _script("a1", ($scope) => _on($scope.a, "click", function() {
+	$on($scope, !$scope.c);
+}));

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,41 @@
+// components/wrapper.marko
+var wrapper_default = _template("__tests__/components/wrapper.marko", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html("<section>");
+	_dynamic_tag($scope0_id, "#text/0", input.content, {}, 0, 0, $sg__input_content);
+	_html("</section>");
+	_serialize_if($scope0_reason, 0) && _scope($scope0_id, {}, "__tests__/components/wrapper.marko", 0);
+});
+
+// template.marko
+var template_default = _template("__tests__/template.marko", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $on__closures = new Set();
+	let on = false;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}`);
+	wrapper_default({ content: _content("__tests__/template.marko_1*content", () => {
+		_scope_reason();
+		const $scope1_id = _scope_id();
+		_if(() => {
+			if (on) {
+				const $scope2_id = _scope_id();
+				_html("<b>on</b>");
+				_scope($scope2_id, {}, "__tests__/template.marko", "6:4");
+				return 0;
+			} else {
+				const $scope3_id = _scope_id();
+				_html("<i>off</i>");
+				_scope($scope3_id, {}, "__tests__/template.marko", "9:4");
+				return 1;
+			}
+		}, $scope1_id, "#text/0", 1, 1, 1, 0, 1);
+		_subscribe($on__closures, _scope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "5:2"));
+	}, $scope0_id) });
+	_script($scope0_id, "__tests__/template.marko_0");
+	_scope($scope0_id, {
+		on,
+		"ClosureScopes:on": $on__closures
+	}, "__tests__/template.marko", 0, { on: "3:6" });
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/html.bundle.js
@@ -1,0 +1,36 @@
+// components/wrapper.marko
+var wrapper_default = _template("b", (input) => {
+	const $scope0_reason = _scope_reason(), $sg__input_content = _serialize_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html("<section>");
+	_dynamic_tag($scope0_id, "a", input.content, {}, 0, 0, $sg__input_content);
+	_html("</section>");
+	_serialize_if($scope0_reason, 0) && _scope($scope0_id, {});
+});
+
+// template.marko
+var template_default = _template("a", (input) => {
+	_scope_reason();
+	const $scope0_id = _scope_id();
+	const $on__closures = /* @__PURE__ */ new Set();
+	let on = false;
+	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}`);
+	wrapper_default({ content: _content("a0", () => {
+		_scope_reason();
+		const $scope1_id = _scope_id();
+		_if(() => {
+			{
+				const $scope3_id = _scope_id();
+				_html("<i>off</i>");
+				_scope($scope3_id, {});
+				return 1;
+			}
+		}, $scope1_id, "a", 1, 1, 1, 0, 1);
+		_subscribe($on__closures, _scope($scope1_id, { _: _scope_with_id($scope0_id) }));
+	}, $scope0_id) });
+	_script($scope0_id, "a1");
+	_scope($scope0_id, {
+		c: on,
+		d: $on__closures
+	});
+}, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/render.debug.md
@@ -1,0 +1,31 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<section>
+  <i>
+    off
+  </i>
+</section>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<section>
+  <b>
+    on
+  </b>
+</section>
+```
+## Change
+```
+INSERT: section > b
+REMOVE: section > b + i
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/render.md
@@ -1,0 +1,31 @@
+# Render
+```html
+<button>
+  toggle
+</button>
+<section>
+  <i>
+    off
+  </i>
+</section>
+```
+
+# Update
+```js
+document.querySelector("button").click();
+```
+```html
+<button>
+  toggle
+</button>
+<section>
+  <b>
+    on
+  </b>
+</section>
+```
+## Change
+```
+INSERT: section > b
+REMOVE: section > b + i
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/writes.debug.html
@@ -1,0 +1,15 @@
+<button>toggle</button><!--M_$1 #button/0-->
+<section><i>off</i><!--M_|3 #text/0 4--></section>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+      on: !1,
+      "ClosureScopes:on": new Set([_(3)])
+    }, 1, {
+      "ConditionalRenderer:#text/0": 1,
+      _: _(1)
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/__snapshots__/writes.html
@@ -1,0 +1,13 @@
+<button>toggle</button><!--M_$1 a-->
+<section><i>off</i><!--M_|3 a 4--></section>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    c: !1,
+    d: new Set([_(3)])
+  }, 1, {
+    Da: 1,
+    _: _(1)
+  }], "a1 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/components/wrapper.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/components/wrapper.marko
@@ -1,0 +1,1 @@
+<section><${input.content}/></section>

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/sizes.json
@@ -1,0 +1,12 @@
+{
+  "dom": {
+    "template.marko.page.mjs": {
+      "min": 6368,
+      "brotli": 2936
+    }
+  },
+  "html": {
+    "min": 438,
+    "brotli": 301
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/template.marko
@@ -1,0 +1,12 @@
+import Wrapper from "./components/wrapper.marko";
+
+<let/on=false>
+<button onClick() { on = !on }>toggle</button>
+<Wrapper>
+  <if=on>
+    <b>on</b>
+  </if>
+  <else>
+    <i>off</i>
+  </else>
+</Wrapper>

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-if-child/test.ts
@@ -1,0 +1,12 @@
+import type { TestConfig } from "../../main.test";
+
+// A bound PascalCase tag whose direct child is an `<if>` still composes
+// statically: the child's parent lookup must see the rewritten name.
+export const config: TestConfig = {
+  steps: [
+    {},
+    (document: Document) => {
+      document.querySelector<HTMLButtonElement>("button")!.click();
+    },
+  ],
+};

--- a/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/pre-analyze.ts
@@ -108,6 +108,19 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
   const { node } = tag;
   const { name, attributes } = node;
   let attrNameReg = userAttrNameReg;
+  if (name.type === "StringLiteral") {
+    const tagName = name.value;
+    if (
+      tag.scope.getBinding(tagName) &&
+      TAG_NAME_IDENTIFIER_REG.test(tagName)
+    ) {
+      // Convert tags which have an associated binding to an identifier.
+      // <MyTag> --> <${MyTag}>
+      node.name = withPreviousLocation(t.identifier(tagName), name);
+    }
+  }
+  // Before the body: a child asking for this tag's type would cache the
+  // unrewritten name as an unresolved dynamic tag.
   normalizeBody(tag.get("body").get("body"));
   normalizeBody(tag.get("attributeTags"));
 
@@ -126,18 +139,6 @@ function normalizeTag(tag: t.NodePath<t.MarkoTag>) {
 
     if (insertions) {
       node.body.body = [...insertions, ...node.body.body];
-    }
-  }
-
-  if (name.type === "StringLiteral") {
-    const tagName = name.value;
-    if (
-      tag.scope.getBinding(tagName) &&
-      TAG_NAME_IDENTIFIER_REG.test(tagName)
-    ) {
-      // Convert tags which have an associated binding to an identifier.
-      // <MyTag> --> <${MyTag}>
-      node.name = withPreviousLocation(t.identifier(tagName), name);
     }
   }
 


### PR DESCRIPTION
Pre-analyze rewrote a bound PascalCase tag (`<Layout>`) to an identifier only after normalizing its body. A direct child such as `<if>` looked up its parent's tag type during that normalization and cached the unrewritten name as an unresolved dynamic tag, so the template compiled with `_dynamic_tag` instead of composing statically.

The rewrite now happens before the body is normalized. Adds a `known-tag-if-child` fixture and a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)