### PR TITLE
Persisted: a constructed scope's setup applies as it is met

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/sizes.json
@@ -10,8 +10,8 @@
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 3107,
-        "brotli": 1498
+        "min": 3069,
+        "brotli": 1475
       },
       "files": {
         "layout.marko": 261,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain/sizes.json
@@ -10,8 +10,8 @@
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 3107,
-        "brotli": 1502
+        "min": 3069,
+        "brotli": 1469
       },
       "files": {
         "layout.marko": 261,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-mount/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-mount/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11521,
-        "brotli": 4863
+        "min": 11482,
+        "brotli": 4837
       },
       "files": {
         "tags/counter.marko": 372,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11348,
-      "brotli": 4802
+      "min": 11309,
+      "brotli": 4774
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9299,
-      "brotli": 4019
+      "min": 9260,
+      "brotli": 3994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9299,
-      "brotli": 4019
+      "min": 9260,
+      "brotli": 3994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10830,
-      "brotli": 4639
+      "min": 10791,
+      "brotli": 4614
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11632,
-      "brotli": 5037
+      "min": 11593,
+      "brotli": 5075
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-inexpressible-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-inexpressible-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9771,
-      "brotli": 4194
+      "min": 9732,
+      "brotli": 4171
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12556,
-      "brotli": 5306
+      "min": 12517,
+      "brotli": 5281
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10546,
-      "brotli": 4540
+      "min": 10507,
+      "brotli": 4521
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10379,
-      "brotli": 4443
+      "min": 10340,
+      "brotli": 4421
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8835,
-      "brotli": 3852
+      "min": 8796,
+      "brotli": 3834
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8835,
-      "brotli": 3852
+      "min": 8796,
+      "brotli": 3834
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10366,
-      "brotli": 4475
+      "min": 10327,
+      "brotli": 4451
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11599,
-      "brotli": 4926
+      "min": 11560,
+      "brotli": 4905
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11705,
-      "brotli": 4965
+      "min": 11666,
+      "brotli": 4941
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9570,
-      "brotli": 4136
+      "min": 9531,
+      "brotli": 4118
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9570,
-      "brotli": 4136
+      "min": 9531,
+      "brotli": 4118
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11559,
-      "brotli": 4907
+      "min": 11520,
+      "brotli": 4890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10265,
-        "brotli": 4401
+        "min": 10226,
+        "brotli": 4381
       },
       "files": {
         "child.marko": 200,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-in-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-in-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10120,
-      "brotli": 4342
+      "min": 10081,
+      "brotli": 4323
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4182
+      "min": 9617,
+      "brotli": 4158
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-in-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13936,
-      "brotli": 5785
+      "min": 13897,
+      "brotli": 5763
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10529,
-      "brotli": 4529
+      "min": 10490,
+      "brotli": 4506
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-script-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-script-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9858,
-      "brotli": 4254
+      "min": 9819,
+      "brotli": 4233
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-settled-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-settled-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9299,
-      "brotli": 4019
+      "min": 9260,
+      "brotli": 3994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-content-owner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-content-owner/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12784,
-        "brotli": 5376
+        "min": 12745,
+        "brotli": 5362
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-dynamic-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9152,
-        "brotli": 3986
+        "min": 9113,
+        "brotli": 3956
       },
       "files": {
         "tags/child.marko": 523,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8770,
-        "brotli": 3856
+        "min": 8731,
+        "brotli": 3833
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-hoisted-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-hoisted-in-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12698,
-        "brotli": 5325
+        "min": 12659,
+        "brotli": 5303
       },
       "files": {
         "tags/store.marko": 218,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-loop-sibling/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-loop-sibling/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11074,
-        "brotli": 4897
+        "min": 11035,
+        "brotli": 4840
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-nested-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-nested-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12788,
-        "brotli": 5379
+        "min": 12749,
+        "brotli": 5360
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12267,
-      "brotli": 5115
+      "min": 12228,
+      "brotli": 5088
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-through-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-through-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9152,
-        "brotli": 3997
+        "min": 9113,
+        "brotli": 3965
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9299,
-      "brotli": 4013
+      "min": 9260,
+      "brotli": 3989
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7067,
-      "brotli": 3188
+      "min": 7029,
+      "brotli": 3168
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9523,
-      "brotli": 4098
+      "min": 9484,
+      "brotli": 4068
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6888,
-      "brotli": 3128
+      "min": 6850,
+      "brotli": 3106
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-nested/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9029,
-        "brotli": 3987
+        "min": 8990,
+        "brotli": 3971
       },
       "files": {
         "tags/badge.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-siblings/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6854,
-      "brotli": 3119
+      "min": 6816,
+      "brotli": 3096
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8207,
-      "brotli": 3631
+      "min": 8168,
+      "brotli": 3614
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7692,
-      "brotli": 3465
+      "min": 7654,
+      "brotli": 3452
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8489,
-        "brotli": 3765
+        "min": 8450,
+        "brotli": 3745
       },
       "files": {
         "tags/box.marko": 73,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-inner/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9300,
-      "brotli": 4091
+      "min": 9261,
+      "brotli": 4071
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-loop-outer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-loop-outer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10410,
-      "brotli": 4606
+      "min": 10371,
+      "brotli": 4581
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8146,
-      "brotli": 3656
+      "min": 8108,
+      "brotli": 3632
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7880,
-      "brotli": 3522
+      "min": 7842,
+      "brotli": 3501
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8290,
-      "brotli": 3656
+      "min": 8251,
+      "brotli": 3636
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7775,
-      "brotli": 3494
+      "min": 7737,
+      "brotli": 3470
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8591,
-      "brotli": 3813
+      "min": 8552,
+      "brotli": 3776
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7795,
-      "brotli": 3494
+      "min": 7757,
+      "brotli": 3484
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-derived-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-derived-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7924,
-      "brotli": 3549
+      "min": 7886,
+      "brotli": 3527
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-fill-local-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-fill-local-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8752,
-      "brotli": 3837
+      "min": 8713,
+      "brotli": 3812
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7147,
-      "brotli": 3231
+      "min": 7109,
+      "brotli": 3214
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-global-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-global-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10075,
-      "brotli": 4469
+      "min": 10036,
+      "brotli": 4467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7385,
-      "brotli": 3332
+      "min": 7347,
+      "brotli": 3316
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8805,
-      "brotli": 3861
+      "min": 8766,
+      "brotli": 3835
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9074,
-      "brotli": 3999
+      "min": 9035,
+      "brotli": 3976
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8574,
-      "brotli": 3786
+      "min": 8535,
+      "brotli": 3767
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8318,
-      "brotli": 3669
+      "min": 8279,
+      "brotli": 3646
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8308,
-      "brotli": 3664
+      "min": 8269,
+      "brotli": 3645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8310,
-      "brotli": 3666
+      "min": 8271,
+      "brotli": 3646
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-sibling/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-sibling/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9000,
-        "brotli": 3940
+        "min": 8961,
+        "brotli": 3915
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8337,
-      "brotli": 3683
+      "min": 8298,
+      "brotli": 3666
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8444,
-      "brotli": 3712
+      "min": 8405,
+      "brotli": 3697
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8197,
-      "brotli": 3615
+      "min": 8158,
+      "brotli": 3588
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6792,
-      "brotli": 3095
+      "min": 6754,
+      "brotli": 3071
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8110,
-      "brotli": 3603
+      "min": 8072,
+      "brotli": 3579
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7148,
-      "brotli": 3242
+      "min": 7110,
+      "brotli": 3224
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7140,
-      "brotli": 3238
+      "min": 7102,
+      "brotli": 3217
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7407,
-      "brotli": 3347
+      "min": 7369,
+      "brotli": 3321
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-param-const-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-param-const-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8444,
-      "brotli": 3739
+      "min": 8405,
+      "brotli": 3722
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-recursive-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-recursive-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8635,
-      "brotli": 3918
+      "min": 8596,
+      "brotli": 3887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6912,
-      "brotli": 3145
+      "min": 6874,
+      "brotli": 3130
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7626,
-      "brotli": 3429
+      "min": 7588,
+      "brotli": 3402
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7140,
-      "brotli": 3239
+      "min": 7102,
+      "brotli": 3216
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7834,
-      "brotli": 3521
+      "min": 7796,
+      "brotli": 3497
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7737,
-      "brotli": 3487
+      "min": 7699,
+      "brotli": 3457
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6972,
-      "brotli": 3167
+      "min": 6934,
+      "brotli": 3142
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7800,
-      "brotli": 3504
+      "min": 7762,
+      "brotli": 3482
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-static-const-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-static-const-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8439,
-      "brotli": 3733
+      "min": 8400,
+      "brotli": 3717
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-unassigned-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-unassigned-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7764,
-      "brotli": 3484
+      "min": 7726,
+      "brotli": 3467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7596,
-      "brotli": 3427
+      "min": 7558,
+      "brotli": 3406
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-structure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11745,
-      "brotli": 4989
+      "min": 11706,
+      "brotli": 4970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11745,
-      "brotli": 4989
+      "min": 11706,
+      "brotli": 4970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-arg-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-arg-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8071,
-        "brotli": 3664
+        "min": 8032,
+        "brotli": 3643
       },
       "files": {
         "tags/struct/index.marko": 300,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8061,
-        "brotli": 3662
+        "min": 8022,
+        "brotli": 3640
       },
       "files": {
         "helper.ts": 61,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8631,
-        "brotli": 3890
+        "min": 8592,
+        "brotli": 3876
       },
       "files": {
         "tags/tabs/index.marko": 487,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-branch-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-branch-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7402,
-      "brotli": 3304
+      "min": 7364,
+      "brotli": 3277
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7692,
-      "brotli": 3458
+      "min": 7654,
+      "brotli": 3450
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7692,
-      "brotli": 3458
+      "min": 7654,
+      "brotli": 3450
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-attr-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-attr-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12154,
-        "brotli": 5203
+        "min": 12115,
+        "brotli": 5180
       },
       "files": {
         "tags/panel/index.marko": 180,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12273,
-        "brotli": 5222
+        "min": 12234,
+        "brotli": 5193
       },
       "files": {
         "tags/card/index.marko": 173,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-in-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-in-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11874,
-      "brotli": 5022
+      "min": 11835,
+      "brotli": 5003
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-open/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12175,
-        "brotli": 5188
+        "min": 12136,
+        "brotli": 5164
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-structure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12252,
-        "brotli": 5213
+        "min": 12213,
+        "brotli": 5193
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12175,
-        "brotli": 5188
+        "min": 12136,
+        "brotli": 5164
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10166,
-        "brotli": 4496
+        "min": 10127,
+        "brotli": 4454
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8413,
-        "brotli": 3707
+        "min": 8374,
+        "brotli": 3685
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10285,
-        "brotli": 4543
+        "min": 10246,
+        "brotli": 4524
       },
       "files": {
         "tags/counter/index.marko": 309,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8470,
-        "brotli": 3722
+        "min": 8431,
+        "brotli": 3708
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8432,
-        "brotli": 3713
+        "min": 8393,
+        "brotli": 3689
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8413,
-        "brotli": 3707
+        "min": 8374,
+        "brotli": 3685
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12788,
-        "brotli": 5414
+        "min": 12749,
+        "brotli": 5391
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-import-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-import-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8913,
-        "brotli": 3950
+        "min": 8874,
+        "brotli": 3930
       },
       "files": {
         "tags/badge/index.marko": 310,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-input-object-method-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-input-object-method-global/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7621,
-        "brotli": 3441
+        "min": 7583,
+        "brotli": 3420
       },
       "files": {
         "tags/code-block.marko": 231,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8975,
-        "brotli": 3932
+        "min": 8936,
+        "brotli": 3910
       },
       "files": {
         "tags/child.marko": 831,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural-attr/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8063,
-        "brotli": 3656
+        "min": 8024,
+        "brotli": 3638
       },
       "files": {
         "tags/tabs2/index.marko": 318,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8041,
-        "brotli": 3645
+        "min": 8002,
+        "brotli": 3624
       },
       "files": {
         "tags/tabs/index.marko": 237,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-server-required/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-server-required/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8739,
-        "brotli": 3881
+        "min": 8700,
+        "brotli": 3860
       },
       "files": {
         "tags/widget/index.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-slot-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-slot-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10891,
-      "brotli": 4665
+      "min": 10852,
+      "brotli": 4640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8301,
-        "brotli": 3667
+        "min": 8262,
+        "brotli": 3647
       },
       "files": {
         "tags/card.marko": 263,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-loop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9794,
-        "brotli": 4356
+        "min": 9755,
+        "brotli": 4336
       },
       "files": {
         "tags/list/index.marko": 675,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-spread-feed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-spread-feed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8818,
-        "brotli": 3962
+        "min": 8779,
+        "brotli": 3939
       },
       "files": {
         "tags/tabs/index.marko": 487,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-fill/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9042,
-        "brotli": 3979
+        "min": 9003,
+        "brotli": 3963
       },
       "files": {
         "tags/toggle-panel/index.marko": 437,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-nested/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9802,
-        "brotli": 4287
+        "min": 9763,
+        "brotli": 4261
       },
       "files": {
         "tags/panel/index.marko": 803,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8385,
-        "brotli": 3756
+        "min": 8346,
+        "brotli": 3729
       },
       "files": {
         "tags/toggle-panel/index.marko": 179,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-try/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8816,
-        "brotli": 3958
+        "min": 8777,
+        "brotli": 3940
       },
       "files": {
         "tags/widget/index.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9010,
-        "brotli": 3998
+        "min": 8971,
+        "brotli": 3972
       },
       "files": {
         "tags/badge/index.marko": 310,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8684,
-      "brotli": 3817
+      "min": 8645,
+      "brotli": 3801
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-alias-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-alias-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4432
+      "min": 10285,
+      "brotli": 4410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-elided/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-elided/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10407,
-      "brotli": 4459
+      "min": 10368,
+      "brotli": 4439
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-static-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-static-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10290,
-      "brotli": 4429
+      "min": 10251,
+      "brotli": 4411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4613
+      "min": 10752,
+      "brotli": 4591
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4432
+      "min": 10285,
+      "brotli": 4410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13157,
-      "brotli": 5469
+      "min": 13118,
+      "brotli": 5445
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-body-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-body-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11315,
-      "brotli": 4804
+      "min": 11276,
+      "brotli": 4780
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11263,
-      "brotli": 4777
+      "min": 11224,
+      "brotli": 4760
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12396,
-      "brotli": 5356
+      "min": 12357,
+      "brotli": 5306
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12733,
-        "brotli": 5386
+        "min": 12694,
+        "brotli": 5361
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12453,
-        "brotli": 5287
+        "min": 12414,
+        "brotli": 5267
       },
       "files": {
         "tags/card/index.marko": 268,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-closure-mix/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-closure-mix/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11974,
-      "brotli": 5169
+      "min": 11935,
+      "brotli": 5142
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-fill-state-join-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-fill-state-join-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12873,
-      "brotli": 5559
+      "min": 12834,
+      "brotli": 5513
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-for-intersect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-for-intersect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13711,
-        "brotli": 5905
+        "min": 13672,
+        "brotli": 5870
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11089,
-        "brotli": 4746
+        "min": 11050,
+        "brotli": 4724
       },
       "files": {
         "tags/widget/index.marko": 123,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-hole/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-hole/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4432
+      "min": 10285,
+      "brotli": 4410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-inner-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-inner-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect-mixed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12580,
-        "brotli": 5358
+        "min": 12541,
+        "brotli": 5334
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12365,
-        "brotli": 5272
+        "min": 12326,
+        "brotli": 5247
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11974,
-      "brotli": 5169
+      "min": 11935,
+      "brotli": 5142
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12366,
-        "brotli": 5270
+        "min": 12327,
+        "brotli": 5241
       },
       "files": {
         "tags/grand/index.marko": 173,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-renderer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-renderer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-stateful-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-stateful-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12489,
-        "brotli": 5287
+        "min": 12450,
+        "brotli": 5260
       },
       "files": {
         "tags/grand/index.marko": 169,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11324,
-      "brotli": 4835
+      "min": 11285,
+      "brotli": 4814
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4432
+      "min": 10285,
+      "brotli": 4410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-placeholder-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-placeholder-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10042,
-      "brotli": 4323
+      "min": 10003,
+      "brotli": 4295
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-pair/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-pair/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10857,
-      "brotli": 4656
+      "min": 10818,
+      "brotli": 4630
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10857,
-      "brotli": 4656
+      "min": 10818,
+      "brotli": 4630
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread-define-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread-define-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12053,
-      "brotli": 5047
+      "min": 12014,
+      "brotli": 5027
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12390,
-      "brotli": 5207
+      "min": 12351,
+      "brotli": 5181
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11159,
-      "brotli": 4782
+      "min": 11120,
+      "brotli": 4758
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-static-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-static-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4613
+      "min": 10752,
+      "brotli": 4591
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12790,
-        "brotli": 5420
+        "min": 12751,
+        "brotli": 5391
       },
       "files": {
         "tags/widget/index.marko": 160,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-try/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13753,
-      "brotli": 5705
+      "min": 13714,
+      "brotli": 5681
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10752,
+      "brotli": 4592
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4432
+      "min": 10285,
+      "brotli": 4410
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8360,
-      "brotli": 3699
+      "min": 8321,
+      "brotli": 3678
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8898,
-      "brotli": 3926
+      "min": 8859,
+      "brotli": 3922
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-define-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-define-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6888,
-      "brotli": 3133
+      "min": 6850,
+      "brotli": 3111
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-define-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-define-recursive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6888,
-      "brotli": 3133
+      "min": 6850,
+      "brotli": 3111
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-body-hole/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-body-hole/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10911,
-        "brotli": 4676
+        "min": 10872,
+        "brotli": 4649
       },
       "files": {
         "card.marko": 113,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13302,
-      "brotli": 5661
+      "min": 13263,
+      "brotli": 5646
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13040,
-        "brotli": 5507
+        "min": 13001,
+        "brotli": 5479
       },
       "files": {
         "card.marko": 556,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10796,
-      "brotli": 4600
+      "min": 10757,
+      "brotli": 4577
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-client-owned-group/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-client-owned-group/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12760,
-        "brotli": 5385
+        "min": 12721,
+        "brotli": 5358
       },
       "files": {
         "tags/picker/card.marko": 534,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-global-server-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-global-server-owned/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4431
+      "min": 10285,
+      "brotli": 4416
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-loop-if-in-unpaired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-loop-if-in-unpaired/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13168,
-        "brotli": 5651
+        "min": 13129,
+        "brotli": 5629
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-native-in-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-native-in-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12524,
-        "brotli": 5317
+        "min": 12485,
+        "brotli": 5289
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-nested-body-in-unpaired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-nested-body-in-unpaired/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11353,
-        "brotli": 4881
+        "min": 11314,
+        "brotli": 4859
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-renderer-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-renderer-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10891,
-      "brotli": 4666
+      "min": 10852,
+      "brotli": 4642
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10324,
-      "brotli": 4431
+      "min": 10285,
+      "brotli": 4416
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-server-outer-state-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-server-outer-state-inner/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11629,
-        "brotli": 4982
+        "min": 11590,
+        "brotli": 4959
       },
       "files": {
         "box.marko": 242,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-swap-effects/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-swap-effects/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11407,
-      "brotli": 4847
+      "min": 11368,
+      "brotli": 4820
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10883,
-      "brotli": 4636
+      "min": 10844,
+      "brotli": 4610
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-native-body-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-native-body-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10796,
-      "brotli": 4600
+      "min": 10757,
+      "brotli": 4577
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11682,
-        "brotli": 4943
+        "min": 11643,
+        "brotli": 4917
       },
       "files": {
         "counter.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-falsy/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-falsy/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11722,
-      "brotli": 4990
+      "min": 11683,
+      "brotli": 4963
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10989,
-      "brotli": 4672
+      "min": 10950,
+      "brotli": 4645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9073,
-      "brotli": 3999
+      "min": 9034,
+      "brotli": 3975
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12072,
-      "brotli": 5134
+      "min": 12033,
+      "brotli": 5105
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 16571,
-      "brotli": 6760
+      "min": 16532,
+      "brotli": 6738
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-in-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-in-stateful/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12515,
-        "brotli": 5344
+        "min": 12476,
+        "brotli": 5316
       },
       "files": {
         "tags/wrap/index.marko": 150,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-section/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-section/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12155,
-      "brotli": 5164
+      "min": 12116,
+      "brotli": 5129
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-subscribers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-subscribers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12306,
-      "brotli": 5199
+      "min": 12267,
+      "brotli": 5170
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10906,
-      "brotli": 4801
+      "min": 10867,
+      "brotli": 4810
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10248,
-      "brotli": 4549
+      "min": 10209,
+      "brotli": 4505
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10248,
-      "brotli": 4549
+      "min": 10209,
+      "brotli": 4505
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9107,
-      "brotli": 4035
+      "min": 9068,
+      "brotli": 3984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10283,
-      "brotli": 4546
+      "min": 10244,
+      "brotli": 4534
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-for-in-until/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-for-in-until/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9629,
-      "brotli": 4289
+      "min": 9590,
+      "brotli": 4273
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-for-rest-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-for-rest-params/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12261,
-      "brotli": 5273
+      "min": 12222,
+      "brotli": 5270
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6888,
-      "brotli": 3133
+      "min": 6850,
+      "brotli": 3111
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8677,
-      "brotli": 3925
+      "min": 8638,
+      "brotli": 3903
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-required/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-required/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8901,
-        "brotli": 3937
+        "min": 8862,
+        "brotli": 3910
       },
       "files": {
         "tags/outer/tags/inner/index.marko": 219,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9097,
-        "brotli": 4026
+        "min": 9058,
+        "brotli": 4002
       },
       "files": {
         "tags/badge/index.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6971,
-      "brotli": 3150
+      "min": 6933,
+      "brotli": 3128
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8539,
-      "brotli": 3911
+      "min": 8500,
+      "brotli": 3862
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-await-frame/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-await-frame/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 1109
     },
     "shared": {
-      "min": 15927,
-      "brotli": 7071
+      "min": 15889,
+      "brotli": 7045
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-in-layout-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-in-layout-body/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 1340
     },
     "shared": {
-      "min": 10608,
-      "brotli": 4720
+      "min": 10570,
+      "brotli": 4696
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-nested-entries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-nested-entries/sizes.json
@@ -25,8 +25,8 @@
       "brotli": 139
     },
     "shared": {
-      "min": 14706,
-      "brotli": 6657
+      "min": 14668,
+      "brotli": 6627
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-route-switch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-route-switch/sizes.json
@@ -17,8 +17,8 @@
       "brotli": 1330
     },
     "shared": {
-      "min": 15371,
-      "brotli": 6868
+      "min": 15333,
+      "brotli": 6841
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-page-fill-join-records/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-page-fill-join-records/sizes.json
@@ -29,8 +29,8 @@
       "brotli": 185
     },
     "shared": {
-      "min": 15919,
-      "brotli": 7320
+      "min": 15881,
+      "brotli": 7289
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-branch/sizes.json
@@ -6,7 +6,7 @@
     },
     "template.marko.page.mjs": {
       "min": 2875,
-      "brotli": 1419
+      "brotli": 1418
     },
     "child.mjs": {
       "min": 371,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-parent/sizes.json
@@ -6,8 +6,8 @@
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 4206,
-        "brotli": 2059
+        "min": 4168,
+        "brotli": 2042
       },
       "files": {
         "components/wrapper.marko": 873,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-conditional/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 87
     },
     "template.marko.page.mjs": {
-      "min": 3773,
-      "brotli": 1842
+      "min": 3740,
+      "brotli": 1818
     },
     "child.mjs": {
       "min": 324,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 86
     },
     "template.marko.page.mjs": {
-      "min": 2640,
-      "brotli": 1305
+      "min": 2602,
+      "brotli": 1283
     },
     "child.mjs": {
       "min": 214,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-inits/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-inits/sizes.json
@@ -13,8 +13,8 @@
       "brotli": 363
     },
     "shared": {
-      "min": 10578,
-      "brotli": 4827
+      "min": 10540,
+      "brotli": 4793
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 2443,
-      "brotli": 1196
+      "min": 2405,
+      "brotli": 1169
     },
     "child.mjs": {
       "min": 205,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-state-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-state-input/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 5064,
-      "brotli": 2436
+      "min": 5025,
+      "brotli": 2413
     },
     "child.mjs": {
       "min": 179,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 2443,
-      "brotli": 1196
+      "min": 2405,
+      "brotli": 1169
     },
     "child.mjs": {
       "min": 205,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,36 @@
+// child.marko
+const $template = "<button class=count><!>:<!></button>";
+const $walks = " D%c%l";
+const $count = /*@__PURE__*/ _fill_let("__tests__/child.marko0", "count/6", ($scope) => _text($scope["#text/2"], $scope.count));
+const $setup__script = _script("__tests__/child.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$count($scope, +$scope.count + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_label = ($scope, input_label) => _text($scope["#text/1"], input_label);
+const $input = ($scope, input) => $input_label($scope, input.label);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, $walks, $setup, $input);
+
+// template.marko
+const $template = "<button class=n> </button><main><!></main>";
+const $walks = " D lD%l";
+const Child = _load_ready_template("ready:__tests__/child.marko", /*@__PURE__*/ _load_template("__tests__/child.marko", () => import("./child.mjs").then((mod) => mod.default)));
+const $n = /*@__PURE__*/ _let("n/8", ($scope) => _text($scope["#text/1"], $scope.n));
+const $setup__script = _script("__tests__/template.marko_0", ($scope) => _on($scope["#button/0"], "click", function() {
+	$n($scope, +$scope.n + 1);
+}));
+function $setup($scope) {
+	$n($scope, 0);
+	$setup__script($scope);
+}
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/2");
+const $input_show__OR__input_label = /*@__PURE__*/ _or(7, ($scope) => $dynamicTag($scope, $scope.input_show ? Child : null, () => ({ label: $scope.input_label })));
+const $input_show = /*@__PURE__*/ _const("input_show", $input_show__OR__input_label);
+const $input_label = /*@__PURE__*/ _const("input_label", $input_show__OR__input_label);
+const $input = ($scope, input) => {
+	$input_show($scope, input.show);
+	$input_label($scope, input.label);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/dom.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/dom.bundle.js
@@ -1,0 +1,21 @@
+// template.marko
+const Child = _load_ready_template("_a", /*@__PURE__*/ _load_template("a", () => import("./child.mjs").then((mod) => mod.default)));
+const $n = /*@__PURE__*/ _let(8, ($scope) => _text($scope.b, $scope.i));
+const $setup__script = _script("b0", ($scope) => _on($scope.a, "click", function() {
+	$n($scope, +$scope.i + 1);
+}));
+
+// child.marko
+const $template = "<button class=count><!>:<!></button>";
+const $walks = " D%c%l";
+const $count = /*@__PURE__*/ _fill_let("a0", 6, ($scope) => _text($scope.c, $scope.g));
+const $setup__script = _script("a0", ($scope) => _on($scope.a, "click", function() {
+	$count($scope, +$scope.g + 1);
+}));
+function $setup($scope) {
+	$count($scope, 0);
+	$setup__script($scope);
+}
+const $input_label = ($scope, input_label) => _text($scope.b, input_label);
+const $input = ($scope, input) => $input_label($scope, input.label);
+var child_default = /*@__PURE__*/ _template("a", $template, $walks, $setup, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,39 @@
+// child.marko
+const $template$1 = "<button class=count><!>:<!></button>";
+const $walks$1 = " D%c%l";
+_shells({ "__tests__/child.marko": "__tests__/child.marko !__tests__/child.marko_0; D%c%;<button class=count><!>:<!></button>" });
+var child_default = _template_persisted("__tests__/child.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button class=count>${_patch_text($scope0_id, "#text/1", input.label, void 0, $scope0_owned, 0)}:${_text_resume($scope0_id, "#text/2", count, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
+	_script($scope0_id, "__tests__/child.marko_0");
+	_patch_value($scope0_id, "__tests__/child.marko0", count, 1);
+	$scope0_reason && _scope($scope0_id, { count }, "__tests__/child.marko", 0, { count: "1:6" });
+}, 0, 0);
+
+// template.marko
+const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/child.marko", void 0, 1);
+const $template = "<button class=n> </button><main><!></main>";
+const $walks = " D lD%l";
+_shells({ "__tests__/template.marko": "__tests__/template.marko !__tests__/template.marko_0; D lD%;<button class=n> </button><main><!></main>" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=n>${_text_resume($scope0_id, "#text/1", n)}</button>${_el_resume($scope0_id, "#button/0")}<main>`);
+	const $tag = input.show ? $Child_withLoadAssets : null;
+	const $input2 = { label: input.label };
+	_dynamic_tag($scope0_id, "#text/2", $tag, $input2, 0, 0, _source_guard($scope0_reason, 0), _patch_dynamic_tag($scope0_id, "#text/2", $tag, $input2, 0, 0, $scope0_owned, 0));
+	_html("</main>");
+	_script($scope0_id, "__tests__/template.marko_0");
+	$scope0_reason && _scope($scope0_id, {
+		input_show: _source_if($scope0_reason, 2) && input.show,
+		input_label: _source_if($scope0_reason, 1) && input.label,
+		n
+	}, "__tests__/template.marko", 0, {
+		input_show: ["input.show"],
+		input_label: ["input.label"],
+		n: "3:6"
+	});
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/html.bundle.js
@@ -1,0 +1,31 @@
+// child.marko
+_shells({ a: "a !a0; D%c%;<button class=count><!>:<!></button>" });
+var child_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let count = 0;
+	_html(`<button class=count>${_patch_text($scope0_id, "b", input.label, void 0, $scope0_owned, 0)}:${_text_resume($scope0_id, "c", count, 2)}</button>${_el_resume($scope0_id, "a")}`);
+	_script($scope0_id, "a0");
+	_patch_value($scope0_id, "a0", count, 1);
+	$scope0_reason && _scope($scope0_id, { g: count });
+}, 0, 0);
+
+// template.marko
+const $Child_withLoadAssets = withLoadAssets(child_default, "_a", void 0, 1);
+_shells({ b: "b !b0; D lD%;<button class=n> </button><main><!></main>" });
+var template_default = _template_persisted("b", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	let n = 0;
+	_html(`<button class=n>${_text_resume($scope0_id, "b", n)}</button>${_el_resume($scope0_id, "a")}<main>`);
+	const $tag = input.show ? $Child_withLoadAssets : null;
+	const $input2 = { label: input.label };
+	_dynamic_tag($scope0_id, "c", $tag, $input2, 0, 0, _source_guard($scope0_reason, 0), _patch_dynamic_tag($scope0_id, "c", $tag, $input2, 0, 0, $scope0_owned, 0));
+	_html("</main>");
+	_script($scope0_id, "b0");
+	$scope0_reason && _scope($scope0_id, {
+		f: _source_if($scope0_reason, 2) && input.show,
+		g: _source_if($scope0_reason, 1) && input.label,
+		i: n
+	});
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/patches.debug.js
@@ -1,0 +1,36 @@
+// PATCH
+{
+  "PatchDynamicTag:#text/2": [0, {
+    label: "a"
+  }]
+}
+
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko !packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko_0; D%c%;<button class=count><!>:<!></button>`, {
+  "PatchDynamicTag:#text/2": ["packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko", {
+    label: "b"
+  }],
+  "PatchReady:ready:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko": {
+    "PatchChild:BranchScopes:#text/2": {
+      "PatchText:#text/1": "b",
+      "PatchSetup:": {
+        "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko0": 0
+      }
+    }
+  }
+}]
+
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko !packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko_0; D%c%;<button class=count><!>:<!></button>`, {
+  "PatchDynamicTag:#text/2": ["packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko", {
+    label: "c"
+  }],
+  "PatchReady:ready:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko": {
+    "PatchChild:BranchScopes:#text/2": {
+      "PatchText:#text/1": "c",
+      "PatchSetup:": {
+        "PatchValue:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko0": 0
+      }
+    }
+  }
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/patches.js
@@ -1,0 +1,36 @@
+// PATCH
+{
+  fc: [0, {
+    label: "a"
+  }]
+}
+
+// PATCH
+[`a !a0; D%c%;<button class=count><!>:<!></button>`, {
+  fc: ["a", {
+    label: "b"
+  }],
+  z_a: {
+    cAc: {
+      tb: "b",
+      s: {
+        va0: 0
+      }
+    }
+  }
+}]
+
+// PATCH
+[`a !a0; D%c%;<button class=count><!>:<!></button>`, {
+  fc: ["a", {
+    label: "c"
+  }],
+  z_a: {
+    cAc: {
+      tb: "c",
+      s: {
+        va0: 0
+      }
+    }
+  }
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,71 @@
+# Render `{"show":true,"label":"a"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    a:0
+  </button>
+</main>
+```
+
+# Update `{"show":false,"label":"a"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main />
+```
+## Change
+```
+REMOVE: main > button
+```
+
+# Update `{"show":true,"label":"b"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    b:0
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > .count
+UPDATE: .count::text@0 "" => "b"
+UPDATE: .count::text@2 "" => "0"
+```
+
+# Update `{"show":true,"label":"c"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    c:0
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: .count::text@0 "b" => "c"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/render-ssr.md
@@ -1,0 +1,71 @@
+# Render `{"show":true,"label":"a"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    a:0
+  </button>
+</main>
+```
+
+# Update `{"show":false,"label":"a"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main />
+```
+## Change
+```
+REMOVE: main > button
+```
+
+# Update `{"show":true,"label":"b"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    b:0
+  </button>
+</main>
+```
+## Change
+```
+INSERT: main > .count
+UPDATE: .count::text@0 "" => "b"
+UPDATE: .count::text@2 "" => "0"
+```
+
+# Update `{"show":true,"label":"c"}`
+```html
+<button
+  class="n"
+>
+  0
+</button>
+<main>
+  <button
+    class="count"
+  >
+    c:0
+  </button>
+</main>
+```
+## Change
+```
+UPDATE: .count::text@0 "b" => "c"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/writes.debug.html
@@ -1,0 +1,26 @@
+<button class=n>0<!--M_$1 #text/1--></button><!--M_$1 #button/0-->
+<main><!--M_[-->
+  <script async type=module src="child.marko.load.mjs"></script><button
+    class=count>a<!--M_$2 #text/1-->:<!>
+      0<!--M_$2 #text/2--></button><!--M_$2 #button/0--><!--M_]1 #text/2 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.b = {
+    "ready:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko": [
+      _ => [2, {
+        count: 0
+      }],
+      "packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko_0 2"
+    ]
+  };
+  M._.r = [_ => [1, {
+      "ConditionalRenderer:#text/2": "packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko",
+      input_show: !0,
+      input_label: "a",
+      n: 0
+    }],
+    "packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/template.marko_0 1"
+  ];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/__snapshots__/writes.html
@@ -1,0 +1,21 @@
+<button class=n>0<!--M_$1 b--></button><!--M_$1 a-->
+<main><!--M_[-->
+  <script async type=module src="child.marko.load.mjs"></script><button
+    class=count>a<!--M_$2 b-->:<!>
+      0<!--M_$2 c--></button><!--M_$2 a--><!--M_]1 c 2-->
+</main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.b = {
+    _a: [_ => [2, {
+      g: 0
+    }], "a0 2"]
+  };
+  M._.r = [_ => [1, {
+    Dc: "a",
+    f: !0,
+    g: "a",
+    i: 0
+  }], "b0 1"];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/child.marko
@@ -1,0 +1,2 @@
+<let/count=0/>
+<button class="count" onClick() { count++ }>${input.label}:${count}</button>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/sizes.json
@@ -1,0 +1,28 @@
+{
+  "dom": {
+    "child.marko.load.mjs": {
+      "min": 98,
+      "brotli": 81
+    },
+    "template.marko.page.mjs": {
+      "min": 3761,
+      "brotli": 1814
+    },
+    "child.mjs": {
+      "min": 377,
+      "brotli": 241
+    },
+    "shared": {
+      "min": 13046,
+      "brotli": 5582
+    }
+  },
+  "html": {
+    "min": 600,
+    "brotli": 351
+  },
+  "patch": {
+    "min": 231,
+    "brotli": 108
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/template.marko
@@ -1,0 +1,7 @@
+import Child from "./child.marko" with { load: "render" }
+
+<let/n=0/>
+<button class="n" onClick() { n++ }>${n}</button>
+<main>
+  <${input.show ? Child : null} label=input.label/>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/test.ts
@@ -1,0 +1,16 @@
+import type { TestConfig } from "../../main.test";
+import { wait } from "../../utils/resolve";
+
+// A dynamic lazy site whose child owns state leaves and returns with its
+// module resident: the composed child seeds its state and stays interactive.
+export const config: TestConfig = {
+  persisted: true,
+  equivalent: false,
+  steps: [
+    { show: true, label: "a" },
+    wait,
+    { show: false, label: "a" },
+    { show: true, label: "b" },
+    { show: true, label: "c" },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 4798,
-      "brotli": 2266
+      "min": 4760,
+      "brotli": 2250
     },
     "child.mjs": {
       "min": 216,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/dom.bundle.debug.js
@@ -1,0 +1,22 @@
+// template.marko
+const $template = "<main><!></main>";
+const $walks = "D%l";
+const $setup = () => {};
+const Child = _load_ready_template("ready:__tests__/child.marko", /*@__PURE__*/ _load_template("__tests__/child.marko", () => import("./child.mjs").then((mod) => mod.default)));
+const $dynamicTag = /*@__PURE__*/ _dynamic_tag("#text/0");
+const $input_show__OR__input_label = /*@__PURE__*/ _or(5, ($scope) => $dynamicTag($scope, $scope.input_show ? Child : null, () => ({ label: $scope.input_label })));
+const $input_show = /*@__PURE__*/ _const("input_show", $input_show__OR__input_label);
+const $input_label = /*@__PURE__*/ _const("input_label", $input_show__OR__input_label);
+const $input = ($scope, input) => {
+	$input_show($scope, input.show);
+	$input_label($scope, input.label);
+};
+var template_default = /*@__PURE__*/ _template("__tests__/template.marko", $template, "D%l", 0, $input);
+
+// child.marko
+const $template = "<p class=child> </p>";
+const $walks = "D l";
+const $setup = () => {};
+const $input_label = ($scope, input_label) => _text($scope["#text/0"], input_label);
+const $input = ($scope, input) => $input_label($scope, input.label);
+var child_default = /*@__PURE__*/ _template("__tests__/child.marko", $template, "D l", 0, $input);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/html.bundle.debug.js
@@ -1,0 +1,32 @@
+// child.marko
+const $template$1 = "<p class=child> </p>";
+const $walks$1 = "D l";
+_shells({ "__tests__/child.marko": "__tests__/child.marko;D ;<p class=child> </p>" });
+var child_default = _template_persisted("__tests__/child.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p class=child>${_patch_text($scope0_id, "#text/0", input.label, void 0, $scope0_owned, 0)}</p>`);
+	$scope0_reason && _scope($scope0_id, {}, "__tests__/child.marko", 0);
+}, 0, 0);
+
+// template.marko
+const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/child.marko", void 0, 1);
+const $template = "<main><!></main>";
+const $walks = "D%l";
+_shells({ "__tests__/template.marko": "__tests__/template.marko;D%;<main><!></main>" });
+var template_default = _template_persisted("__tests__/template.marko", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show__OR__input_label = _source_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html("<main>");
+	const $tag = input.show ? $Child_withLoadAssets : null;
+	const $input2 = { label: input.label };
+	_dynamic_tag($scope0_id, "#text/0", $tag, $input2, 0, 0, $sg__input_show__OR__input_label, _patch_dynamic_tag($scope0_id, "#text/0", $tag, $input2, 0, 0, $scope0_owned, 0));
+	_html("</main>");
+	$scope0_reason && _scope($scope0_id, {
+		input_show: _source_if($scope0_reason, 2) && input.show,
+		input_label: _source_if($scope0_reason, 1) && input.label
+	}, "__tests__/template.marko", 0, {
+		input_show: ["input.show"],
+		input_label: ["input.label"]
+	});
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/html.bundle.js
@@ -1,0 +1,25 @@
+// child.marko
+_shells({ a: "a;D ;<p class=child> </p>" });
+var child_default = _template_persisted("a", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason();
+	const $scope0_id = _scope_id();
+	_html(`<p class=child>${_patch_text($scope0_id, "a", input.label, void 0, $scope0_owned, 0)}</p>`);
+	$scope0_reason && _scope($scope0_id, {});
+}, 0, 0);
+
+// template.marko
+const $Child_withLoadAssets = withLoadAssets(child_default, "_a", void 0, 1);
+_shells({ b: "b;D%;<main><!></main>" });
+var template_default = _template_persisted("b", (input) => {
+	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show__OR__input_label = _source_guard($scope0_reason, 0);
+	const $scope0_id = _scope_id();
+	_html("<main>");
+	const $tag = input.show ? $Child_withLoadAssets : null;
+	const $input2 = { label: input.label };
+	_dynamic_tag($scope0_id, "a", $tag, $input2, 0, 0, $sg__input_show__OR__input_label, _patch_dynamic_tag($scope0_id, "a", $tag, $input2, 0, 0, $scope0_owned, 0));
+	_html("</main>");
+	$scope0_reason && _scope($scope0_id, {
+		d: _source_if($scope0_reason, 2) && input.show,
+		e: _source_if($scope0_reason, 1) && input.label
+	});
+}, 1, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/patches.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/patches.debug.js
@@ -1,0 +1,30 @@
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko;D ;<p class=child> </p>`, {
+  "PatchDynamicTag:#text/0": ["packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko", {
+    label: "b"
+  }],
+  "PatchReady:ready:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko": {
+    "PatchChild:BranchScopes:#text/0": {
+      "PatchText:#text/0": "b"
+    }
+  }
+}]
+
+// PATCH
+{
+  "PatchDynamicTag:#text/0": [0, {
+    label: "b"
+  }]
+}
+
+// PATCH
+[`packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko;D ;<p class=child> </p>`, {
+  "PatchDynamicTag:#text/0": ["packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko", {
+    label: "c"
+  }],
+  "PatchReady:ready:packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko": {
+    "PatchChild:BranchScopes:#text/0": {
+      "PatchText:#text/0": "c"
+    }
+  }
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/patches.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/patches.js
@@ -1,0 +1,30 @@
+// PATCH
+[`a;D ;<p class=child> </p>`, {
+  fa: ["a", {
+    label: "b"
+  }],
+  z_a: {
+    cAa: {
+      ta: "b"
+    }
+  }
+}]
+
+// PATCH
+{
+  fa: [0, {
+    label: "b"
+  }]
+}
+
+// PATCH
+[`a;D ;<p class=child> </p>`, {
+  fa: ["a", {
+    label: "c"
+  }],
+  z_a: {
+    cAa: {
+      ta: "c"
+    }
+  }
+}]

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/render-ssr.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/render-ssr.debug.md
@@ -1,0 +1,45 @@
+# Render `{"show":false,"label":"a"}`
+```html
+<main />
+```
+
+# Update `{"show":true,"label":"b"}`
+```html
+<main>
+  <p
+    class="child"
+  >
+    b
+  </p>
+</main>
+```
+## Change
+```
+INSERT: main > .child
+UPDATE: .child::text " " => "b"
+```
+
+# Update `{"show":false,"label":"b"}`
+```html
+<main />
+```
+## Change
+```
+REMOVE: main > p
+```
+
+# Update `{"show":true,"label":"c"}`
+```html
+<main>
+  <p
+    class="child"
+  >
+    c
+  </p>
+</main>
+```
+## Change
+```
+INSERT: main > .child
+UPDATE: .child::text " " => "c"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/render-ssr.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/render-ssr.md
@@ -1,0 +1,45 @@
+# Render `{"show":false,"label":"a"}`
+```html
+<main />
+```
+
+# Update `{"show":true,"label":"b"}`
+```html
+<main>
+  <p
+    class="child"
+  >
+    b
+  </p>
+</main>
+```
+## Change
+```
+INSERT: main > .child
+UPDATE: .child::text " " => "b"
+```
+
+# Update `{"show":false,"label":"b"}`
+```html
+<main />
+```
+## Change
+```
+REMOVE: main > p
+```
+
+# Update `{"show":true,"label":"c"}`
+```html
+<main>
+  <p
+    class="child"
+  >
+    c
+  </p>
+</main>
+```
+## Change
+```
+INSERT: main > .child
+UPDATE: .child::text " " => "c"
+```

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/writes.debug.html
@@ -1,0 +1,9 @@
+<main><!--M_]1 #text/0--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    input_show: !1,
+    input_label: "a"
+  }]];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/__snapshots__/writes.html
@@ -1,0 +1,9 @@
+<main><!--M_]1 a--></main>
+<script>
+  WALKER_RUNTIME("M")("_");
+  M._.r = [_ => [1, {
+    d: !1,
+    e: "a"
+  }]];
+  M._.w()
+</script>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/child.marko
@@ -1,0 +1,1 @@
+<p class="child">${input.label}</p>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/sizes.json
@@ -1,0 +1,24 @@
+{
+  "dom": {
+    "child.marko.load.mjs": {
+      "min": 92,
+      "brotli": 82
+    },
+    "template.marko.page.mjs": {
+      "min": 3376,
+      "brotli": 1607
+    },
+    "shared": {
+      "min": 9403,
+      "brotli": 4100
+    }
+  },
+  "html": {
+    "min": 349,
+    "brotli": 250
+  },
+  "patch": {
+    "min": 165,
+    "brotli": 85
+  }
+}

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/template.marko
@@ -1,0 +1,5 @@
+import Child from "./child.marko" with { load: "render" }
+
+<main>
+  <${input.show ? Child : null} label=input.label/>
+</main>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/test.ts
@@ -1,0 +1,16 @@
+import type { TestConfig } from "../../main.test";
+import { wait } from "../../utils/resolve";
+
+// A scriptless page with a lazy dynamic site: the entry still ships the
+// ready channel so the flush revealing the child can apply.
+export const config: TestConfig = {
+  persisted: true,
+  equivalent: false,
+  steps: [
+    { show: false, label: "a" },
+    { show: true, label: "b" },
+    wait,
+    { show: false, label: "b" },
+    { show: true, label: "c" },
+  ],
+};

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 2443,
-      "brotli": 1196
+      "min": 2405,
+      "brotli": 1169
     },
     "child.mjs": {
       "min": 205,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-alias-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-alias-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9584,
-      "brotli": 4289
+      "min": 9545,
+      "brotli": 4259
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11008,
-      "brotli": 4842
+      "min": 10969,
+      "brotli": 4829
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-child-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-child-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8849,
-      "brotli": 4004
+      "min": 8810,
+      "brotli": 4008
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-client-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-client-inner/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9216,
-      "brotli": 4168
+      "min": 9177,
+      "brotli": 4167
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8944,
-      "brotli": 4055
+      "min": 8905,
+      "brotli": 4017
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-content-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-content-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12439,
-      "brotli": 5352
+      "min": 12400,
+      "brotli": 5324
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-grow-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-grow-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9747,
-      "brotli": 4326
+      "min": 9708,
+      "brotli": 4312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10892,
-      "brotli": 4796
+      "min": 10853,
+      "brotli": 4775
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9747,
-      "brotli": 4326
+      "min": 9708,
+      "brotli": 4312
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8539,
-      "brotli": 3886
+      "min": 8500,
+      "brotli": 3869
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11974,
-      "brotli": 5169
+      "min": 11935,
+      "brotli": 5142
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-root-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-root-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8952,
-      "brotli": 4008
+      "min": 8913,
+      "brotli": 3984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9218,
-      "brotli": 4117
+      "min": 9179,
+      "brotli": 4095
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9813,
-      "brotli": 4365
+      "min": 9774,
+      "brotli": 4347
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9218,
-      "brotli": 4115
+      "min": 9179,
+      "brotli": 4095
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-nested-grow-outer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-nested-grow-outer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10176,
-      "brotli": 4504
+      "min": 10137,
+      "brotli": 4516
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-rest-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-rest-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9607,
-      "brotli": 4277
+      "min": 9568,
+      "brotli": 4269
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9348,
-      "brotli": 4213
+      "min": 9309,
+      "brotli": 4195
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11026,
-      "brotli": 4781
+      "min": 10987,
+      "brotli": 4752
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8970,
-      "brotli": 4077
+      "min": 8931,
+      "brotli": 4032
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7946,
-      "brotli": 3633
+      "min": 7908,
+      "brotli": 3640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-holes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-holes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8539,
-      "brotli": 3886
+      "min": 8500,
+      "brotli": 3869
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7946,
-      "brotli": 3633
+      "min": 7908,
+      "brotli": 3640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8752,
-      "brotli": 3989
+      "min": 8713,
+      "brotli": 3969
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10407,
-      "brotli": 4458
+      "min": 10368,
+      "brotli": 4443
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11586,
-      "brotli": 4945
+      "min": 11547,
+      "brotli": 4909
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9909,
-      "brotli": 4419
+      "min": 9870,
+      "brotli": 4383
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7596,
-      "brotli": 3425
+      "min": 7558,
+      "brotli": 3401
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9997,
-      "brotli": 4388
+      "min": 9958,
+      "brotli": 4368
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read-in-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14735,
-      "brotli": 6094
+      "min": 14696,
+      "brotli": 6074
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11538,
-      "brotli": 4909
+      "min": 11499,
+      "brotli": 4887
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-renderer-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-renderer-prop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12733,
-        "brotli": 5386
+        "min": 12694,
+        "brotli": 5361
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6971,
-      "brotli": 3145
+      "min": 6933,
+      "brotli": 3127
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-multiline-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-multiline-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6792,
-      "brotli": 3095
+      "min": 6754,
+      "brotli": 3071
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9939,
-      "brotli": 4267
+      "min": 9900,
+      "brotli": 4242
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9872,
-      "brotli": 4248
+      "min": 9833,
+      "brotli": 4224
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10498,
-      "brotli": 4526
+      "min": 10459,
+      "brotli": 4504
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8688,
-      "brotli": 3844
+      "min": 8649,
+      "brotli": 3822
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-style-in-loop-item/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-style-in-loop-item/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9026,
-      "brotli": 4029
+      "min": 8987,
+      "brotli": 4011
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-abort-disconnect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-abort-disconnect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10546,
-      "brotli": 4547
+      "min": 10507,
+      "brotli": 4524
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-catch-param-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-catch-param-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12042,
-      "brotli": 5091
+      "min": 12003,
+      "brotli": 5066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder-direct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder-direct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-two-await-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-two-await-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9656,
-      "brotli": 4173
+      "min": 9617,
+      "brotli": 4150
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole-in-shell/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole-in-shell/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7174,
-      "brotli": 3244
+      "min": 7136,
+      "brotli": 3227
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-unfed-group-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-unfed-group-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8970,
-      "brotli": 3952
+      "min": 8931,
+      "brotli": 3930
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8900,
-      "brotli": 3963
+      "min": 8861,
+      "brotli": 3940
     }
   },
   "html": {

--- a/packages/runtime-tags/src/common/constants/accessor-prop.debug.ts
+++ b/packages/runtime-tags/src/common/constants/accessor-prop.debug.ts
@@ -27,7 +27,6 @@ export const Subscriptions = "#Subscriptions";
 export const TagVariable = "#TagVariable";
 export const TagVariableChange = "#TagVariableChange";
 export const PatchChanged = "#PatchChanged";
-export const PatchSetup = "#PatchSetup";
 export const ReadyId = "#ReadyId";
 
 type Self = typeof import("./accessor-prop.debug");

--- a/packages/runtime-tags/src/common/constants/accessor-prop.ts
+++ b/packages/runtime-tags/src/common/constants/accessor-prop.ts
@@ -29,8 +29,7 @@ export const TagVariableChange = "U";
 // Past `Z` the run continues two-lettered (still dot-accessible; no prefixed
 // key matches, accessors being lowercase).
 export const PatchChanged = "AA";
-export const PatchSetup = "AB";
-export const ReadyId = "AC";
+export const ReadyId = "AB";
 
 type Self = typeof import("./accessor-prop");
 export type Value = Self[keyof Self];

--- a/packages/runtime-tags/src/dom/patch-shells.ts
+++ b/packages/runtime-tags/src/dom/patch-shells.ts
@@ -28,18 +28,12 @@ declare module "./resume" {
 // it even when no client control flow does.
 const _content = /*@__PURE__*/ withBranches(content);
 
-// A branch stashes its setup for the shell's first render; a scope this
-// flush created (`Gen` since the flush's run, met while constructing) has
-// no render coming, so its setup applies now.
+// A scope this flush created (`Gen` since the flush's run, met while
+// constructing) has no render coming, so its setup applies now; a fresh
+// branch's queued shell setup runs after, over the applied values.
 patchers[PatchKey.Setup] = (scope, _key, value) => {
-  if (
-    constructing &&
-    scope[AccessorProp.Gen] >= patchRun &&
-    scope[AccessorProp.ClosestBranch] !== scope
-  ) {
+  if (constructing && scope[AccessorProp.Gen] >= patchRun) {
     patchConstruct(value, scope);
-  } else {
-    scope[AccessorProp.PatchSetup] = value;
   }
 };
 // Ids the flush asks a fresh scope to run, in the shell's grammar
@@ -94,15 +88,7 @@ export const registerShell = (shell: string) => {
   shells[idToken.slice(0, sep)] = [
     shell.slice(second + 1),
     shell.slice(first + 1, second),
-    resolved
-      ? (branch: Scope) => {
-          if (branch[AccessorProp.PatchSetup]) {
-            patchConstruct(branch[AccessorProp.PatchSetup] as Scope, branch);
-            branch[AccessorProp.PatchSetup] = 0;
-          }
-          runSetupIds(resolved, branch);
-        }
-      : 0,
+    resolved ? (branch: Scope) => runSetupIds(resolved, branch) : 0,
   ];
   return idToken.slice(0, sep);
 };


### PR DESCRIPTION
A lazy dynamic tag returning with its module resident renders from its shell during the flush's run, and the ready channel's guard commits after that run. The guard's setup entry for the branch stashed itself for a shell render that had already happened, so the child's state never seeded (its text stayed empty and clicks did nothing).

The stash was only ever an ordering deferral. A constructed scope's setup now applies as it is met: in the usual case the values still land before the queued shell setup runs, and in the returning case nothing waits on a render that already happened. The stash, its accessor prop and the wrapper around every shell's setup are gone, shrinking pages that ship shells.

Fixtures: `persisted-lazy-tag-dynamic-let-return-visit` for the seeding bug, and `persisted-lazy-tag-dynamic-scriptless` covering a scriptless page whose lazy dynamic site's flush must still find its ready channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)