### PR TITLE
Persisted: structure and tag-var facts read from what analyze records

### DIFF
--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -477,10 +477,6 @@ export default {
 
         const forType = getForType(node)!;
         const signal = getSignal(tagSection, nodeRef, "for");
-        signal.patchedStructure =
-          isPersisted() &&
-          !isStatefulBranch(bodySection) &&
-          isBranchPathSection(tagSection);
         signal.build = () => {
           return callRuntime(
             forTypeToBranchRuntime(forType),

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -411,12 +411,6 @@ export const IfTag = {
           }
 
           const signal = getSignal(ifTagSection, nodeRef, "if");
-          signal.patchedStructure =
-            isPersisted() &&
-            !branches.some(
-              ([, branchBody]) => branchBody && isStatefulBranch(branchBody),
-            ) &&
-            isBranchPathSection(ifTagSection);
           signal.build = () => {
             const rendererArgs: (t.Expression | undefined)[] = [];
             for (const [_, branchBodySection] of branches) {

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -131,8 +131,9 @@ const kContentSection = Symbol("known tag content section");
 const kSourcesRecordedGroups = Symbol("known tag sources recorded groups");
 const kChildScopeBinding = Symbol("known tag scope binding");
 export const kStaticBody = Symbol("known tag static body");
-export const kTagVar = Symbol("known tag var");
-const kChildOffsetScopeBinding = Symbol("known tag scope offset binding");
+export const kChildOffsetScopeBinding = Symbol(
+  "known tag scope offset binding",
+);
 const kKnownExprs = Symbol("known tag exprs");
 
 declare module "@marko/compiler/dist/types" {
@@ -141,7 +142,6 @@ declare module "@marko/compiler/dist/types" {
     [kSourcesRecordedGroups]?: number;
     [kChildScopeBinding]?: Binding;
     [kStaticBody]?: boolean;
-    [kTagVar]?: true;
     [kChildOffsetScopeBinding]?: Binding;
     [kKnownExprs]?: KnownExprs;
   }
@@ -165,7 +165,6 @@ export function knownTagAnalyze(
   let staticBody = true;
   for (const child of tagBody.get("body")) staticBody &&= isStatic(child);
   tagExtra[kStaticBody] = staticBody;
-  if (tag.node.var) tagExtra[kTagVar] = true;
   const attrExprs = new Set([tagExtra]);
   if (isPersisted()) {
     // The ref must serialize so a patch can pair the child scope through a
@@ -575,12 +574,6 @@ export function knownTagTranslateDOM(
       attrTagCallsByTag: undefined,
     });
   }
-}
-
-// The child's return reason for call-site classification (persisted
-// rejects returns whose sources cannot map through ownership).
-export function getKnownTagReturnReason(tagExtra: t.MarkoTagExtra) {
-  return tagExtra[kContentSection]?.returnSerializeReason;
 }
 
 export function finalizeKnownTags(section: Section) {

--- a/packages/runtime-tags/src/translator/util/persisted/decisions.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/decisions.ts
@@ -8,7 +8,7 @@ import {
   getParamGroupSources,
   hasParamSource,
   kStaticBody,
-  kTagVar,
+  kChildOffsetScopeBinding,
 } from "../known-tag";
 import { some } from "../optional";
 import { getCanonicalBinding, type ReferencedExtra } from "../references";
@@ -123,7 +123,7 @@ function computeChildPatchPlan(tagExtra: t.MarkoTagExtra): ChildPatchPlan {
     anyState &&
     !anyServerable &&
     tagExtra[kStaticBody] &&
-    !tagExtra[kTagVar] &&
+    !tagExtra[kChildOffsetScopeBinding] &&
     !inStatefulBranch(getKnownTagSection(tagExtra))
   ) {
     return { skipsPatchRender: true };

--- a/packages/runtime-tags/src/translator/util/persisted/refresh.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/refresh.ts
@@ -367,14 +367,6 @@ export function joinsStateIn(closure: Binding, section: Section) {
   return false;
 }
 
-// A closure read in `section` that is a `tagNameLoad` tag's input.
-export function readAsTagNameLoadInput(closure: Binding, section: Section) {
-  for (const read of closure.reads) {
-    if (read.section === section && read.tagNameLoadInput) return true;
-  }
-  return false;
-}
-
 // A fill closure upstream of a state intersection read in `section` (which
 // then rides a `_fill_join_*` wrapper registering the closure's init); a
 // chain leaving the branch ladder refreshes through the closure instead.

--- a/packages/runtime-tags/src/translator/util/references.ts
+++ b/packages/runtime-tags/src/translator/util/references.ts
@@ -234,9 +234,6 @@ declare module "@marko/compiler/dist/types" {
      * (dynamic/aliased) read, a property alias names the key. */
     globalBindings?: ReferencedBindings;
     spreadFrom?: Binding;
-    /** An input expression of a `tagNameLoad` tag (its value stashes until
-     * the child's module arrives). */
-    tagNameLoadInput?: true;
     nativeTagSpread?: true;
     /** A native tag spread that is the element's whole attribute set (no
      * content renderer it could carry). */

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -43,6 +43,7 @@ import {
   getParamUpstreamChain,
   inStatefulBranch,
   isBranchPathSection,
+  isStatefulBranch,
 } from "./persisted/structure";
 import {
   type AssignedBindingExtra,
@@ -76,6 +77,7 @@ import { createScopeReadExpression, getScopeExpression } from "./scope-read";
 import {
   getDynamicClosureIndex,
   getScopeIdIdentifier,
+  getChildSections,
   getSectionForBody,
   groupParamsBySection,
   isDynamicClosure,
@@ -133,8 +135,6 @@ export interface Signal {
   /** Renders a patch does itself (its hole writes, forwards into work it
    * renders): a client render needs them, a fill's run does not. */
   patched: t.Statement[];
-  /** Structure a patch renders whenever it writes the scope. */
-  patchedStructure?: boolean;
   /** Whether a patch renders every render of this signal (`patchRenders`). */
   patchRendered?: boolean;
   /** A fill's run when it differs from the render (`render` without `patched`). */
@@ -752,10 +752,24 @@ function pushForward(signal: Signal, target: Signal, statement: t.Statement) {
 export function patchRenders(signal: Signal): boolean {
   if (signal.patchRendered === undefined) {
     signal.patchRendered = false;
-    signal.patchRendered =
-      !!signal.patchedStructure || !hasClientRender(signal);
+    signal.patchRendered = patchesStructure(signal) || !hasClientRender(signal);
   }
   return signal.patchRendered;
+}
+
+// A loop or branch chain a patch renders whenever it writes the scope: its
+// bodies are the signal's branch sections, none stateful, on the branch path.
+function patchesStructure(signal: Signal) {
+  const bodies = getChildSections(signal.section).filter(
+    (child) =>
+      child.isBranch &&
+      child.sectionAccessor?.binding === signal.referencedBindings,
+  );
+  return (
+    bodies.length > 0 &&
+    isBranchPathSection(signal.section) &&
+    !bodies.some(isStatefulBranch)
+  );
 }
 
 // A patch renders a forward into a value it fills itself as well.

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -112,12 +112,6 @@ export default {
           site: tagExtra[kLoadTagBinding]!,
           load: tagExtra.tagNameLoad,
         });
-        tagExtra.tagNameLoadInput = true;
-        // Reference tracking fills these same extras later, so the fact is
-        // recorded ahead of it on each attr value.
-        for (const attr of tag.node.attributes) {
-          (attr.value.extra ??= {}).tagNameLoadInput = true;
-        }
       }
 
       if (tagExtra.tagNameLoad || !childExtra.domExports?.setupEmpty) {


### PR DESCRIPTION
A loop's or branch chain's signal carried a flag saying a patch renders it, set by the `if` and `for` translators from the section graph; `patchRenders` now finds the signal's bodies among its section's branch children (by `sectionAccessor.binding`) and judges them there. A known tag's var was marked twice: the scope offset binding the var creates already says so. A `tagNameLoad` input mark had no reader, and a return-reason accessor no caller; both are gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)