### PR TITLE
Translator: list every dom feature module as a runtime entry

### DIFF
--- a/packages/runtime-tags/src/__tests__/translator-api.test.ts
+++ b/packages/runtime-tags/src/__tests__/translator-api.test.ts
@@ -6,6 +6,7 @@ import { decode } from "@jridgewell/sourcemap-codec";
 import * as compiler from "@marko/compiler";
 
 import * as translator from "../translator";
+import { domRuntimeFeatures } from "../translator/util/runtime";
 
 const require = createRequire(import.meta.url);
 
@@ -30,6 +31,9 @@ describe("runtime-tags/translator-api", () => {
       ]);
       assert.deepEqual(translator.getRuntimeEntryFiles("dom", false), [
         "@marko/runtime-tags/debug/dom",
+        ...domRuntimeFeatures.map(
+          (feature) => `@marko/runtime-tags/debug/dom/${feature}.feat`,
+        ),
       ]);
     });
 
@@ -39,6 +43,9 @@ describe("runtime-tags/translator-api", () => {
       ]);
       assert.deepEqual(translator.getRuntimeEntryFiles("dom", true), [
         "@marko/runtime-tags/dom",
+        ...domRuntimeFeatures.map(
+          (feature) => `@marko/runtime-tags/dom/${feature}.feat`,
+        ),
       ]);
     });
 

--- a/packages/runtime-tags/src/translator/index.ts
+++ b/packages/runtime-tags/src/translator/index.ts
@@ -2,6 +2,7 @@ import type { Config } from "@marko/compiler";
 
 import pkg from "../../package.json" with { type: "json" };
 import coreTagLib from "./core";
+import { domRuntimeFeatures } from "./util/runtime";
 import runtimeInfo from "./util/runtime-info";
 import { extractVisitors } from "./util/visitors";
 import MarkoCDATA from "./visitors/cdata";
@@ -59,8 +60,11 @@ export function getRuntimeEntryFiles(
   output: Config["output"],
   optimize: boolean,
 ) {
+  const runtime = `${runtimeInfo.name}${optimize ? "" : "/debug"}`;
+  if (output === "html") return [`${runtime}/html`];
   return [
-    `${runtimeInfo.name}${optimize ? "" : "/debug"}/${output === "html" ? "html" : "dom"}`,
+    `${runtime}/dom`,
+    ...domRuntimeFeatures.map((feature) => `${runtime}/dom/${feature}.feat`),
   ];
 }
 

--- a/packages/runtime-tags/src/translator/util/runtime.ts
+++ b/packages/runtime-tags/src/translator/util/runtime.ts
@@ -116,39 +116,42 @@ export function callRuntime(
 
 // A `src/{dom,html}/*.feat.ts` module is a compiler-injected side-effect
 // import: it enables optional runtime behavior that referenced imports alone
-// cannot keep alive under tree shaking (eg catch enablement).
-export type DOMRuntimeFeature =
-  | "catch"
-  | "controllable"
-  | "controllable-input"
-  | "controllable-open"
-  | "controllable-select"
-  | "controllable-textarea"
-  | "dynamic-tag-var"
-  | "patch-attr"
-  | "patch-attrs"
-  | "patch-boundary"
-  | "patch-branch"
-  | "patch-child"
-  | "patch-content"
-  | "patch-control"
-  | "patch-control-checked-value"
-  | "patch-control-input"
-  | "patch-control-open"
-  | "patch-control-select"
-  | "patch-dynamic-tag"
-  | "patch-effect"
-  | "patch-global"
-  | "patch-html"
-  | "patch-loop"
-  | "patch-ready"
-  | "patch-style"
-  | "patch-text"
-  | "patch-text-content"
-  | "patch-value"
-  | "patch-value-bind"
-  | "patch-var"
-  | "placeholder";
+// cannot keep alive under tree shaking (eg catch enablement). A page entry
+// may import one no template does, so a dev optimizer includes them all.
+export const domRuntimeFeatures = [
+  "catch",
+  "controllable",
+  "controllable-input",
+  "controllable-open",
+  "controllable-select",
+  "controllable-textarea",
+  "dynamic-tag-var",
+  "patch-attr",
+  "patch-attrs",
+  "patch-boundary",
+  "patch-branch",
+  "patch-child",
+  "patch-content",
+  "patch-control",
+  "patch-control-checked-value",
+  "patch-control-input",
+  "patch-control-open",
+  "patch-control-select",
+  "patch-dynamic-tag",
+  "patch-effect",
+  "patch-global",
+  "patch-html",
+  "patch-loop",
+  "patch-ready",
+  "patch-style",
+  "patch-text",
+  "patch-text-content",
+  "patch-value",
+  "patch-value-bind",
+  "patch-var",
+  "placeholder",
+] as const;
+export type DOMRuntimeFeature = (typeof domRuntimeFeatures)[number];
 // The analyze-phase half of `importRuntimeFeature`: the page entry links
 // client assets from analyze metadata.
 export function addRuntimeFeatureAsset(feature: DOMRuntimeFeature) {


### PR DESCRIPTION
A page entry may import a dom feature module (`*.feat`) that no template imports, for example a persisted page's ready channel. A dev optimizer only discovered such a module on the first request, which could deadlock a cold start. `getRuntimeEntryFiles` now lists the dom runtime together with every feature module for the dom output, so the optimizer sees them up front.

🤖 Generated with [Claude Code](https://claude.com/claude-code)