### PR TITLE
Persisted: the shell decision reads structure without touching the program

### DIFF
--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -40,6 +40,7 @@ import {
 import { getSerializeGuard } from "../util/serialize-guard";
 import { getSerializeSourcesForExpr } from "../util/serialize-reasons";
 import { addSetupStatement } from "../util/setup-statements";
+import { isShell } from "../util/shell";
 import {
   addStatement,
   addValue,
@@ -128,9 +129,7 @@ export default {
       addRuntimeFeatureAsset("patch-boundary");
       // A scriptless construct paints the settled body via text fills.
       addRuntimeFeatureAsset("patch-text");
-      // Recorded on every section; `buildShells` keeps only those whose
-      // shipped body shells a construct can resolve.
-      (section.constructSetups ??= []).push({
+      (section.awaits ??= []).push({
         binding: tagExtra[kDOMBinding]!,
         body: bodySection,
       });
@@ -189,7 +188,7 @@ export default {
         const patchContent =
           isPersisted() && !valueSources?.param && !valueSources?.global
             ? t.numericLiteral(0)
-            : section.constructSetups?.some((s) => s.binding === nodeRef)
+            : bodySection && isShell(bodySection)
               ? t.stringLiteral(getResumeRegisterId(section, nodeRef, "await"))
               : undefined;
 

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -176,9 +176,8 @@ export interface Section {
   /** A content body shipped as a shell: `"static"` rides its slot
    * in-band, a dynamic one is constructed by id from a dynamic tag entry. */
   contentShell: false | true | "static";
-  /** Awaits a construct must supply body content for (marker binding +
-   * body section); `buildShells` prunes those no shipped shell reaches. */
-  constructSetups: { binding: Binding; body: Section }[] | undefined;
+  /** The section's awaits: each marker binding and body section. */
+  awaits: { binding: Binding; body: Section }[] | undefined;
   /** Lazily loaded child sites in this section, by their marker binding. */
   loadSites: { site: Binding; load: LoadImportConfig }[] | undefined;
   /** Branch whose shell would construct unfaithfully: the first blocker's
@@ -272,7 +271,7 @@ export function startSection(
       isBoundary: false,
       boundaryContent: false,
       contentShell: false,
-      constructSetups: undefined,
+      awaits: undefined,
       loadSites: undefined,
       structure: parentSection && !parentSection.structure ? null : [],
     };

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -14,7 +14,11 @@ import {
   StructureKind,
 } from "./sections";
 import { getResumeRegisterId } from "./signals";
-import { getSectionMeta, trimTrailingExits } from "./structure";
+import {
+  getSectionMeta,
+  resolveStructure,
+  trimTrailingExits,
+} from "./structure";
 
 declare module "@marko/compiler/dist/types" {
   export interface ProgramExtra {
@@ -26,6 +30,13 @@ declare module "@marko/compiler/dist/types" {
 
 export function getShells() {
   return getProgram().node.extra.shells;
+}
+
+// Whether a section ships as a shell (under any id).
+export function isShell(section: Section) {
+  const shells = getShells();
+  for (const id in shells) if (shells[id] === section) return true;
+  return false;
 }
 
 // Decides every branch shell (expressibility, blockers) so the html output
@@ -127,11 +138,6 @@ export function buildShells() {
     Object.assign(shells, bodyShells);
     shells[getShellId(section)] = section;
   });
-  // Only kept sections' awaits construct: their `Pending` patches carry a
-  // content id and (interactive) their body registers in the dom output.
-  forEachSection((section) => {
-    if (!keep.has(section)) section.constructSetups = undefined;
-  });
 }
 
 // Body shells reuse the branch grammar; nested awaits recurse so a
@@ -141,7 +147,7 @@ function buildAwaitBodyShells(
   shells: Record<string, Section>,
   chain: Section[],
 ) {
-  for (const { binding, body } of section.constructSetups || []) {
+  for (const { binding, body } of section.awaits || []) {
     if (
       !isShellExpressible(body) ||
       !buildAwaitBodyShells(body, shells, chain)
@@ -230,24 +236,27 @@ function hasPatchedChild(section: Section) {
 // Await bodies ship as their construct's `await` shells, never as
 // standalone content shells nothing references.
 function isAwaitBody(section: Section) {
-  return !!section.parent?.constructSetups?.some((s) => s.body === section);
+  return !!section.parent?.awaits?.some((s) => s.body === section);
 }
 
-// The shell's template and walk strings when both are fully static.
-// A shell the client rebuilds from its template alone (no walk, no setup).
+// A shell the client rebuilds from its template alone: static markup with
+// no walk. A child always walks, so resolving never reaches its imports.
 function isStaticShell(section: Section) {
-  const shell = getStaticShell(section);
-  return !!shell && !shell[1];
-}
-
-function getStaticShell(section: Section) {
-  if (!isShellExpressible(section)) return;
-  const { writes, walks } = getSectionMeta(section);
-  const walkLiteral = trimTrailingExits(walks);
-  if (!t.isStringLiteral(writes) || !writes.value) return;
-  // A fully static branch claims nothing, so an empty walk string is valid.
-  if (walkLiteral && !t.isStringLiteral(walkLiteral)) return;
-  return [writes.value, walkLiteral?.value ?? ""] as const;
+  if (
+    !isShellExpressible(section) ||
+    section.structure!.some(
+      (op) => typeof op === "object" && op.kind === StructureKind.Child,
+    )
+  ) {
+    return false;
+  }
+  const { writes, walks } = resolveStructure(section);
+  const writesLiteral = normalizeStringExpression(writes, true);
+  return (
+    t.isStringLiteral(writesLiteral) &&
+    !!writesLiteral.value &&
+    !trimTrailingExits(normalizeStringExpression(walks, true))
+  );
 }
 
 // The shell `id marker;walks;template` (`,` for `;walks;` when the


### PR DESCRIPTION
`buildShells` runs at analyze, and resolving a section's template there reached a child's imports, adding declarations to the cached analyze AST. A static shell never composes a child (a child always walks), so the check now resolves only childless structure and never imports.

The section's awaits stay the observation they are (`section.awaits`, each marker binding and body section) instead of being pruned to the ones a shell reaches; whether an await's body ships as a shell is read from the shell table (`isShell`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)