### PR TITLE
Persisted: translate decisions leave analyze metadata alone

### DIFF
--- a/packages/runtime-tags/src/translator/util/branch-tag.ts
+++ b/packages/runtime-tags/src/translator/util/branch-tag.ts
@@ -1,5 +1,3 @@
-import type { types as t } from "@marko/compiler";
-
 import { getAccessorPrefix } from "./get-accessor-enums";
 import { type Binding, kBranchSerializeReason } from "./references";
 import type { Section } from "./sections";
@@ -22,11 +20,11 @@ export function getBranchSectionAccessor(
   };
 }
 
-// Expressions upstream of a branch (a condition, collection, renderer),
-// across every program in the compile.
-const branchUpstreams = new WeakSet<t.NodeExtra>();
-export function isBranchUpstream(extra: t.NodeExtra) {
-  return branchUpstreams.has(extra);
+declare module "@marko/compiler/dist/types" {
+  export interface NodeExtra {
+    /** Upstream of a branch: its condition, collection, or renderer. */
+    branchUpstream?: true;
+  }
 }
 
 export function initBranchSection(
@@ -37,7 +35,7 @@ export function initBranchSection(
   bodySection.isBranch = true;
   bodySection.upstreamExpression = upstreamExpression;
   bodySection.sectionAccessor = sectionAccessor;
-  if (upstreamExpression) branchUpstreams.add(upstreamExpression);
+  if (upstreamExpression) upstreamExpression.branchUpstream = true;
 }
 
 // The branch id rides the always-rendered resume marker and a state-fed

--- a/packages/runtime-tags/src/translator/util/persisted/structure.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/structure.ts
@@ -3,7 +3,6 @@
 import type { types as t } from "@marko/compiler";
 
 import { kDirectContent } from "../binding-prop-tree";
-import { isBranchUpstream } from "../branch-tag";
 import { isPersisted } from "../marko-config";
 import { every, forEach, type Opt, some, toArray } from "../optional";
 import type { Binding, ReferencedExtra, Sources } from "../references";
@@ -196,7 +195,7 @@ function upstreamSourcesFill(binding: Binding): boolean {
 // derivation, so pairing carries it and no fill is needed.
 export function readsOnlyUpstream(binding: Binding) {
   for (const read of binding.reads) {
-    if (!isBranchUpstream(read)) return false;
+    if (!read.branchUpstream) return false;
   }
   return true;
 }

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -99,7 +99,7 @@ import {
   type SerializeReason,
 } from "./serialize-reasons";
 import { simplifyFunction } from "./simplify-fn";
-import { createSectionState } from "./state";
+import { createProgramState, createSectionState } from "./state";
 import { toFirstExpressionOrBlock } from "./to-first-expression-or-block";
 import {
   toMemberExpression,
@@ -1829,7 +1829,7 @@ export function sectionConstructs(section: Section) {
 // Plain fill write of a server-owned branch local, gated by its param
 // group's ownership; a client-fed instance re-derives via closure inits.
 export function writeLocalFill(section: Section, binding: Binding) {
-  writtenLocalFills.add(binding);
+  getWrittenLocalFills().add(binding);
   const write = callRuntime(
     "_patch_value",
     getScopeIdIdentifier(section),
@@ -1859,7 +1859,7 @@ export function writeLocalFill(section: Section, binding: Binding) {
 // Plain write of a server-owned branch local that effects or handlers read,
 // gated by its ownership like the root's writes.
 export function writeLocalWrite(section: Section, binding: Binding) {
-  writtenLocalFills.add(binding);
+  getWrittenLocalFills().add(binding);
   const write = callRuntime(
     "_patch_write",
     getScopeIdIdentifier(section),
@@ -1872,12 +1872,11 @@ export function writeLocalWrite(section: Section, binding: Binding) {
 
 // Locals whose declaration already wrote their fill or write
 // (`translateVar`), so the section's leading writes cover only the rest.
-const writtenLocalFills = new WeakSet<Binding>();
+const [getWrittenLocalFills] = createProgramState(() => new Set<Binding>());
 
 // A spread's effect re-attaches what its serialized set carried: the flush's
 // attribute set is the refresh, so its reads need no other channel.
-function isSerializedSpreadEffect(signal: Signal) {
-  const refs = signal.referencedBindings;
+function isSerializedSpreadEffect(refs: ReferencedBindings) {
   return (
     !!refs &&
     some(refs, (binding) => {
@@ -1892,14 +1891,23 @@ function isSerializedSpreadEffect(signal: Signal) {
 // An effect read the wire cannot keep current blocks constructs; fills,
 // wire writes and direct `$global` reads stay current.
 export function sectionHasServerEffect(section: Section) {
-  for (const signal of getSignals(section).values()) {
-    if (signal.hasHTMLEffect && !isSerializedSpreadEffect(signal)) {
-      if (hasUnfillablePatchReads(signal.referencedBindings)) {
+  const hasServerEffect = (binding: Binding) => {
+    for (const read of binding.reads) {
+      if (
+        read.section === section &&
+        read.isEffect &&
+        !isSerializedSpreadEffect(read.referencedBindings) &&
+        hasUnfillablePatchReads(read.referencedBindings)
+      ) {
         return true;
       }
     }
-  }
-  return false;
+    return false;
+  };
+  return (
+    some(section.bindings, hasServerEffect) ||
+    some(section.referencedClosures, hasServerEffect)
+  );
 }
 
 // The section's mount effects as space-joined register ids, in hydration
@@ -2232,7 +2240,7 @@ export function writeHTMLResumeStatements(
         // branch bindings up front; root writes ride the reason's complement.
         if (!section.parent) {
           fillCalls.push(write);
-        } else if (!writtenLocalFills.has(binding)) {
+        } else if (!getWrittenLocalFills().has(binding)) {
           getHTMLSectionStatements(section).push(t.expressionStatement(write));
         }
       }
@@ -2303,7 +2311,7 @@ export function writeHTMLResumeStatements(
       if (!binding.sources?.state) {
         // A server-owned local writes plainly as soon as it exists (root fills
         // already write as the scope reason's complement).
-        if (section.parent && !writtenLocalFills.has(binding)) {
+        if (section.parent && !getWrittenLocalFills().has(binding)) {
           getHTMLSectionStatements(section).push(
             t.expressionStatement(writeLocalFill(section, binding)),
           );

--- a/packages/runtime-tags/src/translator/util/structure.ts
+++ b/packages/runtime-tags/src/translator/util/structure.ts
@@ -161,7 +161,7 @@ export function resolveStructure(section: Section) {
           break;
         case StructureKind.Child: {
           // A lazy site composes its child only when a flush constructs it.
-          const composed = html && op.load?.serverOnly;
+          const composed = html && op.load?.sitesConstruct;
           const renderer = op.load && !composed ? undefined : op.renderer;
           if (composed) {
             // The walk steps over the site's marker into the composed child;

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -52,15 +52,42 @@ export type LoadImportConfig = (
   | { render: true; triggers?: never }
   | { render: false; triggers: LoadTrigger[] }
 ) & {
-  // Under persisted: a page's import whose every site sits in structure only
-  // the server renders (the client never instantiates a page or that
-  // structure), so the server alone renders it and no client render ships.
-  serverOnly?: true;
+  /** Every site of a page's rendered import sits in structure a patch
+   * constructs, with no state upstream: only a construct ever meets it. */
+  sitesConstruct?: true;
 };
 const triggerRegExp = /\s*([\w-]+)\s*([^?|]+?)?\s*(?:\?([^|]*?))?\s*(?:\||$)/g;
 const [getHtmlLoadWrapped] = createProgramState(
   () => new Map<string, string>(),
 );
+
+// Records which of a page's rendered imports only constructs meet, once
+// every section's shell is decided. A trigger keeps its channel, so a
+// navigation never forces a load; an import is a module binding, so its
+// uses (tag names, values passed along) are its babel references.
+export function recordConstructedLoadImports(program: t.NodePath<t.Program>) {
+  if (!isPersisted() || !isPage()) return;
+  for (const node of program.node.body) {
+    const loadImport = node.extra?.loadImport;
+    if (!t.isImportDeclaration(node) || !loadImport?.render) continue;
+    const { local } = node.specifiers.find(t.isImportDefaultSpecifier)!;
+    if (
+      program.scope.getBinding(local.name)!.referencePaths.every(
+        (ref) =>
+          sectionConstructs(getSection(ref)) &&
+          // State upstream of a site re-renders it on the client.
+          !(
+            t.isMarkoTag(ref.parent) &&
+            getAllTagReferenceNodes(ref.parent).some((node) =>
+              hasStateSource(node.extra),
+            )
+          ),
+      )
+    ) {
+      loadImport.sitesConstruct = true;
+    }
+  }
+}
 
 export default {
   analyze(importDecl) {
@@ -165,28 +192,6 @@ export default {
         if (loadImport) {
           const { local } = node.specifiers.find(t.isImportDefaultSpecifier)!;
           const binding = importDecl.scope.getBinding(local.name)!;
-          // A trigger keeps its channel, so a navigation never forces a load.
-          // An import is a module binding, so its uses (tag names, values
-          // passed along) are its babel references.
-          if (
-            isPersisted() &&
-            loadImport.render &&
-            isPage() &&
-            binding.referencePaths.every(
-              (ref) =>
-                sectionConstructs(getSection(ref)) &&
-                // State upstream of a site re-renders it on the client.
-                !(
-                  t.isMarkoTag(ref.parent) &&
-                  getAllTagReferenceNodes(ref.parent).some((node) =>
-                    hasStateSource(node.extra),
-                  )
-                ),
-            )
-          ) {
-            loadImport.serverOnly = true;
-          }
-
           if (isOutputHTML()) {
             const file = getFile();
             const loadFile = loadFileForImport(file, node.source.value)!;
@@ -223,7 +228,7 @@ export default {
             );
             // Flushes name a server-only template; the page registers its
             // loader only, for the registrations its flushes need.
-            if (loadImport.serverOnly) {
+            if (loadImport.sitesConstruct) {
               importDecl.replaceWith(
                 t.expressionStatement(
                   callRuntime(

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -255,7 +255,7 @@ export default {
             // Lazy sites wire their load (and channel) as construct inits;
             // a server-only site's child sits in the shell itself.
             for (const { site, load } of section.loadSites || []) {
-              if (load.serverOnly) continue;
+              if (load.sitesConstruct) continue;
               marker +=
                 (marker && " ") + getResumeRegisterId(section, site, "init");
             }

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -40,6 +40,7 @@ import {
 import { sectionHasSetupStatements } from "../../util/setup-statements";
 import { buildShells } from "../../util/shell";
 import type { TemplateVisitor } from "../../util/visitors";
+import { recordConstructedLoadImports } from "../import-declaration";
 import programDOM from "./dom";
 import programHTML from "./html";
 import { preAnalyze } from "./pre-analyze";
@@ -129,6 +130,7 @@ export default {
 
       if (isPersisted()) {
         buildShells();
+        recordConstructedLoadImports(program);
       }
       if (!section.hoistedTo && !sectionHasSetupStatements(section)) {
         // The setup export will be a noop, letting parent templates skip

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -213,7 +213,7 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
 
   // A server-only site has no client render: a flush's shell builds it
   // and its setup entries seed it.
-  if (loadConfig?.serverOnly) {
+  if (loadConfig?.sitesConstruct) {
     importRuntimeFeature("patch-child");
     tag.remove();
     return;


### PR DESCRIPTION
Which of a page's rendered lazy imports only constructs ever meet was decided at translate from the html output's effect flags and written onto the import's analyze config, so whichever output translated first decided it for the other. A section's server effects are effect reads analyze already records (`read.isEffect`), so the decision is made once at program analyze exit, after shells are decided, and recorded on the load config as `sitesConstruct`.

The html output's record of locals whose declaration already wrote their fill was a module set keyed by binding, shared across outputs and never cleared; it is program state now. A branch's upstream expression is marked on its extra at analyze (`branchUpstream`) instead of in a module set beside it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)