### PR TITLE
Persisted: one word per concept (flush, upstream, sources, fills)

### DIFF
--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -2123,24 +2123,24 @@ function byFirstArg(name) {
 }
 //#endregion
 //#region packages/runtime-tags/dist/dom.mjs
-let frameVars = {};
+let flushVars = {};
 /**
  * The live page's side of `template.patch`: `[headers, apply]`, the headers
- * a patch request sends (none yet) and the apply for each frame.
+ * a patch request sends (none yet) and the apply for each flush.
  */
 function patch($global) {
   let pageCtx,
     trees = [],
     responseCtx = (data) => (typeof data == "number" ? trees[data] : pageCtx(data));
   responseCtx._ = registeredValues;
-  let names = Object.keys(frameVars),
-    vars = Object.values(frameVars);
+  let names = Object.keys(flushVars),
+    vars = Object.values(flushVars);
   return [
     {},
-    (frame) => {
+    (flush) => {
       ((patchers.$ ||= applyGlobals), beginPatch(curRenders[$global.renderId]));
       try {
-        let fn = Function("_", "$", ...names, "return " + frame);
+        let fn = Function("_", "$", ...names, "return " + flush);
         return (
           (patchRender.r = [
             (ctx) => {
@@ -2266,7 +2266,7 @@ let loads = {},
     return apply;
   });
 /**
- * The loader of a lazy template only frames construct. Never pure: it
+ * The loader of a lazy template only flushes construct. Never pure: it
  * registers where no client code renders the site.
  */
 function _load_lazy(id, load) {

--- a/packages/runtime-tags/CONTEXT.md
+++ b/packages/runtime-tags/CONTEXT.md
@@ -177,15 +177,17 @@ A server rerender of a persisted page applied to the live client DOM by
 refreshing values and navigating structure, without a full page render.
 _Avoid_: rerender, hydration update
 
-**Frame**:
-One flushed payload of a patch render (a sync flush, a settle, a lazy
-module's ready data), applied as a unit: the frame commit check accepts or
-rejects it whole. Not the rerender itself — that is the patch.
-_Avoid_: frame for the patch render
+**Flush**:
+One payload of a patch render (a sync flush, a settle, a lazy module's
+ready data), applied as a unit: the flush commit check accepts or rejects
+it whole. The same word as a normal render's flush; the rerender itself is
+the patch.
+_Avoid_: frame
 
 **Upstream**:
-What an expression or binding derives from: the expressions feeding it and
-the bindings those read (`upstreamAlias`, `upstreamExpression`). Structure
+What an expression or binding derives from: the expressions it reads and
+the bindings those read (`upstreamAlias`, `upstreamExpression`). Summarized
+by kind as its _sources_ (`Sources`: state, param, `$global`). Structure
 has an upstream too — an `<if>` condition, a `<for>` collection, a dynamic
 tag's renderer (`isBranchUpstream`) — and a root param read only there is
 _upstream of structure_.
@@ -193,24 +195,24 @@ _Avoid_: selector, selection, selects (keyed `for` row select aside)
 
 **Stateful structure**:
 A branch body whose upstream expression has a state reason (main's `kStatefulReason`
-vocabulary) — state sources, no `$global`, fill-deliverable param feeds —
+vocabulary) — state sources, no `$global`, param sources a patch fills —
 derived from its upstream expression (`isStatefulBranch`), never stored.
-Resumed code re-renders it, so patch renders skip it and frames omit its
+Resumed code re-renders it, so patch renders skip it and flushes omit its
 entry. Translate code may call the derived policy _client-owned_.
 _Avoid_: state-selected, client-owned as a shared field name
 
 **Hole / filled / unfilled**:
-A read a patch delivers by writing its value at the site is a _hole_ the
+A read a patch keeps current by writing its value at the site is a _hole_ the
 patch _fills_; the html gates say which side acts on a param group:
 `_filled_guard` (a patch fills it: server-owned, or unfed where a construct
-needs the seed), `_unfilled_if` (no patch fills it: the client feeds it, or
+needs the seed), `_unfilled_if` (no patch fills it: the client is upstream, or
 the read sits in unpatched structure). Analyze records reads no patch can
 fill (`hasUnfillablePatchReads`), never the gate.
 _Avoid_: server-side/client-side value, owned read
 
 **Unpatched structure**:
 Structure patch renders skip and so never fill: stateful structure, a
-branch or loop whose upstream a client-owned group feeds, a dynamic tag
+branch or loop with a client-owned group upstream, a dynamic tag
 site a patch never pairs. The html writer tracks it at render as context
 (`withUnpatched`, `inUnpatched`) because a child template cannot see how
 its parent reached it; analyze names the static cases `inResumedStructure`.
@@ -219,7 +221,7 @@ _Avoid_: client-owned structure, client-selected
 **Structural-or-global param**:
 A root param whose reads sit upstream of structure or mix with `$global` — the value
 never leaves through an expression channel, so whoever renders must supply
-it. Translate derives server-ownership requirements from this fact.
+it. Translate derives which groups a patch must fill from this fact.
 _Avoid_: server-required param
 
 **Branch path**:
@@ -232,22 +234,23 @@ _Avoid_: capture path, patch section
 A server-sourced binding whose reads intersect client state, refreshed by
 patches through a registered fill signal. Distinct from a resume-payload
 _fill_ batch.
-_Avoid_: fill outside a patch-delivery discussion
+_Avoid_: fill outside a patch-refresh discussion, deliver/delivery
 
 **Effect write / capture write**:
 Wire channels for refreshable values no fill consumes: an accessor write
 plus effect re-run, or a bare accessor write for registered-function
 captures.
 
-**Group feeds**:
-Per reason group at a templated call site: the feeding provenance
-(`sources`) and whether the group covers a structural-or-global param.
-Translate composes ownership masks and admission from it.
-_Avoid_: group ownership
+**Param group sources**:
+Per reason group at a templated call site (`getParamGroupSources`): the
+call site's sources for the group, function-body reads included, and
+whether it covers a structural-or-global param. Translate composes
+ownership masks and admission from it.
+_Avoid_: group feeds, group ownership, provenance, feed/feeder for a source
 
 **Bind `0`**:
 The serializer's last resort for a handler no recorded link reaches: the
-frame commit check rejects it and the client navigates. Analyze records why
+flush commit check rejects it and the client navigates. Analyze records why
 a faithful patch is impossible, never the mechanism.
 
 ## Compilation modes

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/test.ts
@@ -3,7 +3,7 @@ import { wait } from "../../utils/resolve";
 
 // The app shape with a page deriving from an unserialized global: a patch
 // onto the same page re-feeds the derived value, and a return to a loaded
-// page constructs it from the frame again, never from a client re-run.
+// page constructs it from the flush again, never from a client re-run.
 export const config: TestConfig = {
   persisted: true,
   equivalent: false,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/test.ts
@@ -7,7 +7,7 @@ const inc = (document: Document) => {
 
 // A pending await constructed from its record on a scriptless page settles
 // into a stateful child: the body record's walk created it, so its setup
-// (seed, mount) applies when the settle frame lands.
+// (seed, mount) applies when the settle flush lands.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/test.ts
@@ -6,7 +6,7 @@ const click = (document: Document) => {
 };
 
 // Thenables derived from input (not the nav promise) settle on different
-// ticks: prefix first, then each body, with a click between frames.
+// ticks: prefix first, then each body, with a click between flushes.
 export const config: TestConfig = {
   persisted: true,
   equivalent: false,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A patch whose `<await>` is still pending flushes ready fills now and
-// the resolved body in a later frame.
+// the resolved body in a later flush.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
-// A patch whose `<await>` rejects: prefix frame is pending, the error
-// arrives as a later frame and `@catch` receives it.
+// A patch whose `<await>` rejects: prefix flush is pending, the error
+// arrives as a later flush and `@catch` receives it.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A settled `<await>` boundary: the document render resumes the await body
-// and navigation patches values inside and around it in a single frame.
+// and navigation patches values inside and around it in a single flush.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // `@catch` content on an interactive page renders client-side when the
-// rejection frame lands: its server read delivers as a fill, so the title
+// rejection flush lands: its server read delivers as a fill, so the title
 // is the rejecting patch's, not the initial render's.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // `@catch` content reading a `$global`-derived value: the derivation
-// delivers as a fill each frame, so the catch UI renders the rejecting
+// delivers as a fill each flush, so the catch UI renders the rejecting
 // patch's brand, not the initial render's.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A dynamic `@catch` on a scriptless page bundles nothing: the slot is a
-// sentinel its rejection frame fills with server-rendered catch html.
+// sentinel its rejection flush fills with server-rendered catch html.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// A scriptless `<@catch>` renders server-side per rejection frame, so its
+// A scriptless `<@catch>` renders server-side per rejection flush, so its
 // request reads are current at materialization, on every rejection.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// A value the response's first frame bound (two reads) that a later frame
+// A value the response's first flush bound (two reads) that a later flush
 // (the settled await) writes again: it references the binding, not a copy.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // Nested `<try>` around a settled `<await>`: both boundaries pair, the
-// body fills in one frame.
+// body fills in one flush.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/test.ts
@@ -1,8 +1,8 @@
 import type { TestConfig } from "../../main.test";
 
-// Pending `<await>` inside `<try>` + `@placeholder`: the first frame
+// Pending `<await>` inside `<try>` + `@placeholder`: the first flush
 // applies ready fills and re-enters received placeholder state; the
-// settle frame replaces it with the resolved body.
+// settle flush replaces it with the resolved body.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/test.ts
@@ -3,7 +3,7 @@ import { flush, resolveAfter, wait } from "../../utils/resolve";
 
 // A patch arriving while the boundary's initial stream is still pending
 // rejects to navigation: rebuilding the try needs its body record, which
-// only a frame ships, and shipping it on every frame (or every page) for
+// only a flush ships, and shipping it on every flush (or every page) for
 // this race costs more than the navigation it would save.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// The handler's own scope is constructed by the same frame: the down link resolves after the construct lands.
+// The handler's own scope is constructed by the same flush: the down link resolves after the construct lands.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ title: "a", show: false }, { title: "b", show: true }, click],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/test.ts
@@ -1,8 +1,8 @@
 import type { TestConfig } from "../../main.test";
 import { resolveAfter, wait } from "../../utils/resolve";
 
-// A handler bound in one frame is bound again in the next: each streamed
-// frame re-ships the sources its bind references.
+// A handler bound in one flush is bound again in the next: each streamed
+// flush re-ships the sources its bind references.
 export const config: TestConfig = {
   persisted: true,
   steps: () => [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A constant fed to a child at the root and inside a branch: the setup
-// seed re-ships per frame (the server cannot tell fresh from paired) and
+// seed re-ships per flush (the server cannot tell fresh from paired) and
 // never clobbers the live value.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/test.ts
@@ -5,7 +5,7 @@ const inc = (document: Document) => {
 };
 
 // A stateful child constructed inside a branch: its root state seeds from
-// the frame's setup entry and its mount effect attaches, so the handler
+// the flush's setup entry and its mount effect attaches, so the handler
 // works and later fills refresh it.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/test.ts
@@ -2,7 +2,7 @@ import assert from "assert";
 
 import type { TestConfig } from "../../main.test";
 
-// A child with a tag var inside a branch constructs from the frame; the
+// A child with a tag var inside a branch constructs from the flush; the
 // var's write-back wires the constructed child, so a handler reads it.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-only-child/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-only-child/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A client-owned chain as an element's only child: skipping it on patch
-// renders must leave the sibling capture (and frame shape) intact.
+// renders must leave the sibling capture (and flush shape) intact.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-owned/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-owned/test.ts
@@ -4,7 +4,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// A pure-state test is client-owned: frames omit the entry, patches skip
+// A pure-state test is client-owned: flushes omit the entry, patches skip
 // the body, and a branch the client reveals renders the latest fill.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A param+state `<const>` in a branch refreshes through its join while
-// paired and constructs from both feeds: the frame's fill lands before the
+// paired and constructs from both feeds: the flush's fill lands before the
 // construct, and the fill and state closure inits both arrive at the join.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A never-assigned let is NOT state, so the chain stays server-owned:
-// shells ship, frames speak the selection, the interior captures.
+// shells ship, flushes speak the selection, the interior captures.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ title: "a" }, { title: "b" }],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/test.ts
@@ -6,7 +6,7 @@ const click = (document: Document) => {
 
 // A branch handler capturing server input: fills keep the capture current
 // on paired scopes, and a constructed branch's handler reads the value the
-// construct's frame shipped.
+// construct's flush shipped.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/test.ts
@@ -13,7 +13,7 @@ export const config: TestConfig = {
     click,
     { show: true, inner: true, title: "Store!" },
     click,
-    // The inner branch is destroyed in the same frame the fill changes:
+    // The inner branch is destroyed in the same flush the fill changes:
     // the dispatch skips the dropped selection cleanly.
     { show: true, inner: false, title: "Store?" },
   ],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-iterable-fn-fill/test.ts
@@ -6,7 +6,7 @@ const click = (document: Document) => {
 
 // A registered function inside a custom iterator the bind scan cannot
 // traverse still serializes: its own write channel binds it first, and
-// binds share by value identity across the frame.
+// binds share by value identity across the flush.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ title: "a" }, click, { title: "b" }],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/test.ts
@@ -1,5 +1,5 @@
 import type { TestConfig } from "../../main.test";
-// An effect in a nested branch reads a server-owned local declared in the enclosing branch: the frame writes the local and the effect's hop count targets that scope.
+// An effect in a nested branch reads a server-owned local declared in the enclosing branch: the flush writes the local and the effect's hop count targets that scope.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/test.ts
@@ -1,5 +1,5 @@
 import type { TestConfig } from "../../main.test";
-// A handler in a branch captures a server-owned branch local: the frame writes it so the click sees the patched value.
+// A handler in a branch captures a server-owned branch local: the flush writes it so the click sees the patched value.
 export const config: TestConfig = {
   persisted: true,
   steps: [{ show: true, title: "a" }, { show: true, title: "b" }, click],

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-mixed-call/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-mixed-call/test.ts
@@ -6,7 +6,7 @@ export const config: TestConfig = {
   persisted: true,
   error_html: true,
   // Only the debug serializer reports the function; optimize emits a bind
-  // the frame commit rejects.
+  // the flush commit rejects.
   skip_optimize: true,
   steps: [{ min: 0, check: () => true }],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 import { flush, resolveAfter, wait } from "../../utils/resolve";
 
-// A rejected boundary followed by a frame whose await is still pending:
+// A rejected boundary followed by a flush whose await is still pending:
 // the pending UI replaces the live catch content, then the settle lands.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/test.ts
@@ -6,7 +6,7 @@ const clickBoth = (document: Document) => {
   }
 };
 
-// Two sibling controllables constructing in one frame: each bind entry
+// Two sibling controllables constructing in one flush: each bind entry
 // carries its own child-link path, so both handlers land on the right
 // instance (First 1, Second 2).
 export const config: TestConfig = {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/test.ts
@@ -9,7 +9,7 @@ const clickP = (document: Document) => {
 };
 
 // A child's server-owned local derives from a param the CLIENT feeds: the
-// frame withholds the write and names the feed's init instead, so a fresh
+// flush withholds the write and names the feed's init instead, so a fresh
 // scope re-derives it from the live input and later feeds keep it current.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A content body holding an await constructs from its record (the await
-// body ships alongside) and pairs on later frames.
+// body ships alongside) and pairs on later flushes.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // Body content a child renders inside a branch the call site feeds from
-// state: the frame patches the content when the child renders it and
+// state: the flush patches the content when the child renders it and
 // fills its server values when the child withholds it.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked-value-multiple/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked-value-multiple/test.ts
@@ -10,7 +10,7 @@ const probe = (document: Document) => {
 };
 
 // An array `checkedValue` (checkbox group): the entry re-ships the array by
-// value each frame and each box compares its own `value` against it.
+// value each flush and each box compares its own `value` against it.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-checked-value/test.ts
@@ -11,7 +11,7 @@ const probe = (document: Document) => {
 
 // A `checkedValue` group: each input's entry carries `[checkedValue, value]`
 // and applies through the same helper CSR uses, so a live selection survives
-// an unchanged frame while a changed server value re-selects the group.
+// an unchanged flush while a changed server value re-selects the group.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-removal/test.ts
@@ -12,7 +12,7 @@ const check = (document: Document) => {
     document.querySelector("input")!.value;
 };
 
-// The handler is REMOVED between frames: the cleared slot returns the
+// The handler is REMOVED between flushes: the cleared slot returns the
 // input to uncontrolled behavior — typing sticks, nothing reports.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-static-with-spread/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-static-with-spread/test.ts
@@ -12,7 +12,7 @@ const probe = (document: Document) => {
 };
 
 // A control owned by a static (client-state) attr with a server spread: a
-// frame carrying only the spread must leave the live control alone — the
+// flush carrying only the spread must leave the live control alone — the
 // binding, handler, and typed value all survive the patch.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-swap/test.ts
@@ -6,7 +6,7 @@ const type = (document: Document) => {
   el.dispatchEvent(new document.defaultView!.Event("input", { bubbles: true }));
 };
 
-// The handler IDENTITY swaps between frames: the bind entry re-installs
+// The handler IDENTITY swaps between flushes: the bind entry re-installs
 // the CURRENT registration, so post-swap input reports uppercased.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A renderer swap on a scriptless page constructs from the template's root
-// record, shipped in-band with the frame.
+// record, shipped in-band with the flush.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-effect-only/test.ts
@@ -4,7 +4,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// A frame with no value fills at all (only the effect run) must still name
+// A flush with no value fills at all (only the effect run) must still name
 // the root and apply, preserving the delegated handler and client state.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A 3-deep mixed chain (if → if → for): the fill dispatches through two
-// conditional hops and a keyed loop hop, including same-frame destroy.
+// conditional hops and a keyed loop hop, including same-flush destroy.
 export const config: TestConfig = {
   persisted: true,
   steps: [
@@ -13,7 +13,7 @@ export const config: TestConfig = {
     click,
     { show: true, inner: true, items: ["b", "a"], suffix: "y" },
     click,
-    // The whole chain is destroyed in the frame the fill changes.
+    // The whole chain is destroyed in the flush the fill changes.
     { show: true, inner: false, items: ["b", "a"], suffix: "z" },
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-fn-select/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A ternary selecting between two server-bound arrows: the fill delivers
-// whichever the frame selected, re-bound, with fresh captures.
+// whichever the flush selected, re-bound, with fresh captures.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-fill/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A `$global`-derived value read inside client-owned structure delivers as
-// a fill: each frame re-ships it (globals can change per response), so the
+// a fill: each flush re-ships it (globals can change per response), so the
 // revealed branch re-renders with the current derivation.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-update/test.ts
@@ -4,7 +4,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// Serialized globals re-ship with every frame: an event-time `$global`
+// Serialized globals re-ship with every flush: an event-time `$global`
 // read after a patch sees the patched value, not the hydrated one.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-head-title/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-head-title/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// Head content is document content: a frame patches a title's text and a
+// Head content is document content: a flush patches a title's text and a
 // meta's attribute like any element's.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
-// An inline script in server-selected structure: it runs when a frame
-// reveals the branch, not when a later frame leaves the branch as is, and
+// An inline script in server-selected structure: it runs when a flush
+// reveals the branch, not when a later flush leaves the branch as is, and
 // again on a re-reveal.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/test.ts
@@ -2,7 +2,7 @@ import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
 // A branch holding a load-on-render child beside a server-owned spread:
-// the spread delivers as the element's attrs, so the frame still
+// the spread delivers as the element's attrs, so the flush still
 // constructs the branch and the child with it.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// The chunk a frame names fails to load: the frame rejects (the caller
+// The chunk a flush names fails to load: the flush rejects (the caller
 // navigates) instead of parking, and the page keeps what it had.
 export const config: TestConfig = {
   // Debug intentionally logs the load-failure diagnostic optimize cannot.

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/test.ts
@@ -4,7 +4,7 @@ import { wait } from "../../utils/resolve";
 // A patch REVEALS the branch holding a not-yet-loaded lazy child: the shell
 // ships the site's marker only, the construct starts the client-side load,
 // and the loaded module drives the child's ready channel so the deferred
-// frame data drains and the page becomes interactive.
+// flush data drains and the page becomes interactive.
 export const config: TestConfig = {
   persisted: true,
   equivalent: false,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/test.ts
@@ -2,7 +2,7 @@ import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
 // A dynamic lazy site leaves and returns with its module resident: the
-// frame composes the child and its ready batch applies to it.
+// flush composes the child and its ready batch applies to it.
 export const config: TestConfig = {
   persisted: true,
   equivalent: false,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-failed-before-patch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-failed-before-patch/test.ts
@@ -6,7 +6,7 @@ const load = (document: Document) => {
 };
 
 // The lazy chunk fails with NO patch pending on its channel: the page must
-// stay as it is (no reload), and a later frame naming the dead channel
+// stay as it is (no reload), and a later flush naming the dead channel
 // rejects into navigation instead of parking forever.
 export const config: TestConfig = {
   // Debug intentionally logs the load-failure diagnostic optimize cannot.

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-handler-ready/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-handler-ready/test.ts
@@ -1,9 +1,9 @@
 import type { TestConfig } from "../../main.test";
 import { wait } from "../../utils/resolve";
 
-// Frames for a not-yet-loaded lazy child carry handler binds on its ready
-// channel: each frame's binds materialize and validate when the batch
-// drains, two frames pending on the channel included.
+// Flushes for a not-yet-loaded lazy child carry handler binds on its ready
+// channel: each flush's binds materialize and validate when the batch
+// drains, two flushes pending on the channel included.
 const load = (document: Document) => {
   setTimeout(() => document.body.click());
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-load-failed/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-load-failed/test.ts
@@ -7,7 +7,7 @@ const load = (document: Document) => {
 // A patch defers on the lazy channel, then the loader SCRIPT fails at the
 // network level (script error, no evaluation): the
 // pending `applyPatch` promise settles as rejected (the caller navigates)
-// instead of hanging, and later frames naming the channel reject outright.
+// instead of hanging, and later flushes naming the channel reject outright.
 export const config: TestConfig = {
   // Debug intentionally logs the load-failure diagnostic optimize cannot.
   skip_parity: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/test.ts
@@ -6,7 +6,7 @@ const click = (document: Document) => {
 };
 
 // The site leaves and returns with its module resident: the returning
-// frame's ready batch must wait for the child to clone back in.
+// flush's ready batch must wait for the child to clone back in.
 export const config: TestConfig = {
   persisted: true,
   equivalent: false,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-shared-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-shared-value/test.ts
@@ -9,7 +9,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLElement>("b")!.click();
 };
 
-// An object the frame's tree writes and a lazy child's channel batch reads:
+// An object the flush's tree writes and a lazy child's channel batch reads:
 // the batch must carry it itself, not a path into the tree the client
 // applies and drops.
 export const config: TestConfig = {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // The loop-then-conditional chain dispatches per item and per selection,
-// including a same-frame destroy + fill change.
+// including a same-flush destroy + fill change.
 export const config: TestConfig = {
   persisted: true,
   steps: [
@@ -13,7 +13,7 @@ export const config: TestConfig = {
     click,
     { items: ["a", "b"], flag: true, suffix: "y" },
     click,
-    // The branches are destroyed in the same frame the fill changes.
+    // The branches are destroyed in the same flush the fill changes.
     { items: ["a", "b"], flag: false, suffix: "z" },
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-by-server/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-by-server/test.ts
@@ -6,7 +6,7 @@ export const config: TestConfig = {
   persisted: true,
   error_html: true,
   // Only the debug serializer reports the function; optimize emits a bind
-  // the frame commit rejects.
+  // the flush commit rejects.
   skip_optimize: true,
   steps: [{ key: (item: string) => item }],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-by-wrapped/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-by-wrapped/test.ts
@@ -6,7 +6,7 @@ export const config: TestConfig = {
   persisted: true,
   error_html: true,
   // Only the debug serializer reports the function; optimize emits a bind
-  // the frame commit rejects.
+  // the flush commit rejects.
   skip_optimize: true,
   steps: [{ key: (item: { id: number }) => item.id }],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/test.ts
@@ -8,7 +8,7 @@ const items = (...pairs: [number, string][]) =>
   pairs.map(([id, label]) => ({ id, label }));
 
 // The first patch of the session PREPENDS an item (its shell arrives at the
-// end of the frame, so the additions defer) while a conditional and captures
+// end of the flush, so the additions defer) while a conditional and captures
 // trail the loop: growth must not shift any pairing.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-whole-body/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-whole-body/test.ts
@@ -6,7 +6,7 @@ export const config: TestConfig = {
   persisted: true,
   error_html: true,
   // Only the debug serializer reports the function; optimize emits a bind
-  // the frame commit rejects.
+  // the flush commit rejects.
   skip_optimize: true,
   steps: [{ format: (item: string) => item + "!" }],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // Option `value`/`selected` patch like any attribute; a select's controlled
-// value re-syncs its options after the frame's writes land, as a render does.
+// value re-syncs its options after the flush's writes land, as a render does.
 export const config: TestConfig = {
   persisted: true,
   steps: [

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global-keys/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// Granular global guarding for a script reading TWO keys: a frame changing
+// Granular global guarding for a script reading TWO keys: a flush changing
 // only an UNREAD key must not re-run it; changing EITHER read key must.
 const globals = (brand: string, locale: string, other: string) => ({
   $global: {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-script-global/test.ts
@@ -1,6 +1,6 @@
 import type { TestConfig } from "../../main.test";
 
-// A `<script>` reading a serialized global: a frame whose globals changed
+// A `<script>` reading a serialized global: a flush whose globals changed
 // re-queues the effect, while an unchanged re-ship never re-runs it.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole/test.ts
@@ -4,7 +4,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// An unescaped hole patches as html: a server-owned one from the frame, a
+// An unescaped hole patches as html: a server-owned one from the flush, a
 // client-owned one through its fill; the fill never re-renders the former.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-effect/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-effect/test.ts
@@ -1,7 +1,7 @@
 import type { TestConfig } from "../../main.test";
 
 // A script reading a server-fed return: the effect-write channel
-// refreshes it and re-runs the reader per frame change.
+// refreshes it and re-runs the reader per flush change.
 export const config: TestConfig = {
   persisted: true,
   // The script leaves state on the page a fresh render lacks.

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/test.ts
@@ -4,7 +4,7 @@ const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
 
-// A server-fed return driving a structural test: frames select the
+// A server-fed return driving a structural test: flushes select the
 // branch while client state inside stays live.
 export const config: TestConfig = {
   persisted: true,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-structure/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-structure/test.ts
@@ -5,7 +5,7 @@ const click = (document: Document) => {
 };
 
 // A client-fed return driving a test is client-owned structure: the
-// selection recomputes client-side and frames never speak it.
+// selection recomputes client-side and flushes never speak it.
 export const config: TestConfig = {
   persisted: true,
   steps: [{}, click, {}, click],

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -512,25 +512,25 @@ function testFixtures(interop?: true) {
                 diverged = true;
               },
               onInput: persisted
-                ? async (input, betweenFrames) => {
+                ? async (input, betweenFlushes) => {
                     tracker.beginUpdate();
                     let applied = true;
-                    const frames: string[] = [];
-                    for await (const frame of template.patch(input)) {
-                      if (frames.length && betweenFrames) {
+                    const flushes: string[] = [];
+                    for await (const flush of template.patch(input)) {
+                      if (flushes.length && betweenFlushes) {
                         tracker.logUpdate(input);
                         tracker.beginUpdate();
-                        await betweenFrames(browser.window.document);
+                        await betweenFlushes(browser.window.document);
                         run();
                         await browser.runAsyncScripts();
                         run();
-                        tracker.logUpdate(betweenFrames);
+                        tracker.logUpdate(betweenFlushes);
                         tracker.beginUpdate();
                       }
-                      frames.push(frame);
+                      flushes.push(flush);
                       // A production caller navigates on the first failed
-                      // frame; later frames must not mutate further.
-                      const result = applyPatch!(frame);
+                      // flush; later flushes must not mutate further.
+                      const result = applyPatch!(flush);
                       if (typeof result !== "boolean") {
                         // A deferred patch is waiting on a lazy module; load
                         // triggers schedule via setTimeout, so a macrotask
@@ -540,9 +540,9 @@ function testFixtures(interop?: true) {
                       }
                       if (!(applied = await result)) break;
                     }
-                    patches.push(frames.join(""));
+                    patches.push(flushes.join(""));
                     tracker.logUpdate(input);
-                    if (applied && !diverged && !betweenFrames) {
+                    if (applied && !diverged && !betweenFlushes) {
                       await assertPatchedLikeFresh(input);
                     }
                     if (!applied) {
@@ -640,23 +640,23 @@ function testFixtures(interop?: true) {
                 async () => {
                   const { tracker, chunks, patches, freshDocs } = await ssr();
                   if (persisted) {
-                    // Each wire frame is one expression; format them
+                    // Each wire flush is one expression; format them
                     // independently so beautify cannot glue `}{`.
                     await snapMode(
                       () =>
                         patches
                           .map((joined) => {
-                            const frames = joined
+                            const flushes = joined
                               .split("\n")
-                              .map((frame) => frame.trimEnd())
+                              .map((flush) => flush.trimEnd())
                               .filter(Boolean)
-                              .map((frame) =>
-                                js_beautify(frame, {
+                              .map((flush) =>
+                                js_beautify(flush, {
                                   indent_size: 2,
                                 }).trimEnd(),
                               )
                               .join("\n");
-                            return "// PATCH\n" + frames;
+                            return "// PATCH\n" + flushes;
                           })
                           .join("\n\n")
                           .trimEnd() + "\n",
@@ -690,10 +690,10 @@ function testFixtures(interop?: true) {
                           const doc: Sizes = freshDocs[i]
                             ? await getSizes(freshDocs[i])
                             : stats.html;
-                          const frame = await getSizes(patches[i]);
+                          const flush = await getSizes(patches[i]);
                           assert.ok(
-                            frame.min < doc.min && frame.brotli < doc.brotli,
-                            `persisted response ${i} (${frame.min}b/${frame.brotli}b brotli) is not smaller than its document (${doc.min}b/${doc.brotli}b) for "${entry}"`,
+                            flush.min < doc.min && flush.brotli < doc.brotli,
+                            `persisted response ${i} (${flush.min}b/${flush.brotli}b brotli) is not smaller than its document (${doc.min}b/${doc.brotli}b) for "${entry}"`,
                           );
                         }
                       }
@@ -750,7 +750,7 @@ async function runSteps(
     onStep?: () => void;
     onInput?: (
       input: Input,
-      betweenFrames?: (document: Document) => unknown,
+      betweenFlushes?: (document: Document) => unknown,
     ) => void | boolean | Promise<void | boolean>;
     onFlush?: () => Promise<void>;
     onDestroy?: () => void;
@@ -797,7 +797,7 @@ async function runSteps(
       }
     } else if (opts.onInput) {
       const input = isNavigate(update) ? update.navigateInput : update;
-      const between = isNavigate(update) ? update.betweenFrames : undefined;
+      const between = isNavigate(update) ? update.betweenFlushes : undefined;
       if ((await opts.onInput(input, between)) === false) break;
     } else {
       // if new input is detected, stop testing

--- a/packages/runtime-tags/src/__tests__/serializer.test.ts
+++ b/packages/runtime-tags/src/__tests__/serializer.test.ts
@@ -2549,7 +2549,7 @@ describe("serializer", () => {
     assert.equal(partials.length, 25001);
   });
 
-  describe("patch frames", () => {
+  describe("patch flushes", () => {
     const patchBoundary = () =>
       ({
         signal: { aborted: false },

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -98,13 +98,13 @@ export function isThrows(value: any): value is Throws {
 
 export type Navigate = {
   navigateInput: Record<string, unknown>;
-  betweenFrames?: (document: Document) => unknown;
+  betweenFlushes?: (document: Document) => unknown;
 };
 export function navigate(
   input: Record<string, unknown>,
-  betweenFrames?: (document: Document) => unknown,
+  betweenFlushes?: (document: Document) => unknown,
 ): Navigate {
-  return { navigateInput: input, betweenFrames };
+  return { navigateInput: input, betweenFlushes };
 }
 export function isNavigate(value: any): value is Navigate {
   return (

--- a/packages/runtime-tags/src/common/constants/patch-key.ts
+++ b/packages/runtime-tags/src/common/constants/patch-key.ts
@@ -16,7 +16,7 @@ export const DynamicTag = "f";
 // Mirrors `AccessorProp.Global` on live scopes.
 export const Globals = "$";
 // Setup-only: registered ids a fresh scope runs, in the shell record's
-// `inits…!effects…` grammar (a client-fed local's feeds, a child's mounts).
+// `inits…!effects…` grammar (a client-upstream local's inits, a child's mounts).
 export const Init = "i";
 export const Loop = "l";
 export const Pending = "p";

--- a/packages/runtime-tags/src/common/meta.ts
+++ b/packages/runtime-tags/src/common/meta.ts
@@ -17,5 +17,5 @@ export const PLACEHOLDER_DISMISS_REGISTER_ID = MARKO_DEBUG
 // Rebuilds a registered content value from an in-band template.
 export const CONTENT_REGISTER_ID = MARKO_DEBUG ? "_content" : "_c";
 
-// Frame-scoped var resolving an index in the frame's bind table.
-export const BIND_FRAME_VAR = MARKO_DEBUG ? "bind" : "b";
+// Flush-scoped var resolving an index in the flush's bind table.
+export const BIND_FLUSH_VAR = MARKO_DEBUG ? "bind" : "b";

--- a/packages/runtime-tags/src/dom/load.ts
+++ b/packages/runtime-tags/src/dom/load.ts
@@ -69,7 +69,7 @@ export const _load_template = /*@__PURE__*/ withLazy(
 );
 
 // A persisted page's ready feature drives a branch's stamped channel once
-// loaded content is live (or fails), so deferred frame data drains after.
+// loaded content is live (or fails), so deferred flush data drains after.
 let loadReady: ((branch: BranchScope) => void) | undefined;
 let loadReadyFailed: typeof loadReady;
 // Installed by the persisted ready feature, whose wrappers below are the
@@ -84,7 +84,7 @@ export function installLoadReady(
   loadReadyFailed = onFailed;
   loadStart = onStart;
 }
-// A persisted page's `<${Lazy}>` site: frame data for a child this template
+// A persisted page's `<${Lazy}>` site: flush data for a child this template
 // constructs waits for its clone, so its setup reports the start.
 export const _load_ready_template = (
   readyId: string,

--- a/packages/runtime-tags/src/dom/patch-boundary.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-boundary.feat.ts
@@ -142,13 +142,13 @@ const settled = new WeakMap<Scope, Set<string>>();
 patchers[PatchKey.Pending] = (scope, key, value) => {
   const accessor = key.slice(PatchKey.Pending.length);
   const link = (AccessorPrefix.BranchScopes + accessor) as Accessor;
-  // The server now owns this await frame. Invalidate a promise started while
+  // The server now owns this await flush. Invalidate a promise started while
   // setting up a newly constructed parent body so its stale resolution drops.
   scope[(AccessorPrefix.Promise + accessor) as Accessor] = 0 as never;
-  // A settle from an earlier response must not hide this frame's pending UI.
+  // A settle from an earlier response must not hide this flush's pending UI.
   settled.get(scope)?.delete(accessor);
-  // A construct has no live await branch: the entry's id delivers the body
-  // content record its frame shipped. Mirrors `_await_content`.
+  // A construct has no live await branch: the entry's id names the body
+  // content record its flush shipped. Mirrors `_await_content`.
   if (typeof value === "string" && !scope[link]) {
     const renderer = getShellContent(shells[value]);
     const pendingScopes = collectScopes(
@@ -164,7 +164,7 @@ patchers[PatchKey.Pending] = (scope, key, value) => {
     );
     (scope[link] as BranchScope)[AccessorProp.PendingScopes] = pendingScopes;
   }
-  // Same-frame settle (Promise.resolve) also writes Child; skip pending UI.
+  // Same-flush settle (Promise.resolve) also writes Child; skip pending UI.
   queueMicrotask(() => {
     if (!settled.get(scope)?.has(accessor)) beginAwaitPending(scope, accessor);
   });
@@ -221,7 +221,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
   const link = key.slice(PatchKey.Child.length) as Accessor;
   const accessor = link.slice(AccessorPrefix.BranchScopes.length);
   // A try showing its catch render (shown like a placeholder, with no await
-  // pending) takes its body back first: the frame's partial addresses the body.
+  // pending) takes its body back first: the flush's partial addresses the body.
   if (
     (scope[link] as BranchScope | undefined)?.[
       AccessorProp.PlaceholderBranch
@@ -293,11 +293,11 @@ patchers[PatchKey.Child] = (scope, key, value) => {
 
 patchers[PatchKey.Catch] = (scope, key, error) => {
   const accessor = key.slice(PatchKey.Catch.length);
-  // An elided catch slot (`0`) fills from the frame's server-rendered html;
-  // a frame without it (an async catch body) rejects.
+  // An elided catch slot (`0`) fills from the flush's server-rendered html;
+  // a flush without it (an async catch body) rejects.
   const tryBranch = findBranchWithKey(scope, AccessorProp.CatchContent);
   let content = tryBranch?.[AccessorProp.CatchContent] as Renderer | 0;
-  // The slot stays `0`: every rejection frame renders its own catch html.
+  // The slot stays `0`: every rejection flush renders its own catch html.
   if (content === 0) {
     const [err, html] = error as [unknown, string | 0];
     if (typeof html !== "string") failPatch();
@@ -315,7 +315,7 @@ patchers[PatchKey.Catch] = (scope, key, error) => {
 };
 
 // The catch render shows like a placeholder: the parked try body comes
-// back when the next frame patches the try.
+// back when the next flush patches the try.
 function showCatch(tryBranch: BranchScope, error: unknown, content: Renderer) {
   const shown = tryBranch[AccessorProp.PlaceholderBranch] as
     | BranchScope

--- a/packages/runtime-tags/src/dom/patch-child.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-child.feat.ts
@@ -20,7 +20,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
   // the boundary's resumed branch (see pair-patches-into-still-streaming).
   if (!child) failPatch();
   child[AccessorProp.Owner] ??= scope;
-  // A scope this frame's shell walk created is bare (no render set it up):
+  // A scope this flush's shell walk created is bare (no render set it up):
   // its entries construct, like the branch's own; a live one pairs.
   if (child[AccessorProp.Gen] >= patchRun) {
     withConstructing(() => patchScope(value as Scope, child));

--- a/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
@@ -28,7 +28,7 @@ patchers[PatchKey.DynamicTag] = constructPatchers[PatchKey.DynamicTag] = (
     string | 0 | undefined,
     string | 0 | undefined,
   ];
-  // A bind reference delivers owner-bound content.
+  // A bind reference resolves owner-bound content.
   if (typeof renderer === "function") renderer = renderer();
   if (typeof renderer === "string" && (bare || input !== undefined)) {
     if (renderer[0] === ">") {

--- a/packages/runtime-tags/src/dom/patch-effect.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-effect.feat.ts
@@ -6,7 +6,7 @@ import { getRegisteredWithScope, patchers } from "./resume";
 
 // Key: effect register id. Entry: space-joined read accessors, a numeric
 // token switching the owner hops for those after it. A read stamped with
-// this frame's epoch re-runs the effect ONCE.
+// this flush's epoch re-runs the effect ONCE.
 patchers[PatchKey.Effect] = (scope, key, entry) => {
   if (scope[AccessorProp.Gen] === runId) return;
   const epoch = runId;

--- a/packages/runtime-tags/src/dom/patch-load.ts
+++ b/packages/runtime-tags/src/dom/patch-load.ts
@@ -1,11 +1,11 @@
 import { ready, readyFailed } from "./resume";
 
-// Loaders of the lazy templates only frames construct, by channel: the ready
-// feature starts one when a frame waits on its channel.
+// Loaders of the lazy templates only flushes construct, by channel: the ready
+// feature starts one when a flush waits on its channel.
 export const loads: Record<string, () => void> = {};
 
 /**
- * The loader of a lazy template only frames construct. Never pure: it
+ * The loader of a lazy template only flushes construct. Never pure: it
  * registers where no client code renders the site.
  */
 export function _load_lazy(id: string, load: () => Promise<unknown>) {

--- a/packages/runtime-tags/src/dom/patch-ready.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-ready.feat.ts
@@ -5,7 +5,7 @@ import {
   type Scope,
 } from "../common/types";
 import { installLoadReady } from "./load";
-import { applyReadyPatch, frameBinds, installPatchReady } from "./patch";
+import { applyReadyPatch, flushBinds, installPatchReady } from "./patch";
 import { loads } from "./patch-load";
 import { queueEffect, run } from "./queue";
 import {
@@ -21,7 +21,7 @@ import {
   type RenderData,
 } from "./resume";
 
-// A channel's guards: its entries met in a frame's tree, each with the live
+// A channel's guards: its entries met in a flush's tree, each with the live
 // scope they apply to.
 type Guards = [entries: Scope, scope: Scope][];
 // A render's patch awaiting its channels.
@@ -61,12 +61,12 @@ installLoadReady(
   },
 );
 
-// The frame's run may construct a site of the channel (a returning lazy
+// The flush's run may construct a site of the channel (a returning lazy
 // tag), so a guard applies at commit, after the run, channels settled.
 let pendingGuards: Record<string, Guards> = {};
 patchers[PatchKey.Ready] = (scope, key, entries) => {
   const readyId = key.slice(PatchKey.Ready.length);
-  // A site whose module died at page load stays inert: a frame targeting
+  // A site whose module died at page load stays inert: a flush targeting
   // it could never apply, so it rejects (the caller navigates).
   if (failed.has(readyId)) throw 0;
   (pendingGuards[readyId] ||= []).push([entries as Scope, scope]);
@@ -87,12 +87,12 @@ function commitReady() {
           .set(patchRender, {
             [ReadyPatchProp.Channels]: new Map(),
             [ReadyPatchProp.Resolvers]: [],
-            [ReadyPatchProp.Binds]: frameBinds,
+            [ReadyPatchProp.Binds]: flushBinds,
             [ReadyPatchProp.Run]: patchRun,
           })
           .get(patchRender)!)[ReadyPatchProp.Channels];
-      // A later frame's guards append: they re-ship full state, so in-order
-      // application leaves the newest frame's values live.
+      // A later flush's guards append: they re-ship full state, so in-order
+      // application leaves the newest flush's values live.
       channels.get(readyId)?.push(...channel) || channels.set(readyId, channel);
       loads[readyId]?.();
     }
@@ -131,7 +131,7 @@ function markReady(readyId: string) {
 }
 
 // A dead channel can never make its server content whole: pending appliers
-// resolve rejected (their caller navigates) and later frames naming it reject.
+// resolve rejected (their caller navigates) and later flushes naming it reject.
 const failed = new Set<string>();
 function failReady(readyId: string) {
   failed.add(readyId);

--- a/packages/runtime-tags/src/dom/patch-shells.ts
+++ b/packages/runtime-tags/src/dom/patch-shells.ts
@@ -22,7 +22,7 @@ import {
 const _content = /*@__PURE__*/ withBranches(content);
 
 // A branch stashes its setup for the shell's first render; a scope this
-// frame created (`Gen` since the frame's run, met while constructing) has
+// flush created (`Gen` since the flush's run, met while constructing) has
 // no render coming, so its setup applies now.
 patchers[PatchKey.Setup] = (scope, _key, value) => {
   if (
@@ -35,8 +35,8 @@ patchers[PatchKey.Setup] = (scope, _key, value) => {
     scope[AccessorProp.PatchSetup] = value as Scope;
   }
 };
-// Ids the frame asks a fresh scope to run, in the shell record's grammar
-// (`inits…!effects…`): a child's mounts, a client-fed local's feed inits.
+// Ids the flush asks a fresh scope to run, in the shell record's grammar
+// (`inits…!effects…`): a child's mounts, a client-upstream local's inits.
 constructPatchers[PatchKey.Init] = (scope, _key, ids) =>
   runSetupIds(resolveSetupIds(ids as string), scope);
 

--- a/packages/runtime-tags/src/dom/patch-value-bind.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-value-bind.feat.ts
@@ -1,25 +1,25 @@
 import "./patch-value.feat";
-import { BIND_FRAME_VAR } from "../common/meta";
+import { BIND_FLUSH_VAR } from "../common/meta";
 import type { Scope } from "../common/types";
-import { frameBinds, frameVars } from "./patch";
+import { flushBinds, flushVars } from "./patch";
 import { getRegisteredWithScope, patchers } from "./resume";
 
-// The frame epoch's binds: a source entry re-binds its registration at the
+// The flush epoch's binds: a source entry re-binds its registration at the
 // paired live scope, and bound fills reference the bind by index. A source
 // entry's key is that index (from 1), dispatched on its first digit like
 // any kind; the index is the datum, so no prefix.
 for (let digit = 10; --digit;) {
   patchers[digit] = (scope, key, id) => {
-    frameBinds[key] = (
+    flushBinds[key] = (
       getRegisteredWithScope(id as string) as (scope: Scope) => unknown
     )(scope);
   };
 }
-// A reference resolves lazily from its frame's table (later frames replace
-// `frameBinds`): its source walks in after the frame text evaluates, with
-// the frame or with a guard the frame left pending.
-frameVars[BIND_FRAME_VAR] = (i: number) => {
-  const binds = frameBinds;
+// A reference resolves lazily from its flush's table (later flushes replace
+// `flushBinds`): its source walks in after the flush text evaluates, with
+// the flush or with a guard the flush left pending.
+flushVars[BIND_FLUSH_VAR] = (i: number) => {
+  const binds = flushBinds;
   // A bound value that is not callable (owner-bound content) is the value.
   return (...args: unknown[]) =>
     typeof binds[i] === "function"

--- a/packages/runtime-tags/src/dom/patch.ts
+++ b/packages/runtime-tags/src/dom/patch.ts
@@ -15,56 +15,56 @@ import {
 } from "./resume";
 import type { RenderData, SerializeContext } from "./resume";
 
-// Installed by `patch-ready`: commits a frame's guards, settles a frame
+// Installed by `patch-ready`: commits a flush's guards, settles a flush
 // holding data for a not-yet-loaded module, discards a rejected one.
 let commitReady: (() => void) | undefined;
 let pendingReady: (() => Promise<boolean> | undefined) | undefined;
 let discardReady: (() => void) | undefined;
 
-// Frame-scoped bindings patch features inject.
-export const frameVars: Record<string, unknown> = {};
+// Flush-scoped bindings patch features inject.
+export const flushVars: Record<string, unknown> = {};
 
-// The frame's bind table (`patch-value-bind`): a guard the frame left
-// pending applies under it, so a source shipped with the frame serves the
+// The flush's bind table (`patch-value-bind`): a guard the flush left
+// pending applies under it, so a source shipped with the flush serves the
 // guard's reference.
-export let frameBinds: Record<string, unknown> = {};
+export let flushBinds: Record<string, unknown> = {};
 
 /** The live page's `$global`: names its render. */
 export type PatchGlobal = { renderId: string };
 
 /**
  * The live page's side of `template.patch`: `[headers, apply]`, the headers
- * a patch request sends (none yet) and the apply for each frame.
+ * a patch request sends (none yet) and the apply for each flush.
  */
 export function patch($global: PatchGlobal) {
   // The response's own serialize context keeps every tree the response
   // applied, keyed as the server keys them (the k-th tree), so a later
-  // frame references into an earlier one; anything else is the page's.
+  // flush references into an earlier one; anything else is the page's.
   let pageCtx: SerializeContext;
   const trees: unknown[] = [];
   const responseCtx = ((data: number | (Scope | number)[]) =>
     typeof data === "number" ? trees[data] : pageCtx(data)) as SerializeContext;
   responseCtx._ = registeredValues;
-  // Every patch feature is evaluated by now: the frame text references each
+  // Every patch feature is evaluated by now: the flush text references each
   // binding as a free variable (`b(1)`), skipping registry indirection.
-  const names = Object.keys(frameVars);
-  const vars = Object.values(frameVars);
-  const apply = (frame: string): boolean | Promise<boolean> => {
+  const names = Object.keys(flushVars);
+  const vars = Object.values(flushVars);
+  const apply = (flush: string): boolean | Promise<boolean> => {
     // Registered here so this module stays tree-shakable; a page with
     // `$global` joins installed its own (`patch-global.feat`).
     patchers[PatchKey.Globals] ||= applyGlobals;
-    frameBinds = {};
+    flushBinds = {};
     beginPatch(curRenders[$global.renderId]);
     try {
-      // A frame is trusted executable resume data from the same server
+      // A flush is trusted executable resume data from the same server
       // that produced the document; `$` stays the serializer's `undefined`.
       // eslint-disable-next-line no-new-func
-      const fn = new Function("_", "$", ...names, "return " + frame);
+      const fn = new Function("_", "$", ...names, "return " + flush);
       patchRender.r = [
         (ctx: SerializeContext) => {
           pageCtx = ctx;
           const value = fn(responseCtx, undefined, ...vars);
-          // The tree is the frame's last value; a frame of only shells (or
+          // The tree is the flush's last value; a flush of only shells (or
           // nothing) ends in a string (`undefined`), and the server keys none.
           const tree = Array.isArray(value) ? value[value.length - 1] : value;
           if (typeof tree === "object") trees.push(tree);
@@ -74,14 +74,14 @@ export function patch($global: PatchGlobal) {
       commitFrame();
       return pendingReady?.() || true;
     } catch (error) {
-      // The frame did not apply faithfully, so the caller navigates; only
+      // The flush did not apply faithfully, so the caller navigates; only
       // an intentional rejection (`failPatch`) throws 0.
       if (MARKO_DEBUG && error) console.error(error);
       discardReady?.();
       abortRun();
       return false;
     } finally {
-      // A rejected frame must not read as page data on a later walk; the
+      // A rejected flush must not read as page data on a later walk; the
       // array stays, a still-streaming page pushes into it.
       patchRender.r!.length = 0;
       abortPatch();
@@ -90,7 +90,7 @@ export function patch($global: PatchGlobal) {
   return [{}, apply] as const;
 }
 
-// A plain patched write; a changed value is marked with the frame's epoch
+// A plain patched write; a changed value is marked with the flush's epoch
 // (`patch-effect`, `patch-global`).
 export function patchWrite(scope: Scope, accessor: Accessor, value: unknown) {
   if (scope[accessor] !== value || !(accessor in scope)) {
@@ -122,14 +122,14 @@ export function installPatchReady(
 }
 
 // Commits deferred ready-channel data after its module loads, as an empty
-// frame run so it shares a frame's commit sequence and patch context.
+// flush run so it shares a flush's commit sequence and patch context.
 export function applyReadyPatch(
   render: RenderData,
   binds: Record<string, unknown>,
   runAt: number,
   push: () => void,
 ) {
-  frameBinds = binds;
+  flushBinds = binds;
   beginPatch(render, runAt);
   try {
     push();

--- a/packages/runtime-tags/src/dom/queue.ts
+++ b/packages/runtime-tags/src/dom/queue.ts
@@ -88,7 +88,7 @@ export function run() {
   runEffects(effects);
 }
 
-// Discards a rejected frame's queued work and retires its epoch, so
+// Discards a rejected flush's queued work and retires its epoch, so
 // residue (marks, fresh `Gen`s, queued checks) can never match later.
 export function abortRun() {
   runId++;

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -66,7 +66,7 @@ type Patcher = (scope: Scope, key: string, value: unknown) => void;
 
 export const registeredValues: Record<string, unknown> = {};
 export const patchers: Record<string, Patcher> = {};
-// Frame records ahead of the scope tree (`id;walks;template` shell
+// Flush records ahead of the scope tree (`id;walks;template` shell
 // strings), registered by the patch feature that understands them.
 export let onPatchRecord: ((entry: string) => void) | undefined;
 export const _patch_records = (handler: NonNullable<typeof onPatchRecord>) =>
@@ -112,12 +112,12 @@ let patchReadyFailed: undefined | ((readyId: string) => void);
 // Lazy load support latch, set as `dom/load.ts`'s runtime is evaluated, which
 // is before any resume; a page without lazy tags folds it and the retention away.
 let lazyEnabled: undefined | 1;
-// The render a frame is applying against (set by `beginPatch`); read only
+// The render a flush is applying against (set by `beginPatch`); read only
 // while `patching`.
 export let patchRender!: RenderData;
 let patching: 0 | 1 = 0;
-// The run the frame began on: a scope created since is the frame's own
-// construct (its entries construct); a deferred apply restores its frame's.
+// The run the flush began on: a scope created since is the flush's own
+// construct (its entries construct); a deferred apply restores its flush's.
 export let patchRun = 0;
 
 export function beginPatch(render: RenderData, runAt = runId) {
@@ -161,7 +161,7 @@ export function installReady(
 }
 
 // A channel module that never arrives can never drain its data: the
-// persisted feature settles pending patches and rejects later frames.
+// persisted feature settles pending patches and rejects later flushes.
 export function readyFailed(readyId: string) {
   if (MARKO_DEBUG) {
     if (!readyIds?.has(readyId)) {
@@ -479,7 +479,7 @@ export function init(runtimeId = DEFAULT_RUNTIME_ID) {
               if (Array.isArray(scopes)) {
                 applyScopes(scopes);
               } else if (patching && patchRender === render && scopes) {
-                // A shell-less frame is its bare tree object.
+                // A shell-less flush is its bare tree object.
                 applyScopes([scopes as Scope]);
               }
             }
@@ -654,7 +654,7 @@ export function _resume<T>(id: string, obj: T): T {
   return (registeredValues[id] = obj);
 }
 
-// A fill closure's construct init is the arrival at each join it feeds:
+// A fill closure's construct init is the arrival at each join downstream:
 // registered from the join's own fill wrapper, so it lives exactly as long.
 export function _init_join<T extends (scope: Scope) => void>(
   id: string,

--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -212,7 +212,7 @@ export function _fill_join_closure<T extends SignalFn>(
 }
 
 // Keeps a fill-joined value and its closure signal together so optimized
-// pages retain the only delivery path to subscribed content scopes.
+// pages retain the only refresh path to subscribed content scopes.
 export function _fill_join_subscribers<T extends SignalFn>(
   key: string,
   valueAccessor: EncodedAccessor,
@@ -243,7 +243,7 @@ export function _fill_join_subscribers<T extends SignalFn>(
   });
 }
 
-// A declaration doubles as its fill; `fillFn` (renders minus frame writes)
+// A declaration doubles as its fill; `fillFn` (renders minus flush writes)
 // is the fill-driven run when it has any.
 function fill<T extends Signal<any>>(
   key: string,

--- a/packages/runtime-tags/src/html/dynamic-tag.ts
+++ b/packages/runtime-tags/src/html/dynamic-tag.ts
@@ -302,7 +302,7 @@ export function _content_resume(
 }
 
 // Content with no client renderer elides its slot: a catch slot serializes
-// `0` (its frame carries html), a placeholder slot `undefined`.
+// `0` (its flush carries html), a placeholder slot `undefined`.
 export function _content_elide(
   id: string,
   fn: ServerRenderer,
@@ -334,7 +334,7 @@ export function _content_record(id: string, scopeId: number | undefined) {
       scopeId,
     ),
     contentAccessPrefix +
-      shells[id].slice(1) +
+      shells[id] +
       (scopeId === undefined ? ")" : ",_(" + scopeId + "))"),
   );
 }

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -113,10 +113,10 @@ export function renderPatch(
 }
 
 // Serialize guards stay unset so the compiled resume payload drops at the
-// source: a frame carries only patch fills.
+// source: a flush carries only patch fills.
 class PatchState extends State {
   public sentShells?: Set<string>;
-  public shellFrames = "";
+  public pendingShells = "";
   override writesPatches = true;
 
   override shipShell(shellId: string | 0 | undefined) {
@@ -146,7 +146,7 @@ class PatchState extends State {
   constructor($global: State["$global"]) {
     super($global);
     this.hasMainRuntime = true;
-    // The live page owns its serialized globals; a frame never re-ships them.
+    // The live page owns its serialized globals; a flush never re-ships them.
     this.hasGlobals = true;
   }
 
@@ -154,7 +154,7 @@ class PatchState extends State {
     const out = scripts ? scripts + "\n" : "";
     this.patchFlushed = undefined;
     this.patchTrees = undefined;
-    // The client's bind table lives one frame: a later frame re-ships the
+    // The client's bind table lives one flush: a later flush re-ships the
     // sources it references.
     this.binds = undefined;
     this.patchBinds = 0;
@@ -165,8 +165,8 @@ class PatchState extends State {
   // mid-expression) hoists shells into a preceding `_()` call.
   override resumeScript(resumes: string) {
     this.patchFlushed = 1;
-    const shellChunks = this.shellFrames && this.shellFrames.slice(1);
-    this.shellFrames = "";
+    const shellChunks = this.pendingShells;
+    this.pendingShells = "";
     if (this.patchDeferred) {
       this.patchDeferred = undefined;
       return shellChunks
@@ -233,7 +233,7 @@ class PatchState extends State {
                 : [branchPartial]
               : shellId || 1,
     });
-    // Later settle frames nest under the live branch as a Child apply.
+    // Later settle flushes nest under the live branch as a Child apply.
     if (branchIndex !== undefined) {
       link[2] = PatchKey.Child + AccessorPrefix.BranchScopes + accessor;
     }
@@ -311,7 +311,7 @@ export function _patch_attr(
   if (state.writesPatches) {
     // `0` is the removal sentinel: normalized values are always strings and
     // `undefined` entries are dropped entirely.
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Attr + accessor + " " + name,
       attrValue(value) ?? 0,
@@ -385,8 +385,9 @@ export function _patch_child(
   }
 }
 
-// A server-owned local whose param group the client feeds is not written:
-// a fresh scope re-derives it by running its feeds' closure inits (setup).
+// A server-owned local whose param group the client is upstream of is not
+// written: a fresh scope re-derives it by running its upstreams' closure
+// inits (setup).
 export function _patch_init(scopeId: number, initIds: string) {
   if (getState().writesPatches) {
     for (const id of initIds.split(" ")) addSetupId(scopeId, id);
@@ -410,7 +411,7 @@ export function _patch_value(
     if (setup) {
       if (state.patchFlushed) {
         throw new Error(
-          "A persisted patch cannot write after its frame flushed (async patch content is not supported).",
+          "A persisted patch cannot write after its flush was written (async patch content is not supported).",
         );
       }
       // Setup entries nest under `s`: the client applies them only to
@@ -442,7 +443,7 @@ export function _patch_control(
   const state = getState();
   if (state.writesPatches && _filled_guard(owned, group!)) {
     writeEmbeddedBinds(state as PatchState, value);
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Control + type + accessor,
       value,
@@ -641,7 +642,7 @@ export function _patch_attrs_partial_content(
   _attr_content(accessor, scopeId, content, serializeReason);
 }
 
-// The content renderer never rides the set: its entry delivers it.
+// The content renderer never rides the set: its entry carries it.
 function withoutContent(data: Record<string, unknown>) {
   if (data?.content === undefined) return data;
   const { content: _, ...set } = data;
@@ -658,7 +659,7 @@ export function _patch_text(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Text + accessor,
       _to_text(value),
@@ -686,7 +687,7 @@ export function _patch_html(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Html + accessor,
       _unescaped(value),
@@ -711,7 +712,7 @@ export function _patch_style(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Style + accessor + " " + name,
       value,
@@ -734,7 +735,7 @@ export function _patch_text_content(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(scopeId, PatchKey.TextContent + accessor, value, owned, group);
+    writeFilled(scopeId, PatchKey.TextContent + accessor, value, owned, group);
   } else {
     getChunk()!.needsWalk = true;
   }
@@ -758,7 +759,7 @@ export function _patch_attrs(
       writeEmbeddedBinds(state as PatchState, data);
       // `controllable` marks a spread owning the element's controllable; the
       // array form carries `skip`/`controllable` without key bytes.
-      writeOwned(
+      writeFilled(
         scopeId,
         PatchKey.Attrs + accessor,
         controllable ? [data ?? 0, 0, 1] : (data ?? 0),
@@ -787,7 +788,7 @@ export function _patch_attrs_partial(
   if (state.writesPatches) {
     if (_filled_guard(owned, group!)) {
       writeEmbeddedBinds(state as PatchState, data);
-      writeOwned(
+      writeFilled(
         scopeId,
         PatchKey.Attrs + accessor,
         controllable ? [data ?? 0, skip, 1] : [data ?? 0, skip],
@@ -812,7 +813,7 @@ export function _patch_attr_option_value(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Attr + accessor + " value",
       attrValue(value) ?? 0,
@@ -835,7 +836,7 @@ function patchStringAttr(
 ) {
   const state = getState();
   if (state.writesPatches) {
-    writeOwned(
+    writeFilled(
       scopeId,
       PatchKey.Attr + accessor + " " + name,
       value || 0,
@@ -849,14 +850,14 @@ function patchStringAttr(
   return stringAttr(name, value);
 }
 
-// Whether a consumer withheld a content renderer the frame handed it
-// (created, never invoked): server values inside deliver as fills then.
+// Whether a consumer withheld a content renderer the flush handed it
+// (created, never invoked): server values inside fill then.
 export function _content_withheld(id: string) {
   const state = getState() as PatchState;
   return !!state.createdContents?.has(id) && !state.renderedContents?.has(id);
 }
 
-function writeOwned(
+function writeFilled(
   scopeId: number,
   key: string,
   value: unknown,
@@ -872,7 +873,7 @@ function shipShell(state: PatchState, shellId: string | 0 | undefined) {
   if (!shellId || !shells[shellId]) return undefined;
   if (!(state.sentShells ??= new Set()).has(shellId)) {
     state.sentShells.add(shellId);
-    state.shellFrames += shells[shellId];
+    state.pendingShells += (state.pendingShells && ",") + shells[shellId];
   }
   return shellId;
 }

--- a/packages/runtime-tags/src/html/serializer.ts
+++ b/packages/runtime-tags/src/html/serializer.ts
@@ -1,4 +1,4 @@
-import { BIND_FRAME_VAR } from "../common/meta";
+import { BIND_FLUSH_VAR } from "../common/meta";
 import * as Char from "./constants/char";
 import type { Boundary } from "./writer";
 
@@ -301,9 +301,9 @@ const KNOWN_OBJECTS = /* @__PURE__ */ (() =>
 class State {
   ids = 0;
   flushId = 0;
-  // A frame's tree is no live scope: the response's context keeps every
+  // A flush's tree is no live scope: the response's context keeps every
   // tree it applied, keyed as the client keys them (the k-th tree), and a
-  // later frame paths from that key.
+  // later flush paths from that key.
   trees = 0;
   wroteUndefined = false;
   buf = [] as string[];
@@ -467,7 +467,7 @@ export function getRegistered(val: WeakKey) {
 // applies a payload's return value when it is an array.
 function writeScopesRoot(state: State, flushes: ScopeFlush[]) {
   const { buf } = state;
-  // A patch frame is one flat entry array, so the scope run serializes with
+  // A patch flush is one flat entry array, so the scope run serializes with
   // no fn wrapper or list brackets.
   const patch = state.boundary?.state?.writesPatches;
   let nextSlotId = -1;
@@ -476,9 +476,9 @@ function writeScopesRoot(state: State, flushes: ScopeFlush[]) {
   for (const flush of flushes) {
     const scopeId = flush[0];
     const scope = flush[1];
-    // A frame's flush is its own tree (the scope object is shared).
+    // Each flush is its own tree (the scope object is shared).
     const ref = patch
-      ? newFrameReference(state)
+      ? newFlushReference(state)
       : state.refs.get(scope) || newScopeReference(state, scope, scopeId);
 
     // Empty scopes fold into the next emitted slot's skip count.
@@ -506,7 +506,7 @@ function writeScopesRoot(state: State, flushes: ScopeFlush[]) {
   if (state.pendingAssignments.size || hasChannelMutations(state)) {
     extras = ",0)";
     // A deferred patch run applies through `_()` mid-expression, so a patch
-    // frame must evaluate its shell records first (see `resumeScript`).
+    // flush must evaluate its shell records first (see `resumeScript`).
     if (patch) state.boundary!.state.patchDeferred = 1;
     if (fillIndex !== -1) {
       buf[fillIndex] = "_([" + buf[fillIndex];
@@ -759,7 +759,7 @@ function trackScope(state: State, val: WeakKey, scopeId: number) {
   }
 }
 
-function newFrameReference(state: State) {
+function newFlushReference(state: State) {
   const ref = new Reference(null, null, state.flushId, null);
   ref.id = "_(" + state.trees++ + ")";
   return ref;
@@ -796,8 +796,8 @@ function writeRegistered(
       state.boundary.state as { binds?: Map<WeakKey, number> }
     ).binds?.get(val);
     // Bind `0` is never written, so a registration the render-time scan
-    // could not reach rejects at the frame's commit check (navigation).
-    state.buf.push(BIND_FRAME_VAR + "(" + (n || 0) + ")");
+    // could not reach rejects at the flush's commit check (navigation).
+    state.buf.push(BIND_FLUSH_VAR + "(" + (n || 0) + ")");
   } else if (scope) {
     // Registered factories read their self-resolving scope only when invoked.
     const ref = new Reference(

--- a/packages/runtime-tags/src/html/shells.ts
+++ b/packages/runtime-tags/src/html/shells.ts
@@ -1,5 +1,5 @@
 // Shell records (`id marker;walks;template`): raw for the server's static
-// renders, quoted once per response as frame chunks for constructs.
+// renders, quoted once per response as flush list members for constructs.
 export const shellRecords: Record<string, string> = {};
 export const shells: Record<string, string> = {};
 
@@ -7,6 +7,6 @@ export function _shells(registered: Record<string, string>) {
   for (const id in registered) {
     shellRecords[id] = registered[id];
     shells[id] =
-      ",`" + registered[id].replace(/[\\`]|\$\{/g, (m) => "\\" + m) + "`";
+      "`" + registered[id].replace(/[\\`]|\$\{/g, (m) => "\\" + m) + "`";
   }
 }

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -123,7 +123,7 @@ export function _peek_scope_id() {
 
 const kPendingContexts = Symbol("Pending Contexts");
 // The nearest elided `@catch` renderer: a rejection under it captures the
-// server-rendered catch html into its frame.
+// server-rendered catch html into its flush.
 const kElidedCatch = Symbol("Elided Catch");
 // Boundary content elided from a scriptless page's slots (no client
 // renderer): marked so `_try` routes rejections through inert captures.
@@ -236,7 +236,7 @@ export function _script(
 }
 
 // Setup ids share the shell record grammar (`inits…!effects…`); each side
-// dedupes so a feed shared by several locals arrives once.
+// dedupes so an upstream shared by several locals arrives once.
 export function addSetupId(scopeId: number, id: string, effect?: 1) {
   const { state } = $chunk.boundary;
   const setup = (patchPartial(state, scopeId)[PatchKey.Setup] ??= {}) as Record<
@@ -354,7 +354,7 @@ function markText(
 }
 
 // Structural patch entries hold their child partial objects, so the root
-// partial IS the frame tree and one ordinary serializer flush emits it.
+// partial IS the flush tree and one ordinary serializer flush emits it.
 export function writePatch(
   scopeId: number,
   entries: Record<string, unknown>,
@@ -364,7 +364,7 @@ export function writePatch(
   if (state.patchInert) return;
   if (state.patchFlushed) {
     throw new Error(
-      "A persisted patch cannot write after its frame flushed (async patch content is not supported).",
+      "A persisted patch cannot write after its flush was written (async patch content is not supported).",
     );
   }
   const partial = patchPartial($chunk.boundary.state, scopeId, serializeState);
@@ -439,7 +439,7 @@ export function patchPartial(
     if (serializeState.readyId && !pending) {
       // A channel's entries sit in the enclosing tree under the channel's
       // key, at the parent's child entry (scope `link[0]`, slot `link[1]`)
-      // or the root: one flat frame, applied once the channel is ready.
+      // or the root: one flat flush, applied once the channel is ready.
       const guard = (patchPartial(
         state,
         link ? link[0] : scopeId,
@@ -1106,8 +1106,8 @@ function scopeWithId(state: State, scopeId: number) {
 export function _global_subscribe(id: string, scopeId: number, unfilled?: 1) {
   const { state } = $chunk.boundary;
   if (!unfilled && !inUnpatched()) return;
-  // A frame's scopes are live already (paired) or subscribe as they render
-  // (constructed); the frame re-ships every global they could read.
+  // A flush's scopes are live already (paired) or subscribe as they render
+  // (constructed); the flush re-ships every global they could read.
   if (state.writesPatches) return;
   const key = AccessorPrefix.ClosureScopes + id;
   let subscribers = (state.globalSubscribers ??= {})[key];
@@ -1136,7 +1136,7 @@ export function _subscribe(
 }
 
 // On when no patch fills the group's value here (`_source_if` folded in: on
-// a page the reason is the mask): the client feeds it, or the read sits in
+// a page the reason is the mask): the client is upstream, or the read sits in
 // unpatched structure.
 export function _unfilled_if(owned?: SerializeReasonValue, group?: number) {
   const fed = maskGroup(owned, group!);
@@ -1161,10 +1161,10 @@ export function _persisted_reason() {
   state.serializeReason = undefined;
   if (state.writesPatches) {
     // The first persisted template of the render is the page root, about to
-    // allocate the next id — the frame names it as the walk's entry pair.
+    // allocate the next id — the flush names it as the walk's entry pair.
     if (!state.rootScopeId) {
       state.rootScopeId = _peek_scope_id();
-      // Globals re-ship with every frame (undefined included) so the live
+      // Globals re-ship with every flush (undefined included) so the live
       // page's global object never reads stale.
       const globals = getFilteredGlobals(state.$global, 1);
       if (globals) {
@@ -1198,7 +1198,7 @@ export function _filled_guard(mask: SerializeReasonValue, group: number) {
   const owned = maskGroup(mask, group);
   return owned === 2 || (owned === 0 && isInResumedBranch()) ? 1 : 0;
 }
-// Whether the client feeds the group (the low mask bit): the resumed page
+// Whether the client is upstream of the group (the low mask bit): the resumed page
 // then owns whatever sits downstream of the group.
 export function _client_guard(mask: SerializeReasonValue, group: number) {
   return maskGroup(mask, group) & 1 ? 1 : 0;
@@ -1268,7 +1268,7 @@ export function writeWaitReady(
 }
 
 // Renders content into a detached chunk with patch writes suppressed so the
-// html ships as frame data; async content yields `0` (reject).
+// html ships as flush data; async content yields `0` (reject).
 function renderInert(renderer: (arg: unknown) => void, arg: unknown) {
   const chunk = $chunk;
   const { state } = chunk.boundary;
@@ -1375,7 +1375,7 @@ export function _await<T>(
       if (boundary.state.writesPatches) {
         if (!boundary.signal.aborted) {
           chunk.render(() => {
-            // An elided catch has no client renderer: its frame carries
+            // An elided catch has no client renderer: its flush carries
             // the server-rendered catch html alongside the error.
             const elidedCatch = $chunk.context?.[kElidedCatch] as
               | ((err: unknown) => void)
@@ -1420,7 +1420,7 @@ export function _try(
   const { state } = boundary;
   const { resumeWrites } = boundary;
   // A patch shows `@placeholder`/`@catch` from received client state;
-  // the document reorder/`<t hidden>` path must not ride the frame stream.
+  // the document reorder/`<t hidden>` path must not ride the flush stream.
   const { writesPatches } = state;
   // Construct payload (content id + slot ids, `0` = elided catch) rides the
   // pairing entry, except for always-pairing branches outside divergence.
@@ -1745,8 +1745,8 @@ export class State implements SerializeState {
   public writeReorders: Chunk[] | null = null;
   public scopes = new Map<number, ScopeInternals>();
   public globalSubscribers?: Record<string, Set<ScopeInternals>>;
-  // Content renderers a frame created and invoked (by id): one created but
-  // never invoked was withheld by its consumer, so its fills deliver.
+  // Content renderers a flush created and invoked (by id): one created but
+  // never invoked was withheld by its consumer, so its values fill.
   public createdContents?: Set<string>;
   public renderedContents?: Set<string>;
   public flushScopes = false;
@@ -1885,7 +1885,7 @@ export class Boundary extends AbortController {
   }
 
   flush() {
-    // A pending patch must not stringify until its frame is actually
+    // A pending patch must not stringify until its flush is actually
     // emitted: the same partial objects keep receiving later writes.
     if (!this.signal.aborted && !(this.count && this.state.writesPatches)) {
       flushSerializer(this, this.state);
@@ -2223,7 +2223,7 @@ export class Chunk {
       let carried: Chunk[] | null = null;
 
       for (const reorderedChunk of state.writeReorders) {
-        // A chunk requeued when its reorder marker streamed delivers once
+        // A chunk requeued when its reorder marker streamed emits once
         // settled, or as an empty reorder once an aborted boundary strands it.
         if (reorderedChunk.async && reorderedChunk.consumed) {
           let aborted: Boundary | undefined = reorderedChunk.boundary;

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -206,7 +206,7 @@ export default {
                   toFirstExpressionOrBlock(node.body.body),
                 ),
                 // A persisted page always marks a patchable boundary: the
-                // frame pairs its body through the resumed branch link.
+                // flush pairs its body through the resumed branch link.
                 isPersisted() && !inStatefulBranch(section)
                   ? t.numericLiteral(1)
                   : getSerializeGuard(
@@ -264,7 +264,7 @@ export default {
             t.variableDeclaration("const", [
               t.variableDeclarator(
                 t.identifier(bodySection.name),
-                // Constructs resolve body content from the frame's shipped
+                // Constructs resolve body content from the flush's shipped
                 // record; registering here would bundle html resume elides.
                 awaitContent,
               ),

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -383,7 +383,7 @@ export default {
                 ? t.stringLiteral(id)
                 : t.numericLiteral(0),
               // A loop with params upstream yields to the client when the call
-              // site feeds its inputs from state.
+              // site has state upstream of its inputs.
               ...getExprWriteOwnership(node.extra!),
             );
           }
@@ -394,7 +394,7 @@ export default {
         );
         if (stateful) {
           // Patch renders skip the loop: its state reads are server-stale
-          // and the frame never speaks the listing.
+          // and the flush never speaks the listing.
           let rootSection = tagSection;
           while (rootSection.parent) rootSection = rootSection.parent;
           statement = t.ifStatement(

--- a/packages/runtime-tags/src/translator/core/html-comment.ts
+++ b/packages/runtime-tags/src/translator/core/html-comment.ts
@@ -107,7 +107,7 @@ export default {
 
       trackDomVarReferences(tag, nodeBinding);
 
-      // Split so the force cannot swallow the exprs' provenance.
+      // Split so the force cannot swallow the exprs' sources.
       if (tagVar) addSerializeExpr(tagSection, true, nodeBinding);
       addSerializeExpr(tagSection, tagExtra, nodeBinding);
       if (

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -330,7 +330,7 @@ export const IfTag = {
                     )
                   : undefined,
                 // A chain with params upstream yields to the client when
-                // the call site feeds them from state.
+                // the call site has state upstream of them.
                 ...(persistedPatch ? getExprWriteOwnership(ifTagExtra) : []),
               ),
             );

--- a/packages/runtime-tags/src/translator/core/style.ts
+++ b/packages/runtime-tags/src/translator/core/style.ts
@@ -156,7 +156,7 @@ function analyzeDynamicStyle(tag: t.NodePath<t.MarkoTag>, names: string[]) {
   });
 }
 
-// A dynamic style in server-owned structure writes its rule from the frame
+// A dynamic style in server-owned structure writes its rule from the flush
 // (a state-fed interpolation recomputes through the signal graph).
 function patchesStyle(section: Section) {
   return (

--- a/packages/runtime-tags/src/translator/util/constants/binding-type.ts
+++ b/packages/runtime-tags/src/translator/util/constants/binding-type.ts
@@ -8,7 +8,7 @@ export const param = 3;
 export const local = 4;
 export const derived = 5;
 export const constant = 6;
-// `$global` and its property aliases: tracked for provenance, inert in
+// `$global` and its property aliases: tracked as sources, inert in
 // the signal graph (no slot, no subscription, no closure, no ordinal).
 export const global = 7;
 

--- a/packages/runtime-tags/src/translator/util/for-selector.ts
+++ b/packages/runtime-tags/src/translator/util/for-selector.ts
@@ -1,7 +1,7 @@
 import type { types as t } from "@marko/compiler";
 
 import { forEach } from "./optional";
-import { isPatchFillBinding } from "./persisted/delivery";
+import { isPatchFillBinding } from "./persisted/refresh";
 import { inStatefulBranch } from "./persisted/structure";
 import {
   type Binding,
@@ -47,7 +47,7 @@ export function detectForSelector(
       if (
         closure.type !== BindingType.constant &&
         isDirectClosure(bodySection, closure) &&
-        // A fill delivers through the plain scan join; the keyed selector
+        // A fill refreshes through the plain scan join; the keyed selector
         // dispatch has no fill channel.
         !(inStatefulBranch(bodySection) && isPatchFillBinding(canonical)) &&
         !closures?.has(canonical) &&

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -86,11 +86,11 @@ import {
 } from "./serialize-guard";
 import {
   addSerializeExpr,
-  addSerializeProvenance,
+  addSerializeSources,
   addSerializeReason,
-  getSerializeProvenance,
+  getAllSourcesForExprs,
+  getSerializeSources,
   getSerializeReason,
-  getSerializeSourcesForExpr,
   getSerializeSourcesForExprs,
   getSerializeSourcesForRef,
 } from "./serialize-reasons";
@@ -126,9 +126,7 @@ const [getKnownTags] = createSectionState(
 );
 
 const kContentSection = Symbol("known tag content section");
-const kProvenanceRecordedGroups = Symbol(
-  "known tag provenance recorded groups",
-);
+const kSourcesRecordedGroups = Symbol("known tag sources recorded groups");
 const kChildScopeBinding = Symbol("known tag scope binding");
 export const kStaticBody = Symbol("known tag static body");
 export const kTagVar = Symbol("known tag var");
@@ -138,7 +136,7 @@ const kKnownExprs = Symbol("known tag exprs");
 declare module "@marko/compiler/dist/types" {
   export interface MarkoTagExtra {
     [kContentSection]?: Section;
-    [kProvenanceRecordedGroups]?: number;
+    [kSourcesRecordedGroups]?: number;
     [kChildScopeBinding]?: Binding;
     [kStaticBody]?: boolean;
     [kTagVar]?: true;
@@ -220,7 +218,7 @@ export function knownTagAnalyze(
       section,
     );
     setBindingDownstream(varBinding, varExpr);
-    // Split so the force cannot swallow the exprs' provenance.
+    // Split so the force cannot swallow the exprs' sources.
     if (mutatesTagVar) addSerializeExpr(section, true, childScopeBinding);
     addSerializeExpr(section, varExpr, childScopeBinding);
   }
@@ -336,9 +334,9 @@ export function knownTagTranslateHTML(
       } else {
         // Pages serialize fully, so the ambient slot carries the ownership
         // mask (needed exactly when a `_must_render` patch renders it).
-        const feeds = getParamGroupFeeds(tagExtra);
-        if (feeds) {
-          childSerializeReasonExpr = buildOwnershipMaskExpr(section, feeds);
+        const groups = getParamGroupSources(tagExtra);
+        if (groups) {
+          childSerializeReasonExpr = buildOwnershipMaskExpr(section, groups);
         }
       }
     } else if (contentSection.paramReasonGroups.length === 1) {
@@ -510,7 +508,7 @@ export function knownTagTranslateDOM(
   if (isPersisted() && !inStatefulBranch(getSection(tag))) {
     importRuntimeFeature("patch-child");
     if (tag.node.var) importRuntimeFeature("patch-value-bind");
-    for (const group of getParamGroupFeeds(extra) || []) {
+    for (const group of getParamGroupSources(extra) || []) {
       if (
         group.sources?.state &&
         some(group.params, (binding) => binding.upstreamOfStructure)
@@ -537,7 +535,7 @@ export function knownTagTranslateDOM(
       }
       return t.callExpression(importRuntime("_var_change"), changeArgs);
     };
-    // A frame constructing the child seeds the wiring through its setup.
+    // A flush constructing the child seeds the wiring through its setup.
     if (isPersisted()) importRuntimeFeature("patch-var");
     const wireVar = callRuntime(
       "_var",
@@ -565,7 +563,7 @@ export function knownTagTranslateDOM(
 }
 
 // The child's return reason for call-site classification (persisted
-// rejects returns whose provenance cannot map through ownership).
+// rejects returns whose sources cannot map through ownership).
 export function getKnownTagReturnReason(tagExtra: t.MarkoTagExtra) {
   return tagExtra[kContentSection]?.returnSerializeReason;
 }
@@ -577,22 +575,22 @@ export function finalizeKnownTags(section: Section) {
     const contentSection = tagExtra[kContentSection]!;
     if (knownExprs && scopeBinding && contentSection.paramReasonGroups) {
       if (isPersisted()) {
-        tagExtra[kProvenanceRecordedGroups] =
+        tagExtra[kSourcesRecordedGroups] =
           contentSection.paramReasonGroups.length;
       }
       for (const group of contentSection.paramReasonGroups) {
-        const feeders = mapParamReasonToExpr(knownExprs, group.reason);
+        const exprs = mapParamReasonToExpr(knownExprs, group.reason);
         addSerializeReason(
           section,
-          getSerializeSourcesForExprs(feeders),
+          getSerializeSourcesForExprs(exprs),
           scopeBinding,
           group.id,
         );
         if (isPersisted()) {
           // Fn-body reads inform ownership but never serialization, so
-          // they join the group's provenance only.
+          // they join the group's sources only.
           let fnSources: Sources | undefined;
-          forEach(feeders as Opt<t.NodeExtra>, (extra) => {
+          forEach(exprs as Opt<t.NodeExtra>, (extra) => {
             forEach(
               (extra as t.FunctionExtra).referencedBindingsInFunction,
               (binding) => {
@@ -603,52 +601,34 @@ export function finalizeKnownTags(section: Section) {
               },
             );
           });
-          addSerializeProvenance(section, fnSources, scopeBinding, group.id);
-          const provenance = getSerializeProvenance(
-            section,
-            scopeBinding,
-            group.id,
-          );
+          addSerializeSources(section, fnSources, scopeBinding, group.id);
+          const sources = getSerializeSources(section, scopeBinding, group.id);
           // The ownership mask composes over these groups at translate
           // time; group order freezes here.
-          ensureReasonGroups(provenance);
+          ensureReasonGroups(sources);
           // Under client state the child re-derives the group, so its
-          // server feeds must keep reaching it. A member only upstream of
+          // server sources must keep reaching it. A member only upstream of
           // branches (its params nest into the group) is served by pairing
-          // when its own feed has no state.
-          if (provenance?.state) {
+          // when its own sources have no state.
+          if (sources?.state) {
             forEach(group.reason, (param) => {
-              const feeder = mapParamBindingToExpr(knownExprs, param);
-              let sources: Sources | undefined;
-              forEach(feeder, (extra) => {
-                sources = mergeSources(
-                  sources,
-                  getSerializeSourcesForExpr(extra),
-                );
-                forEach(
-                  (extra as t.FunctionExtra).referencedBindingsInFunction,
-                  (binding) => {
-                    sources = mergeSources(
-                      sources,
-                      getSerializeSourcesForRef(binding),
-                    );
-                  },
-                );
-              });
-              if (sources?.state || !readsOnlyUpstream(param)) {
-                forEach(sources?.param, (binding) => {
-                  binding.feedsStateMixedGroup = true;
+              const paramSources = getAllSourcesForExprs(
+                mapParamBindingToExpr(knownExprs, param),
+              );
+              if (paramSources?.state || !readsOnlyUpstream(param)) {
+                forEach(paramSources?.param, (binding) => {
+                  binding.upstreamOfStateMixedGroup = true;
                 });
               }
             });
           }
-          // The fact rolls up: a param feeding a child's structural param
+          // The fact rolls up: a param upstream of a child's structural param
           // makes this template's params so too.
           if (some(group.reason, (binding) => binding.upstreamOfStructure)) {
-            recordStructuralParams(provenance);
+            recordStructuralParams(sources);
             // Client state upstream of the child's structure hands it the
             // structure at run time: its fills need the value patcher.
-            if (provenance?.state) addRuntimeFeatureAsset("patch-value");
+            if (sources?.state) addRuntimeFeatureAsset("patch-value");
           }
         }
       }
@@ -656,44 +636,40 @@ export function finalizeKnownTags(section: Section) {
   }
 }
 
-export interface ParamGroupFeeds {
+export interface ParamGroupSources {
   /** The child params this group covers. */
   params: NonNullable<Opt<Binding>>;
-  /** The call site's provenance feeding this group (fn-body reads
-   * included; survives any force on the key). */
+  /** The call site's sources for this group (fn-body reads included;
+   * survives any force on the key). */
   sources: Sources | undefined;
 }
 
-// Whether a group has a feed only the server can supply (params); state
+// Whether a group has a source only the server can supply (params); state
 // and `$global` both recompute client-side.
-export function hasServerFeed(sources: Sources | undefined) {
+export function hasParamSource(sources: Sources | undefined) {
   return !!(sources?.param || sources?.global);
 }
 
-// Per-group feed classification for a known templated call site, aligned
+// Per-group sources for a known templated call site, aligned
 // with the child's `paramReasonGroups` indices.
 // A tag analyzed as a known child template (vs a `<define>` site).
 export function isKnownTagExtra(tagExtra: t.MarkoTagExtra) {
   return !!tagExtra[kKnownExprs];
 }
 
-export function getParamGroupFeeds(
+export function getParamGroupSources(
   tagExtra: t.MarkoTagExtra,
-): ParamGroupFeeds[] | undefined {
+): ParamGroupSources[] | undefined {
   const scopeBinding = tagExtra[kChildScopeBinding];
   const contentSection = tagExtra[kContentSection];
   const groups = contentSection?.paramReasonGroups;
   if (!tagExtra[kKnownExprs] || !scopeBinding || !groups) return;
   // Groups born after the record (circular same-file tags) have no
-  // provenance: fail closed as unanalyzable input.
-  if (groups.length !== tagExtra[kProvenanceRecordedGroups]) return;
+  // sources: fail closed as unanalyzable input.
+  if (groups.length !== tagExtra[kSourcesRecordedGroups]) return;
   return groups.map((group) => ({
     params: group.reason,
-    sources: getSerializeProvenance(
-      scopeBinding.section,
-      scopeBinding,
-      group.id,
-    ),
+    sources: getSerializeSources(scopeBinding.section, scopeBinding, group.id),
   }));
 }
 
@@ -701,23 +677,23 @@ export function getParamGroupFeeds(
 // dynamic), or undefined when the all-server default is equivalent.
 function buildOwnershipMaskExpr(
   section: Section,
-  feeds: ParamGroupFeeds[],
+  groups: ParamGroupSources[],
 ): t.Expression | undefined {
   const rootSection = getRootSection(section);
-  const values = feeds.map(({ sources }) => {
-    if (sources?.state) return hasServerFeed(sources) ? 3 : 1;
+  const values = groups.map(({ sources }) => {
+    if (sources?.state) return hasParamSource(sources) ? 3 : 1;
     let subset: Opt<Binding>;
     forEach(sources?.param, (binding) => {
       if (binding.section === rootSection) {
         subset = bindingUtil.add(subset, binding);
       }
     });
-    if (!subset) return hasServerFeed(sources) ? 2 : 0;
+    if (!subset) return hasParamSource(sources) ? 2 : 0;
     const composed = getOwnershipGroupValue(
       rootSection,
       subset as NonNullable<Sources["param"]>,
     );
-    // A `$global` feed adds a static server bit beside the composition.
+    // A `$global` source adds a static server bit beside the composition.
     return sources!.global
       ? t.binaryExpression("|", t.numericLiteral(2), composed)
       : composed;
@@ -735,14 +711,17 @@ function buildOwnershipMaskExpr(
     if (value === 0) continue;
     if (typeof value === "number" && i < 15) {
       mask |= value << (1 + 2 * i);
-      const names = getDebugNames(feeds[i].params);
+      const names = getDebugNames(groups[i].params);
       if (names) maskNames += maskNames ? ` | ${names}` : names;
     } else {
       needsObject = true;
     }
     props.push(
       t.objectProperty(
-        withLeadingComment(t.numericLiteral(i), getDebugNames(feeds[i].params)),
+        withLeadingComment(
+          t.numericLiteral(i),
+          getDebugNames(groups[i].params),
+        ),
         typeof value === "number" ? t.numericLiteral(value) : value,
       ),
     );

--- a/packages/runtime-tags/src/translator/util/persisted/decisions.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/decisions.ts
@@ -5,8 +5,8 @@ import { getProgram, isAttributeTag } from "@marko/compiler/babel-utils";
 
 import {
   getKnownTagSection,
-  getParamGroupFeeds,
-  hasServerFeed,
+  getParamGroupSources,
+  hasParamSource,
   kStaticBody,
   kTagVar,
 } from "../known-tag";
@@ -42,23 +42,23 @@ export function isContentRenderTag(tag: t.NodePath<t.MarkoTag>) {
     getCanonicalBinding(binding.upstreamAlias) === getInputBinding(program)
   );
 }
-// A dynamic tag whose renderer and every input the server owns (any client
-// state feed disqualifies); needs resolved references — call at finalize.
+// A dynamic tag with no state source upstream of its renderer, inputs or
+// attr tags, so a patch fills it whole; needs resolved references (finalize).
 export function isServerOwnedDynamicTag(tag: t.NodePath<t.MarkoTag>) {
   const { node } = tag;
   if (t.isStringLiteral(node.name)) return false;
   // Name, attribute, spread and argument reads all merge into the tag extra.
-  if (hasStateFeed(node.extra)) return false;
+  if (hasStateSource(node.extra)) return false;
   let attrTagState = false;
   const checkAttrTags = (body: t.NodePath<t.MarkoTagBody>) => {
     for (const child of body.get("body")) {
       if (child.isMarkoTag() && isAttributeTag(child)) {
         for (const attr of child.node.attributes) {
           if (attr.type === "MarkoAttribute") {
-            attrTagState ||= hasStateFeed(attr.value.extra);
+            attrTagState ||= hasStateSource(attr.value.extra);
           }
         }
-        attrTagState ||= hasStateFeed(child.node.extra);
+        attrTagState ||= hasStateSource(child.node.extra);
         checkAttrTags(child.get("body"));
       }
     }
@@ -67,7 +67,7 @@ export function isServerOwnedDynamicTag(tag: t.NodePath<t.MarkoTag>) {
   return !attrTagState;
 }
 
-export function hasStateFeed(extra: t.NodeExtra | undefined) {
+export function hasStateSource(extra: t.NodeExtra | undefined) {
   return (
     !!getSerializeSourcesForExpr(extra || {})?.state ||
     some(
@@ -96,21 +96,21 @@ export function getChildPatchPlan(tagExtra: t.MarkoTagExtra) {
   if (!plan) {
     plan = computeChildPatchPlan(tagExtra);
     // Before known-tag finalize the groups are not yet stamped: no memo.
-    if (getParamGroupFeeds(tagExtra)) childPatchPlans.set(tagExtra, plan);
+    if (getParamGroupSources(tagExtra)) childPatchPlans.set(tagExtra, plan);
   }
   return plan;
 }
 
 function computeChildPatchPlan(tagExtra: t.MarkoTagExtra): ChildPatchPlan {
-  const feeds = getParamGroupFeeds(tagExtra);
+  const groups = getParamGroupSources(tagExtra);
   // No per-group analysis: a child that never reads its input renders
   // nothing from it, so the all-server default is exact.
-  if (!feeds) return {};
+  if (!groups) return {};
   // Argument and spread reads merge into the tag extra; groups see the rest.
-  let anyState = hasStateFeed(tagExtra as t.NodeExtra);
+  let anyState = hasStateSource(tagExtra as t.NodeExtra);
   let anyServerable = false;
-  for (const group of feeds) {
-    anyServerable ||= hasServerFeed(group.sources);
+  for (const group of groups) {
+    anyServerable ||= hasParamSource(group.sources);
     anyState ||= !!group.sources?.state;
   }
   // Skip only when nothing could change server-side; a tag variable's

--- a/packages/runtime-tags/src/translator/util/persisted/refresh.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/refresh.ts
@@ -1,10 +1,10 @@
 import type { types as t } from "@marko/compiler";
-// Translate-side patch delivery: which bindings refresh over the wire, fill
+// Translate-side patch fills: which bindings a patch fills or writes, fill
 // identity, and what a fresh scope can render. Analyze facts: ./structure.
 import { getProgram, getFile } from "@marko/compiler/babel-utils";
 
 import * as BindingType from "../constants/binding-type";
-import { getParamGroupFeeds, isKnownTagExtra } from "../known-tag";
+import { getParamGroupSources, isKnownTagExtra } from "../known-tag";
 import { isPersisted } from "../marko-config";
 import {
   every,
@@ -56,8 +56,8 @@ export function getPatchFillBindings(section: { bindings: Opt<Binding> }) {
 
 // Whether every param source promotes to a fill: the client can then
 // re-evaluate an expression mixing them with state at any time.
-export function paramsDeliverAsFills(params: Sources["param"]) {
-  return every(params, (param) => isPatchFillBinding(getDeliveryRoot(param)));
+export function paramsFill(params: Sources["param"]) {
+  return every(params, (param) => isPatchFillBinding(getFillRoot(param)));
 }
 
 // A canonical root server value a patch can keep current (aliases never
@@ -77,7 +77,7 @@ function isPatchRefreshableBinding(binding: Binding) {
   );
 }
 
-// A scope a frame writes into: the root, or a paired/constructed branch
+// A scope a flush writes into: the root, or a paired/constructed branch
 // on the branch path (a stateful branch is the client's alone).
 function isPatchWrittenSection(section: Section) {
   return (
@@ -97,7 +97,7 @@ export function isPatchFillBinding(binding: Binding) {
     isPersisted() &&
     ((!binding.section.parent && !getProgram().node.extra.page) ||
       (binding.section.isBranch && isBranchPathSection(binding.section))) &&
-    // Stateful branches never construct from frames, so their
+    // Stateful branches never construct from flushes, so their
     // state needs no seed fill.
     !isStatefulBranch(binding.section) &&
     getCanonicalBinding(binding) === binding &&
@@ -117,7 +117,7 @@ export function isPatchFillBinding(binding: Binding) {
 
 // The root value an alias chain reads: aliases never fill or write on
 // their own, their root does.
-export function getDeliveryRoot(binding: Binding) {
+export function getFillRoot(binding: Binding) {
   let root = binding;
   for (let cur = getCanonicalBinding(root); cur !== root;) {
     root = cur;
@@ -144,7 +144,7 @@ export function getFillConditions(binding: Binding) {
 }
 
 function getFillReadKind(binding: Binding): true | FillConditions | undefined {
-  if (binding.feedsStateMixedGroup) return true;
+  if (binding.upstreamOfStateMixedGroup) return true;
   let conditions: FillConditions | undefined;
   for (const alias of binding.aliases) {
     // A property alias or rest fills on its own; a direct alias reads this.
@@ -199,7 +199,7 @@ function getFillReadKind(binding: Binding): true | FillConditions | undefined {
       }
       if (effect || binding.section.parent) continue;
       // An `<await>` value re-fires no promise client-side: the boundary's
-      // own frames deliver its settlement.
+      // own flushes carry its settlement.
       if (content && !isBoundaryValueRead(read)) {
         const withholds = consumerMayWithhold(content);
         if (withholds === true) return true;
@@ -245,7 +245,7 @@ function consumerMayWithhold(content: Section) {
     return false;
   }
   if (getChildPatchPlan(consumer).skipsPatchRender) return true;
-  for (const group of getParamGroupFeeds(consumer) || []) {
+  for (const group of getParamGroupSources(consumer) || []) {
     if (
       group.sources?.state &&
       some(group.params, (param) => param.upstreamOfStructure)
@@ -293,7 +293,7 @@ export function isPatchWriteBinding(binding: Binding) {
 // id when a patch changes what they saw.
 export function hasPatchEffectReads(binding: Binding): boolean {
   for (const read of binding.reads) {
-    // A serialized spread's set is its own delivery.
+    // A serialized spread's set is its own refresh.
     if (read.isEffect && !read.attrSetSpread) return true;
   }
   for (const alias of binding.aliases) {
@@ -327,14 +327,14 @@ export function getConstructInitClosures(section: Section) {
 }
 
 // A closure read in `section` that is a `tagNameLoad` tag's input.
-export function feedsTagNameLoadIn(closure: Binding, section: Section) {
+export function readAsTagNameLoadInput(closure: Binding, section: Section) {
   for (const read of closure.reads) {
     if (read.section === section && read.tagNameLoadInput) return true;
   }
   return false;
 }
 
-// A fill closure feeding a state intersection read in `section` (which
+// A fill closure upstream of a state intersection read in `section` (which
 // then rides a `_fill_join_*` wrapper registering the closure's init).
 function fillJoinsIn(closure: Binding, section: Section) {
   if (closure.sources?.state || !isPatchFillBinding(closure)) return false;
@@ -350,24 +350,24 @@ function fillJoinsIn(closure: Binding, section: Section) {
   return false;
 }
 
-// Closures a section's server-owned local fills derive from: when a frame
+// Closures a section's server-owned local fills derive from: when a flush
 // withholds such a write, the fresh scope re-derives through their inits.
-export function getLocalFillFeeds(section: Section) {
-  let feeds: Opt<Binding>;
+export function getLocalFillUpstreams(section: Section) {
+  let upstreams: Opt<Binding>;
   forEach(getPatchFillBindings(section), (fill) => {
     if (fill.section === section && !fill.sources?.state) {
-      forEach(fill.sources?.param, (feed) => {
-        if (feed.section !== section && !includes(feeds, feed)) {
-          feeds = push(feeds, feed);
+      forEach(fill.sources?.param, (upstream) => {
+        if (upstream.section !== section && !includes(upstreams, upstream)) {
+          upstreams = push(upstreams, upstream);
         }
       });
     }
   });
-  return feeds;
+  return upstreams;
 }
 
 // A local the server computes without client state; a `$global`
-// contribution is fine since the shipped value is per-frame current.
+// contribution is fine since the shipped value is per-flush current.
 function isSeedableLocal(binding: Binding) {
   return (
     !binding.sources?.state &&
@@ -408,18 +408,18 @@ export function getRootGlobalReads(section: Section) {
 }
 
 // Server-sourced reads a patch cannot keep current: param-sourced bindings
-// that neither fill nor refresh over the wire read stale after any patch.
+// a patch neither fills nor writes read stale after any patch.
 export function hasUnfillablePatchReads(refs: Opt<Binding>) {
   return some(refs, (binding) => {
     const sources = getSerializeSourcesForRef(binding);
-    return !!sources?.param && !sources.global && !delivers(binding);
+    return !!sources?.param && !sources.global && !patchFills(binding);
   });
 }
 
-// A root value delivers as a fill or write; a local derivation delivers
-// when every server feed it derives from does (it recomputes client-side).
-function delivers(binding: Binding, seen = new Set<Binding>()): boolean {
-  const root = getDeliveryRoot(binding);
+// A patch fills a root value (a fill or a write) and a local derivation
+// when every server source it derives from (it recomputes client-side).
+function patchFills(binding: Binding, seen = new Set<Binding>()): boolean {
+  const root = getFillRoot(binding);
   if (seen.has(root)) return true;
   seen.add(root);
   if (!root.section.parent) {
@@ -427,5 +427,5 @@ function delivers(binding: Binding, seen = new Set<Binding>()): boolean {
   }
   // A branch's own param (a loop item) arrives with the structure.
   if (isSectionParam(root)) return true;
-  return every(root.sources?.param, (param) => delivers(param, seen));
+  return every(root.sources?.param, (param) => patchFills(param, seen));
 }

--- a/packages/runtime-tags/src/translator/util/persisted/structure.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/structure.ts
@@ -1,5 +1,5 @@
 // Analyze-side structure facts for persisted pages, in template terms;
-// ownership conclusions and wire channels belong to translate (./delivery).
+// ownership conclusions and wire channels belong to translate (./refresh).
 import type { types as t } from "@marko/compiler";
 
 import { kDirectContent } from "../binding-prop-tree";
@@ -12,8 +12,8 @@ import {
   getSerializeSourcesForExpr,
   getSerializeSourcesForRef,
 } from "../serialize-reasons";
-import { isPatchFillBinding, paramsDeliverAsFills } from "./delivery";
 import { onFinalizePersisted } from "./lifecycle";
+import { isPatchFillBinding, paramsFill } from "./refresh";
 
 // A boundary branch live on every persisted page (serialized on every page
 // render, nothing on the chain diverges), so it pairs without a construct.
@@ -56,7 +56,7 @@ export function childRendersStateful(
 }
 
 // A binding (or a property of it) rendered as a tag inside stateful
-// structure, here or by the child binding a read feeds.
+// structure, here or by the child binding a read is upstream of.
 const rendering = new Set<Binding>();
 function rendersStateful(binding: Binding): boolean {
   if (rendering.has(binding)) return false;
@@ -81,7 +81,7 @@ function rendersStatefulProp(binding: Binding, prop: string) {
   return !!alias && rendersStateful(alias);
 }
 // A read inside stateful structure renders there (directly, or by the
-// child it feeds); elsewhere only the child's own structure decides.
+// child it is upstream of); elsewhere only the child's own structure decides.
 function readsRenderStateful(binding: Binding) {
   for (const read of binding.reads) {
     if (
@@ -94,7 +94,7 @@ function readsRenderStateful(binding: Binding) {
   }
   return false;
 }
-// A tag body is stateful when the prop it feeds renders so in the child;
+// A tag body is stateful when the prop it is upstream of renders so in the child;
 // the last hop stays a prop query so whole reads of its owner count.
 function bodyRendersStateful(section: Section) {
   const downstream = section.downstream;
@@ -107,8 +107,8 @@ function bodyRendersStateful(section: Section) {
   return !!target && rendersStatefulProp(target, props[props.length - 1]);
 }
 
-// A branch body whose upstream has a state reason (or nested in one) whose param
-// feeds all deliver; resolved sources are required, so call at finalize or later.
+// A branch body whose upstream has a state reason (or nested in one) and
+// whose param sources a patch fills; needs resolved sources (finalize or later).
 const statefulBySection = new WeakMap<Section, boolean>();
 const computing = new Map<Section, number>();
 let provisionalAt = Infinity;
@@ -135,7 +135,7 @@ export function isStatefulBranch(section: Section): boolean {
       (!expr && bodyRendersStateful(section)) ||
       (!!expr &&
         (!!sources?.state || inStatefulBranch(section.parent)) &&
-        every(expr.referencedBindings, upstreamFeedDelivers));
+        every(expr.referencedBindings, upstreamSourcesFill));
     computing.delete(section);
     // A frame that consumed an OUTER frame's provisional answer must not
     // cache: that outer result may still land stateful.
@@ -151,19 +151,17 @@ export function isStatefulBranch(section: Section): boolean {
 
 // A state-mixed ref recomputes client-side, so its param ORIGINS must fill;
 // a pure-param ref ships its own computed value.
-function upstreamFeedDelivers(binding: Binding) {
+function upstreamSourcesFill(binding: Binding) {
   const sources = getSerializeSourcesForRef(binding);
   return (
     !sources?.param ||
-    (sources.state
-      ? paramsDeliverAsFills(sources.param)
-      : isPatchFillBinding(binding)) ||
+    (sources.state ? paramsFill(sources.param) : isPatchFillBinding(binding)) ||
     inStatefulBranch(binding.section)
   );
 }
 
 // A param read only upstream of branches: its value never joins a client
-// derivation, so pairing delivers it and no fill is needed.
+// derivation, so pairing carries it and no fill is needed.
 export function readsOnlyUpstream(binding: Binding) {
   for (const read of binding.reads) {
     if (!isBranchUpstream(read)) return false;
@@ -171,7 +169,7 @@ export function readsOnlyUpstream(binding: Binding) {
   return true;
 }
 
-// Params alone upstream: a call site feeding them from state hands the
+// Params alone upstream: a call site with state upstream of them hands the
 // branch to the client at run time. Call at finalize or later.
 export function getParamUpstreamSources(section: Section) {
   if (

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -30,12 +30,12 @@ import {
   push,
   Sorted,
 } from "./optional";
+import { finalizePersisted } from "./persisted/lifecycle";
 import {
   getRootGlobalReads,
   isPatchFillBinding,
   isPatchWriteBinding,
-} from "./persisted/delivery";
-import { finalizePersisted } from "./persisted/lifecycle";
+} from "./persisted/refresh";
 import { addRuntimeFeatureAsset, callRuntime } from "./runtime";
 import { createScopeReadExpression, getScopeExpression } from "./scope-read";
 import {
@@ -141,15 +141,15 @@ export interface Binding {
   exposed: boolean;
   forcePersist: boolean;
   /** A root param whose reads sit upstream of a branch or loop (here, or in a
-   * child it feeds). */
+   * child it is upstream of). */
   upstreamOfStructure: boolean;
   /** Captured inside a registered function: live-scope reads reach it at
    * any later invocation. */
   registeredFnCapture: boolean;
-  /** Feeds a child input group that client state also feeds (the child
-   * re-derives that group from both). */
-  feedsStateMixedGroup: boolean;
-  /** Can hold a function a fill must deliver bind-aware: a literal fn,
+  /** Upstream of a child input group that client state is also upstream
+   * of (the child re-derives that group from both). */
+  upstreamOfStateMixedGroup: boolean;
+  /** Can hold a function a fill must carry bind-aware: a literal fn,
    * an invoked or handler-attr read, or a derivation over one. */
   functionValued: boolean;
   /** Binding-side counterpart of `Section.serializePropKeys`, keyed by
@@ -305,7 +305,7 @@ export function createBinding(
     forcePersist: false,
     upstreamOfStructure: false,
     registeredFnCapture: false,
-    feedsStateMixedGroup: false,
+    upstreamOfStateMixedGroup: false,
     functionValued: false,
     serializePropKeys: undefined,
     reserveSize: 0,
@@ -1236,7 +1236,7 @@ export function finalizeReferences() {
           }
 
           setReadsOwner(section, canonicalUpstreamAlias.section);
-          // Split so the force cannot swallow the sources' provenance.
+          // Split so the force cannot swallow the sources.
           if (isEffect) {
             addOwnerSerializeReason(
               section,
@@ -1270,7 +1270,7 @@ export function finalizeReferences() {
       section.sectionAccessor &&
       section.upstreamExpression
     ) {
-      // Split so the force cannot swallow the sources' provenance.
+      // Split so the force cannot swallow the sources.
       if (section.isHoistThrough || section.hoisted) {
         addSerializeReason(section, true, kBranchSerializeReason);
       }
@@ -1357,7 +1357,7 @@ export function finalizeReferences() {
       let branchesSources: undefined | Sources;
 
       // The walk keeps merging through a forced hop: the force decides the
-      // reason, but later hops' sources still feed provenance.
+      // reason, but later hops' sources still count as sources.
       while (currentSection !== sourceSection) {
         const upstreamReason = currentSection.downstream?.binding
           ? getSectionRegisterReasons(currentSection) || undefined
@@ -1477,7 +1477,7 @@ export function finalizeReferences() {
   forEachSection(finalizeParamSerializeReasonGroups);
   forEachSectionReverse((section) => {
     finalizeKnownTags(section);
-    // Call-site provenance (above) can make more root params fills.
+    // Call-site sources (above) can make more root params fills.
     if (isPersisted()) {
       forEach(section.bindings, (binding) => {
         const fills = isPatchFillBinding(binding);
@@ -1523,7 +1523,7 @@ export function finalizeReferences() {
       }
 
       // Renders run in id order, so a closure-only intersection must come
-      // before the owned derived binding it may feed.
+      // before the owned derived binding it may be upstream of.
       intersections.sort((a, b) => {
         const aAnchor = sectionAnchors.get(a);
         const bAnchor = sectionAnchors.get(b);
@@ -1701,7 +1701,7 @@ const [getBindingValueExprs] = createProgramState(
   () => new Map<Binding, boolean | Opt<t.NodeExtra>>(),
 );
 // A `$global` read compiles verbatim (no read slot, signal, or register
-// id) unless persisted keys it: a keyed read delivers like any reference.
+// id) unless persisted keys it: a keyed read refreshes like any reference.
 function isVerbatimGlobal(binding: Binding) {
   return (
     binding.type === BindingType.global &&
@@ -1778,7 +1778,7 @@ function resolveDerivedSources(binding: Binding) {
     const seen = new Set<Binding>();
     forEach(exprs, (expr) => {
       // A value holding a function literal (or one selected among
-      // function-valued bindings) can deliver one.
+      // function-valued bindings) can carry one.
       if (expr.functionValued) binding.functionValued = true;
       if (isReferencedExtra(expr)) {
         forEach(expr.referencedBindings, (ref) => {
@@ -2004,7 +2004,7 @@ function addReadToExpression(
   if (!fnRoot && isSerializedChangeHandlerRead(exprRoot)) {
     read.serializedValue = true;
     // The captured handler can be a scope-bound registration, so its
-    // fill must deliver bind-aware.
+    // fill must carry it bind-aware.
     binding.functionValued = true;
   }
 
@@ -3086,7 +3086,7 @@ function setReadsOwner(from: Section, to: Section) {
   }
 }
 
-// The call site expressions feeding a child template's input, keyed the way
+// The call site expressions upstream of a child template's input, keyed the way
 // the child destructures it; `value` is the whole-value expression.
 export interface KnownExprs {
   known?: Record<string, KnownExprs>;

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -135,14 +135,14 @@ export interface Section {
   /** Reasons any of the section's dom nodes resumes, as the analyzed reasons
    * (not merged) so each one's guard stays buildable. */
   domSerializeReasons: undefined | SerializeReasons;
-  /** Pending serialize exprs, resolved into the reasons (and provenance)
+  /** Pending serialize exprs, resolved into the reasons (and sources)
    * once references finalize. */
   serializeExprs: Opt<t.NodeExtra>;
   propSerializeExprs: Map<SerializeKey, OneMany<t.NodeExtra>> | undefined;
-  /** Whose values feed each serialization decision — survives force-`true`
+  /** The sources of each serialization decision — survives force-`true`
    * and counts function-body reads; complete after reference finalize. */
-  serializeProvenance: Sources | undefined;
-  propSerializeProvenance: Map<SerializeKey, Sources> | undefined;
+  serializeSources: Sources | undefined;
+  propSerializeSources: Map<SerializeKey, Sources> | undefined;
   /** Interned per-prop reason keys for string/symbol props. */
   serializePropKeys: Map<string | symbol, SerializeKey> | undefined;
   paramReasonGroups: ParamSerializeReasonGroups | undefined;
@@ -153,7 +153,7 @@ export interface Section {
   /** For a `<define>` body: the sections of its direct `<${var}>` sites. */
   defineSites: Section[] | undefined;
   /** The content's rendering tag (its extra), and the child binding the
-   * content feeds when the child can serialize it. */
+   * content is upstream of when the child can serialize it. */
   downstream:
     | {
         tag: t.MarkoTagExtra;
@@ -177,7 +177,7 @@ export interface Section {
   /** A content body shipped as a shell record: `"static"` rides its slot
    * in-band, a dynamic one is constructed by id from a dynamic tag entry. */
   contentRecord: false | true | "static";
-  /** Awaits a construct must deliver body content for (marker binding +
+  /** Awaits a construct must supply body content for (marker binding +
    * body section); `buildShells` prunes those no shipped shell reaches. */
   constructSetups: { binding: Binding; body: Section }[] | undefined;
   /** Lazily loaded child sites in this section, by their marker binding. */
@@ -257,8 +257,8 @@ export function startSection(
       domSerializeReasons: undefined,
       serializeExprs: undefined,
       propSerializeExprs: undefined,
-      serializeProvenance: undefined,
-      propSerializeProvenance: undefined,
+      serializeSources: undefined,
+      propSerializeSources: undefined,
       serializePropKeys: undefined,
       paramReasonGroups: undefined,
       returnValueExpr: undefined,

--- a/packages/runtime-tags/src/translator/util/serialize-reasons.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-reasons.ts
@@ -63,9 +63,9 @@ export function addSerializeReason(
 ) {
   if (reason) {
     if (reason !== true) {
-      addProvenance(section, reason, prop && getPropKey(section, prop, prefix));
+      addSources(section, reason, prop && getPropKey(section, prop, prefix));
       // A `$global` read alone never serializes (the client reads the
-      // globals object, as without persisted pages); it stays provenance.
+      // globals object, as without persisted pages); it stays a source.
       if (!reason.state && !reason.param) return;
     }
     if (prop) {
@@ -105,7 +105,7 @@ export function addSerializeExpr(
 ) {
   if (expr) {
     // Exprs accumulate even once forced: resolving into a `true` reason is
-    // a no-op, and provenance still needs them.
+    // a no-op, and the sources still need them.
     if (prop) {
       const key = getPropKey(section, prop, prefix);
       if (expr === true) {
@@ -309,7 +309,7 @@ export function applySerializeExprs(section: Section) {
   if (propExprs) {
     section.propSerializeExprs = undefined;
     for (const [key, exprs] of propExprs) {
-      addProvenance(section, getProvenanceForExprs(exprs), key);
+      addSources(section, getAllSourcesForExprs(exprs), key);
       const exprReason = getSerializeSourcesForExprs(exprs);
       if (exprReason) {
         const curReason = section.serializeReasons.get(key);
@@ -324,7 +324,7 @@ export function applySerializeExprs(section: Section) {
   const scopeExprs = section.serializeExprs;
   if (scopeExprs) {
     section.serializeExprs = undefined;
-    addProvenance(section, getProvenanceForExprs(scopeExprs));
+    addSources(section, getAllSourcesForExprs(scopeExprs));
     const exprReason = getSerializeSourcesForExprs(scopeExprs);
     if (exprReason) {
       const curReason = section.serializeReason;
@@ -371,58 +371,55 @@ export function finalizeSerializeReason(section: Section) {
     }
   }
 
-  // Prop provenance folds into the scope's, mirroring the reason merge.
-  const propProvenance = section.propSerializeProvenance;
-  if (propProvenance) {
-    for (const provenance of propProvenance.values()) {
-      addProvenance(section, provenance);
+  // Prop sources fold into the scope's, mirroring the reason merge.
+  const propSources = section.propSerializeSources;
+  if (propSources) {
+    for (const sources of propSources.values()) {
+      addSources(section, sources);
     }
   }
 }
 
-// Records provenance without touching the reason: for feeds that inform
+// Records sources without touching the reason: for upstreams that inform
 // ownership but must never cause serialization (function-body reads).
-export function addSerializeProvenance(
+export function addSerializeSources(
   section: Section,
   sources: Sources | undefined,
   prop?: Binding | AccessorProp | symbol,
   prefix?: AccessorPrefix | symbol,
 ) {
-  addProvenance(section, sources, prop && getPropKey(section, prop, prefix));
+  addSources(section, sources, prop && getPropKey(section, prop, prefix));
 }
 
-// What feeds a serialization decision, complete after reference finalize;
+// The sources of a serialization decision, complete after reference finalize;
 // EMPTY under a forced reason means unrecorded, never "sourceless".
-export function getSerializeProvenance(
+export function getSerializeSources(
   section: Section,
   prop?: Binding | AccessorProp | symbol,
   prefix?: AccessorPrefix | symbol,
 ): Sources | undefined {
   return prop
-    ? section.propSerializeProvenance?.get(getPropKey(section, prop, prefix))
-    : section.serializeProvenance;
+    ? section.propSerializeSources?.get(getPropKey(section, prop, prefix))
+    : section.serializeSources;
 }
 
-function addProvenance(
+function addSources(
   section: Section,
   sources: Sources | undefined,
   key?: SerializeKey,
 ) {
   if (!sources) return;
   if (key) {
-    const provenance = (section.propSerializeProvenance ??= new Map());
-    provenance.set(key, mergeSources(provenance.get(key), sources)!);
+    const propSources = (section.propSerializeSources ??= new Map());
+    propSources.set(key, mergeSources(propSources.get(key), sources)!);
   } else {
-    section.serializeProvenance = mergeSources(
-      section.serializeProvenance,
-      sources,
-    )!;
+    section.serializeSources = mergeSources(section.serializeSources, sources)!;
   }
 }
 
-// Unlike the reason resolution, provenance counts reads inside function
+// Unlike the reason resolution, these sources count reads inside function
 // values: a consumer may invoke them at render time.
-function getProvenanceForExprs(exprs: Opt<t.NodeExtra>) {
+export function getAllSourcesForExprs(exprs: Opt<t.NodeExtra>) {
   let sources: Sources | undefined;
   forEach(exprs, (expr) => {
     sources = mergeSources(sources, getSerializeSourcesForExpr(expr));

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -19,7 +19,7 @@ import { getSectionMeta, trimTrailingExits } from "./structure";
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
     /** Patchable shell records by id: the branch (or await body) section
-     * whose structure the html output serializes as a frame record. */
+     * whose structure the html output serializes as a shell record. */
     shellRecords?: Record<string, Section>;
   }
 }
@@ -29,7 +29,7 @@ export function getShellRecords() {
 }
 
 // Decides every branch shell (expressibility, blockers) so the html output
-// serializes the kept sections as frame records.
+// serializes the kept sections as shell records.
 export function buildShells() {
   const interactive = getProgram().node.extra.isInteractive;
   const keep = new Set<Section>();
@@ -102,7 +102,7 @@ export function buildShells() {
   });
   forEachSection((section) => {
     // Every branch-path body ships a shell, except
-    // stateful bodies: they never construct from a frame.
+    // stateful bodies: they never construct from a flush.
     if (
       !section.isBranch ||
       !isBranchPathSection(section) ||
@@ -226,7 +226,7 @@ function getStaticShell(section: Section) {
   return [writes.value, walkLiteral?.value ?? ""] as const;
 }
 
-// The frame record `id marker;walks;template` (`,` for `;walks;` when the
+// The shell record `id marker;walks;template` (`,` for `;walks;` when the
 // walk is empty): the section's dom template parts, child imports included.
 export function buildShellRecord(id: string, section: Section, marker = "") {
   const { writes, walks } = getSectionMeta(section);

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -25,16 +25,16 @@ import {
   toArray,
 } from "./optional";
 import {
-  getDeliveryRoot,
+  getFillRoot,
   getFillConditions,
-  getLocalFillFeeds,
+  getLocalFillUpstreams,
   getPatchFillBindings,
   getPatchFillKey,
   hasUnfillablePatchReads,
   hasPatchEffectReads,
   isPatchWriteBinding,
   isPatchFillBinding,
-} from "./persisted/delivery";
+} from "./persisted/refresh";
 import {
   inResumedStructure,
   getParamUpstreamChain,
@@ -125,7 +125,7 @@ export interface Signal {
    * synchronous `_return` may reach before the registering tag's own setup. */
   prepare: t.Statement[];
   render: t.Statement[];
-  /** Renders of holes a persisted frame writes itself: a client render
+  /** Renders of holes a persisted flush writes itself: a client render
    * needs them, a fill (refreshing a paired scope) does not. */
   patched: t.Statement[];
   /** The fill-driven run of a declaration that has `patched` renders. */
@@ -487,7 +487,7 @@ export function getSignal(
 
 // A dynamic content record elides the chain's dom renderers, and with them
 // the `_closure_get` pending registration the replay script would look up.
-function inRecordDeliveredChain(section: Section) {
+function inShellRecordChain(section: Section) {
   for (let cur: Section | undefined = section; cur; cur = cur.parent) {
     if (cur.contentRecord === true) return true;
   }
@@ -579,7 +579,7 @@ function hasResumedRead(binding: Binding, section: Section) {
 }
 
 // The `$global` keys a signal joins; none when a server value the client
-// never receives also feeds it (server-computed: fills and writes deliver).
+// never receives is also upstream (server-computed: a patch fills it).
 function getGlobalJoinKeys(signal: Signal) {
   const keys: string[] = [];
   if (!hasUnfillablePatchReads(signal.referencedBindings)) {
@@ -641,7 +641,7 @@ export function initValue(binding: Binding, isLet = false) {
         : "_let"
       : "_const";
     // A fill binding's own declaration doubles as its fill registration
-    // (even a pure forwarder); renders the frame writes itself stay out.
+    // (even a pure forwarder); renders the flush writes itself stay out.
     if (fills) {
       const call = callRuntime(
         `_fill${helper}`,
@@ -652,7 +652,7 @@ export function initValue(binding: Binding, isLet = false) {
       );
       // Its consumer is a child's state join, retained without this
       // declaration: the registration must survive on its own.
-      if (binding.feedsStateMixedGroup) t.removeComments(call);
+      if (binding.upstreamOfStateMixedGroup) t.removeComments(call);
       return call;
     }
     if (
@@ -969,7 +969,7 @@ export function getSignalFn(signal: Signal): t.Expression {
   let render = signal.prepare.length
     ? signal.prepare.concat(signal.render)
     : signal.render;
-  // A fill's run is the render without the frame's own writes.
+  // A fill's run is the render without the flush's own writes.
   if (signal.patched.length) {
     if (isValue && isPatchFillBinding(binding)) {
       signal.fillFn = t.cloneNode(toScopeFn(render), true);
@@ -1284,7 +1284,7 @@ export function writeSignals(section: Section) {
                 "_fill_join";
               let hopExprs: t.Expression[] = [];
               if (member.section !== signal.section) {
-                // A chain that leaves the branch ladder delivers through the
+                // A chain that leaves the branch ladder refreshes through the
                 // member's own closure signal (`_fill_join_closure`) instead.
                 if (!isBranchSectionChain(signal.section, member.section)) {
                   if (inStatefulBranch(signal.section)) {
@@ -1377,10 +1377,10 @@ export function writeSignals(section: Section) {
           // subscriber set, so its chain shape does not matter.
           (isBranchChainTo(signal.section, signal.referencedBindings.section) ||
             isDynamicClosure(signal.section, signal.referencedBindings)) &&
-          hasFillDeliveredRead(signal.referencedBindings, signal.section)
+          hasFilledRead(signal.referencedBindings, signal.section)
         ) {
           // Inside unpatched structure a lone closure over a server
-          // fill IS the delivery channel: it registers the join itself.
+          // fill IS the refresh channel: it registers the join itself.
           value =
             !getClosureSignal(signal.section) ||
             isDynamicClosure(signal.section, signal.referencedBindings)
@@ -1502,7 +1502,7 @@ function inBoundaryContent(section: Section | undefined) {
 
 // A lone read, or an intersection member whose chain leaves the branch
 // ladder, renders through the closure itself (over-counting is safe).
-function hasFillDeliveredRead(binding: Binding, section: Section): boolean {
+function hasFilledRead(binding: Binding, section: Section): boolean {
   for (const read of binding.reads) {
     // A script (not a handler) inside the section re-runs from the closure.
     if (
@@ -1521,7 +1521,7 @@ function hasFillDeliveredRead(binding: Binding, section: Section): boolean {
   for (const alias of binding.aliases) {
     if (
       getCanonicalBinding(alias) === binding &&
-      hasFillDeliveredRead(alias, section)
+      hasFilledRead(alias, section)
     ) {
       return true;
     }
@@ -1699,11 +1699,12 @@ function toSequenceExpression(exprs: t.Expression[]) {
 }
 
 // A closure into a body that ships a shell whose init a construct may run:
-// state (named by the shell record) or a local fill's feed (by the frame).
+// state (named by the shell record) or a local fill's upstream (by the flush).
 function constructsWithInit(section: Section, closure: Binding) {
   return (
     sectionConstructs(section) &&
-    (!!closure.sources?.state || includes(getLocalFillFeeds(section), closure))
+    (!!closure.sources?.state ||
+      includes(getLocalFillUpstreams(section), closure))
   );
 }
 
@@ -1731,9 +1732,10 @@ export function writeLocalFill(section: Section, binding: Binding) {
   const owned = getFilledGuard(getSerializeSourcesForRef(binding));
   if (!owned) return write;
   let initIds = "";
-  forEach(binding.sources?.param, (feed) => {
-    if (feed.section !== section) {
-      initIds += (initIds && " ") + getResumeRegisterId(section, feed, "init");
+  forEach(binding.sources?.param, (upstream) => {
+    if (upstream.section !== section) {
+      initIds +=
+        (initIds && " ") + getResumeRegisterId(section, upstream, "init");
     }
   });
   return t.conditionalExpression(
@@ -1765,8 +1767,8 @@ export function writeLocalWrite(section: Section, binding: Binding) {
 // (`translateVar`), so the section's leading writes cover only the rest.
 const writtenLocalFills = new WeakSet<Binding>();
 
-// A spread's effect re-attaches what its serialized set carried: the frame's
-// attribute set is the delivery, so its reads need no other channel.
+// A spread's effect re-attaches what its serialized set carried: the flush's
+// attribute set is the refresh, so its reads need no other channel.
 function isSerializedSpreadEffect(signal: Signal) {
   const refs = signal.referencedBindings;
   return (
@@ -1870,12 +1872,12 @@ export function writeHTMLResumeStatements(
         }
 
         if (underTryPlaceholder(section)) {
-          // A scriptless page or a record-delivered chain never registers
+          // A scriptless page or a shell-record chain never registers
           // the pending replay, so the envelope must not reference it.
           const reason =
             isPersisted() &&
             (!getProgram().node.extra.isInteractive ||
-              inRecordDeliveredChain(section))
+              inShellRecordChain(section))
               ? undefined
               : getSerializeReason(section);
           if (reason) {
@@ -2115,7 +2117,7 @@ export function writeHTMLResumeStatements(
       if (signal.hasHTMLEffect) {
         const byHops: string[][] = [];
         forEach(signal.referencedBindings, (binding) => {
-          const root = getDeliveryRoot(binding);
+          const root = getFillRoot(binding);
           if (isPatchWriteBinding(root) && hasPatchEffectReads(root)) {
             (byHops[section.depth - root.section.depth] ??= []).push(
               getScopeAccessor(root),

--- a/packages/runtime-tags/src/translator/util/structure.ts
+++ b/packages/runtime-tags/src/translator/util/structure.ts
@@ -160,7 +160,7 @@ export function resolveStructure(section: Section) {
           }
           break;
         case StructureKind.Child: {
-          // A lazy site composes its child only when a frame constructs it.
+          // A lazy site composes its child only when a flush constructs it.
           const composed = html && op.load?.serverOnly;
           const renderer = op.load && !composed ? undefined : op.renderer;
           if (composed) {

--- a/packages/runtime-tags/src/translator/util/translate-var.ts
+++ b/packages/runtime-tags/src/translator/util/translate-var.ts
@@ -5,7 +5,7 @@ import { generateUidIdentifier } from "./generate-uid";
 import { getDeclaredBindingExpression } from "./get-declared-binding-expression";
 import { isPersisted } from "./marko-config";
 import { toArray } from "./optional";
-import { isPatchFillBinding, isPatchWriteBinding } from "./persisted/delivery";
+import { isPatchFillBinding, isPatchWriteBinding } from "./persisted/refresh";
 import { getCanonicalBinding } from "./references";
 import { getOrCreateSection } from "./sections";
 import { getSerializeReason } from "./serialize-reasons";

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -186,10 +186,10 @@ export default {
             node.attributes = undefined;
             return;
           } else {
-            // A persisted page's frames may carry data for this module before
+            // A persisted page's flushes may carry data for this module before
             // it loads; the feature defers them until its `ready()` call.
             if (isPersisted()) {
-              // A frame's ready batch may bind handlers before the child's
+              // A flush's ready batch may bind handlers before the child's
               // own feature loads, so the page carries the bind feature.
               importRuntimeFeature("patch-ready");
               importRuntimeFeature("patch-value-bind");
@@ -200,8 +200,8 @@ export default {
               file,
               loadFile.opts.filename,
             );
-            // Frames name a server-only template; the page registers its
-            // loader only, for the registrations its frames need.
+            // Flushes name a server-only template; the page registers its
+            // loader only, for the registrations its flushes need.
             if (loadImport.serverOnly) {
               importDecl.replaceWith(
                 t.expressionStatement(
@@ -260,7 +260,7 @@ export default {
                 t.variableDeclaration("const", [
                   t.variableDeclarator(
                     local,
-                    // A frame's data for a site this template constructs
+                    // A flush's data for a site this template constructs
                     // waits for its clone; the wrapper reports the start.
                     isPersisted()
                       ? callRuntime(

--- a/packages/runtime-tags/src/translator/visitors/placeholder.ts
+++ b/packages/runtime-tags/src/translator/visitors/placeholder.ts
@@ -185,8 +185,8 @@ function translateExit(placeholder: t.NodePath<t.MarkoPlaceholder>) {
       isPersisted() && isBranchPathSection(section)
         ? getSerializeSourcesForExpr(valueExtra)
         : undefined;
-    // A state-fed hole recomputes through the signal graph, and inside
-    // client-owned structure delivery is owner fills: neither patch-writes.
+    // A state-sourced hole recomputes through the signal graph, and inside
+    // unpatched structure owner fills refresh it: neither patch-writes.
     const isPatch =
       isPersisted() &&
       isBranchPathSection(section) &&

--- a/packages/runtime-tags/src/translator/visitors/program/dom.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/dom.ts
@@ -12,7 +12,7 @@ import {
   hasPatchEffectReads,
   isPatchWriteBinding,
   isPatchFillBinding,
-} from "../../util/persisted/delivery";
+} from "../../util/persisted/refresh";
 import {
   type Binding,
   BindingType,
@@ -178,7 +178,7 @@ export default {
         }
       });
 
-      // Patches deliver server contributions to registered fill signals, so
+      // Patches write server contributions to registered fill signals, so
       // a template with fills in any section ships the patcher.
       let boundFills = false;
       forEachSection((fillSection) => {
@@ -202,7 +202,7 @@ export default {
         }
       });
       // Only function-carrying fills need the bind patchers; an unshipped patcher
-      // rejects the frame into navigation, never a broken bind.
+      // rejects the flush into navigation, never a broken bind.
       if (boundFills) {
         importRuntimeFeature("patch-value-bind");
       }

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -12,14 +12,14 @@ import { getMarkoOpts, isPersisted } from "../../util/marko-config";
 import { writeModuleRegistrations } from "../../util/module-registrations";
 import { forEach, some } from "../../util/optional";
 import {
-  getConstructInitClosures,
-  getPatchFillBindings,
-  isPatchFillBinding,
-} from "../../util/persisted/delivery";
-import {
   getPersistedIntrinsics,
   scopeReasonRuntime,
 } from "../../util/persisted/intrinsics";
+import {
+  getConstructInitClosures,
+  getPatchFillBindings,
+  isPatchFillBinding,
+} from "../../util/persisted/refresh";
 import {
   BindingType,
   getReadReplacement,

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -211,8 +211,8 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
   const isLoad = !!loadConfig;
   const tagName = getStaticTagName(node);
 
-  // A server-only site has no client render: a frame's shell builds it
-  // and its setup entries feed it.
+  // A server-only site has no client render: a flush's shell builds it
+  // and its setup entries seed it.
   if (loadConfig?.serverOnly) {
     importRuntimeFeature("patch-child");
     tag.remove();
@@ -304,7 +304,7 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
             : setupLoadExpr,
         );
         // A construct's client-side load drives the child's ready channel
-        // (stamped on its branch), so deferred frame data drains after insert.
+        // (stamped on its branch), so deferred flush data drains after insert.
         if (isPersisted() && getReadyId(childFile) !== undefined) {
           loadSetupCall = callRuntime(
             "_load_ready",
@@ -318,7 +318,7 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
             t.variableDeclarator(
               setupIdent,
               // A constructing branch runs the site's load wiring as a shell
-              // init; `_resume` (impure) survives tree-shaking to deliver it.
+              // init; `_resume` (impure) survives tree-shaking to carry it.
               isPersisted() && sectionConstructs(section)
                 ? callRuntime(
                     "_resume",

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -213,8 +213,8 @@ export default {
 
       if (hasVar) {
         const varBinding = trackVarReferences(tag, BindingType.derived)!;
-        // A frame writes the variable from what the tag renders: its inputs
-        // are its provenance (a client render drives it through `_var`).
+        // A flush writes the variable from what the tag renders: its inputs
+        // are its sources (a client render drives it through `_var`).
         if (isPersisted()) setBindingValueExprs(varBinding, tagExtra);
         tag.node.var!.extra!.binding!.scopeOffset = tagExtra[
           kChildOffsetScopeBinding
@@ -223,7 +223,7 @@ export default {
 
       const bodySection = startSection(tagBody);
       trackParamsReferences(tagBody, BindingType.param);
-      // Split so the force cannot swallow the exprs' provenance.
+      // Split so the force cannot swallow the exprs' sources.
       if (hasVar) addSerializeExpr(tagSection, true, nodeBinding);
       addSerializeExpr(tagSection, tagExtra, nodeBinding);
 
@@ -499,8 +499,8 @@ export default {
         // `2` skips: a client-owned group upstream); the render takes it.
         let patchPairingArg: t.Expression | undefined;
         if (writesPatchDynamicTag(tag, tagSection)) {
-          // The site's renderer and input evaluate once: hoisted, they feed
-          // the render and the entry alike.
+          // The site's renderer and input evaluate once: hoisted, both the
+          // render and the entry read them.
           if (!t.isIdentifier(tagExpression)) {
             const tagId = generateUidIdentifier("tag");
             statements.push(

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -41,7 +41,7 @@ import {
 } from "../../util/marko-config";
 import normalizeStringExpression from "../../util/normalize-string-expression";
 import { includes, type Opt, push } from "../../util/optional";
-import { hasStateFeed } from "../../util/persisted/decisions";
+import { hasStateSource } from "../../util/persisted/decisions";
 import {
   ensurePersistedWriteGroups,
   inStatefulBranch,
@@ -604,7 +604,7 @@ export default {
               );
             }
           } else if (spreadExpression) {
-            // A lone spread is unambiguous provenance; with several, a merged
+            // A lone spread is an unambiguous source; with several, a merged
             // property could come from any, so the serializer's generic
             // phrasing (plus the runtime-read property name) stays honest.
             const spreads = tag.node.attributes.filter((attr) =>
@@ -979,7 +979,7 @@ export default {
             isPersisted() &&
             isBranchPathSection(tagSection) &&
             !inStatefulBranch(tagSection) &&
-            !hasStateFeed(staticContentAttr.value.extra);
+            !hasStateSource(staticContentAttr.value.extra);
           let content: t.Expression = staticContentAttr.value;
           if (patched) {
             if (!t.isIdentifier(content)) {
@@ -1532,8 +1532,8 @@ function getSpreadControllableValueProps(tagName: string) {
 }
 
 type RelatedControllable = ReturnType<typeof getRelatedControllable>;
-// A state-fed attribute recomputes client-side, and inside client-owned
-// structure delivery is owner fills: neither patch-writes.
+// A state-sourced attribute recomputes client-side, and inside unpatched
+// structure owner fills refresh it: neither patch-writes.
 export function writesPatchAttr(
   tagSection: Section,
   extra: t.NodeExtra | undefined,


### PR DESCRIPTION
A naming pass over persisted pages so each concept has one word, with no behaviour change (bundles and wire are byte-identical apart from the shell list members below).

- **flush**: a patch's applied unit was a "frame" while a normal render calls the same thing a flush. Renamed everywhere (`flushBinds`, `flushVars`, `BIND_FLUSH_VAR`, `newFlushReference`, the test harness's `betweenFlushes`). `shellFrames` was really the per-response shell chunk buffer and is `pendingShells`; "frame records" are shell records. Shell list members no longer carry a leading comma that both consumers sliced off.
- **sources / upstream**: "feed" and "provenance" both meant `Sources` or the upstream relation. `hasStateSource`, `hasParamSource`, `getParamGroupSources`, `upstreamOfStateMixedGroup`, `getLocalFillUpstreams`, `upstreamSourcesFill`, `readAsTagNameLoadInput`, `serializeSources` / `getSerializeSources` / `addSerializeSources`, and `getAllSourcesForExprs` (now exported, replacing an inline copy in `finalizeKnownTags`).
- **fills**: "deliver" meant a patch filling or writing a value. `patchFills`, `getFillRoot`, `paramsFill`, `hasFilledRead`, `inShellRecordChain`, `writeFilled` beside `_filled_guard`; the module `persisted/delivery` is `persisted/refresh`. "Owned" stays only where it means the ownership mask.
- CONTEXT.md defines flush, upstream, and param group sources, and lists frame, feed, provenance, and deliver under Avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)