### PR TITLE
Persisted: marks record facts alone; a patch measures against its step's document

### DIFF
--- a/.sizes/dom.js
+++ b/.sizes/dom.js
@@ -2271,8 +2271,8 @@ let loads = {},
     return apply;
   });
 /**
- * The loader of a lazy template only flushes construct. Never pure: it
- * registers where no client code renders the site.
+ * The loader of a lazy template that only flushes create. Never pure: it
+ * registers where no client code renders the tag.
  */
 function _load_lazy(id, load) {
   let pending;

--- a/packages/runtime-tags/CONTEXT.md
+++ b/packages/runtime-tags/CONTEXT.md
@@ -138,9 +138,16 @@ The render coordinator that tracks async work, flushes chunks, and carries the
 abort signal. Not an error boundary.
 
 **Resume**:
-Filling scopes, adopting server-rendered nodes, rebuilding branches, and running
+Filling scopes, adopting server-rendered nodes, creating branches, and running
 effects without an initial client rerender.
 _Avoid_: hydrate, hydration
+
+**Created scope**:
+A scope a patch creates from a shell where the live page has none, seeded by
+its fills and set up by registered ids (`inits…!effects…`) in place of a
+renderer's setup; a live scope the patch writes into is _paired_. The same
+word as a client render's `createBranch`; the patch is just who creates.
+_Avoid_: construct, rebuild
 
 **Resume payload**:
 Server-emitted JavaScript data and fill operations for required scope slots,
@@ -189,9 +196,11 @@ What an expression or binding derives from: the expressions it reads and
 the bindings those read (`upstreamAlias`, `upstreamExpression`). Summarized
 by kind as its _sources_ (`Sources`: state, param, `$global`). Structure
 has an upstream too — an `<if>` condition, a `<for>` collection, a dynamic
-tag's renderer (`isBranchUpstream`) — and a root param read only there is
-_upstream of structure_.
-_Avoid_: selector, selection, selects (keyed `for` row select aside)
+tag's renderer (a branch section's `upstreamExpression`) — and a root param read only there is
+_upstream of structure_. A tag or read is _downstream_ of what it reads; the
+expressions at a tag are its call site's expressions.
+_Avoid_: selector, selection, selects (keyed `for` row select aside), site
+for a tag or read on its own
 
 **Stateful structure**:
 A branch body whose upstream expression has a state reason (main's `kStatefulReason`

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/render.debug.md
@@ -78,7 +78,7 @@ document.querySelector("button").click();
 UPDATE: main > button::text@6 "1" => "2"
 ```
 
-# Update `{"title":"Store!","show":true,"promise":{}}`
+# Update `{"title":"Store!","show":true,"promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>
@@ -142,7 +142,7 @@ document.querySelector("button").click();
 UPDATE: main > button::text@6 "2" => "3"
 ```
 
-# Update `{"title":"Open","show":true,"promise":{}}`
+# Update `{"title":"Open","show":true,"promise":{"value":"back"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/__snapshots__/render.md
@@ -78,7 +78,7 @@ document.querySelector("button").click();
 UPDATE: main > button::text@6 "1" => "2"
 ```
 
-# Update `{"title":"Store!","show":true,"promise":{}}`
+# Update `{"title":"Store!","show":true,"promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>
@@ -142,7 +142,7 @@ document.querySelector("button").click();
 UPDATE: main > button::text@6 "2" => "3"
 ```
 
-# Update `{"title":"Open","show":true,"promise":{}}`
+# Update `{"title":"Open","show":true,"promise":{"value":"back"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/test.ts
@@ -1,15 +1,9 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 const click = (document: Document) => {
   document.querySelector<HTMLButtonElement>("button")!.click();
 };
-
-const delayed = (value: string) => ({
-  then: (onFulfilled: (value: string) => unknown) =>
-    new Promise<string>((resolve) => setTimeout(resolve, 10, value)).then(
-      onFulfilled,
-    ),
-});
 
 // An `<await>` inside a server-driven `<if>`: the branch constructs from
 // its shell, then Pending/Child settle the body. Client count survives.
@@ -20,10 +14,18 @@ export const config: TestConfig = {
     click,
     { title: "Store", show: true, promise: Promise.resolve("hi") },
     click,
-    { title: "Store!", show: true, promise: delayed("slow") },
+    navigate(() => ({
+      title: "Store!",
+      show: true,
+      promise: resolveAfter("slow"),
+    })),
     { title: "Store!", show: false, promise: Promise.resolve("x") },
     click,
-    { title: "Open", show: true, promise: delayed("back") },
+    navigate(() => ({
+      title: "Open",
+      show: true,
+      promise: resolveAfter("back"),
+    })),
     click,
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/__snapshots__/render.debug.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>
@@ -28,7 +28,7 @@ REMOVE: main > em
 INSERT: main > h1 + em
 ```
 
-# Update `{"title":"Store!!","promise":{}}`
+# Update `{"title":"Store!!","promise":{"value":"slower"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/__snapshots__/render.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>
@@ -28,7 +28,7 @@ REMOVE: main > em
 INSERT: main > h1 + em
 ```
 
-# Update `{"title":"Store!!","promise":{}}`
+# Update `{"title":"Store!!","promise":{"value":"slower"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/test.ts
@@ -1,13 +1,5 @@
 import type { TestConfig } from "../../main.test";
-
-const slow = (value: string) => ({
-  // then() starts the timer so the delay begins at render, not at
-  // getSteps (which runs before the first document render).
-  then: (onFulfilled: (value: string) => unknown) =>
-    new Promise<string>((resolve) => setTimeout(resolve, 10, value)).then(
-      onFulfilled,
-    ),
-});
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 // Two consecutive responses with a pending `<await>`: the second must show
 // its pending UI again (a settle from the first response is not sticky).
@@ -15,7 +7,7 @@ export const config: TestConfig = {
   persisted: true,
   steps: () => [
     { title: "Store", promise: Promise.resolve("hi") },
-    { title: "Store!", promise: slow("slow") },
-    { title: "Store!!", promise: slow("slower") },
+    navigate(() => ({ title: "Store!", promise: resolveAfter("slow") })),
+    navigate(() => ({ title: "Store!!", promise: resolveAfter("slower") })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/render.debug.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/__snapshots__/render.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/test.ts
@@ -1,4 +1,5 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 // A patch whose `<await>` is still pending flushes ready fills now and
 // the resolved body in a later flush.
@@ -6,16 +7,6 @@ export const config: TestConfig = {
   persisted: true,
   steps: () => [
     { title: "Store", promise: Promise.resolve("hi") },
-    {
-      title: "Store!",
-      // then() starts the timer so the delay begins at render, not at
-      // getSteps (which runs before the first document render).
-      promise: {
-        then: (onFulfilled: (value: string) => unknown) =>
-          new Promise<string>((resolve) =>
-            setTimeout(resolve, 10, "slow"),
-          ).then(onFulfilled),
-      },
-    },
+    navigate(() => ({ title: "Store!", promise: resolveAfter("slow") })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/render.debug.md
@@ -7,7 +7,7 @@
 </main>
 ```
 
-# Update `{"promise":{}}`
+# Update `{"promise":{"value":{}}}`
 ```html
 <main>
   <em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/__snapshots__/render.md
@@ -7,7 +7,7 @@
 </main>
 ```
 
-# Update `{"promise":{}}`
+# Update `{"promise":{"value":{}}}`
 ```html
 <main>
   <em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/test.ts
@@ -1,4 +1,5 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, rejectAfter } from "../../utils/resolve";
 
 // A patch whose `<await>` rejects: prefix flush is pending, the error
 // arrives as a later flush and `@catch` receives it.
@@ -6,16 +7,6 @@ export const config: TestConfig = {
   persisted: true,
   steps: () => [
     { promise: Promise.resolve("hi") },
-    {
-      promise: {
-        then: (
-          _ok: (value: string) => unknown,
-          fail: (err: unknown) => unknown,
-        ) =>
-          new Promise<never>((_, reject) =>
-            setTimeout(() => reject(new Error("boom")), 10),
-          ).then(_ok, fail),
-      },
-    },
+    navigate(() => ({ promise: rejectAfter(new Error("boom")) })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/__snapshots__/render.debug.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"label":"second","promise":{}}`
+# Update `{"label":"second","promise":{"value":"slow"}}`
 ```html
 <main>
   <em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/__snapshots__/render.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"label":"second","promise":{}}`
+# Update `{"label":"second","promise":{"value":"slow"}}`
 ```html
 <main>
   <em>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/test.ts
@@ -1,4 +1,5 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 // `@placeholder` content on an interactive page renders client-side when
 // pending shows: its server read delivers as a fill, so the label is the
@@ -7,14 +8,6 @@ export const config: TestConfig = {
   persisted: true,
   steps: () => [
     { label: "first", promise: Promise.resolve("hi") },
-    {
-      label: "second",
-      promise: {
-        then: (onFulfilled: (value: string) => unknown) =>
-          new Promise<string>((resolve) =>
-            setTimeout(resolve, 10, "slow"),
-          ).then(onFulfilled),
-      },
-    },
+    navigate(() => ({ label: "second", promise: resolveAfter("slow") })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/__snapshots__/render.debug.md
@@ -19,7 +19,7 @@
 </main>
 ```
 
-# Update `{"label":"b","promise":{}}`
+# Update `{"label":"b","promise":{"value":"y"}}`
 ```html
 <main>
   <div

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/__snapshots__/render.md
@@ -19,7 +19,7 @@
 </main>
 ```
 
-# Update `{"label":"b","promise":{}}`
+# Update `{"label":"b","promise":{"value":"y"}}`
 ```html
 <main>
   <div

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/test.ts
@@ -1,4 +1,5 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 // A value the response's first flush bound (two reads) that a later flush
 // (the settled await) writes again: it references the binding, not a copy.
@@ -7,15 +8,6 @@ export const config: TestConfig = {
   skip_fresh_render: true,
   steps: () => [
     { label: "a", promise: Promise.resolve("x") },
-    {
-      label: "b",
-      // then() starts the timer so the delay begins at render.
-      promise: {
-        then: (onFulfilled: (value: string) => unknown) =>
-          new Promise<string>((resolve) => setTimeout(resolve, 10, "y")).then(
-            onFulfilled,
-          ),
-      },
-    },
+    navigate(() => ({ label: "b", promise: resolveAfter("y") })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/__snapshots__/render.debug.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/__snapshots__/render.md
@@ -10,7 +10,7 @@
 </main>
 ```
 
-# Update `{"title":"Store!","promise":{}}`
+# Update `{"title":"Store!","promise":{"value":"slow"}}`
 ```html
 <main>
   <h1>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/test.ts
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/test.ts
@@ -1,4 +1,5 @@
 import type { TestConfig } from "../../main.test";
+import { navigate, resolveAfter } from "../../utils/resolve";
 
 // Pending `<await>` inside `<try>` + `@placeholder`: the first flush
 // applies ready fills and re-enters received placeholder state; the
@@ -7,14 +8,6 @@ export const config: TestConfig = {
   persisted: true,
   steps: () => [
     { title: "Store", promise: Promise.resolve("hi") },
-    {
-      title: "Store!",
-      promise: {
-        then: (onFulfilled: (value: string) => unknown) =>
-          new Promise<string>((resolve) =>
-            setTimeout(resolve, 10, "slow"),
-          ).then(onFulfilled),
-      },
-    },
+    navigate(() => ({ title: "Store!", promise: resolveAfter("slow") })),
   ],
 };

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/dom.bundle.debug.js
@@ -77,7 +77,7 @@ const $input$1 = ($scope, input) => $input_items$1($scope, input.items);
 var page_default = /*@__PURE__*/ _template("__tests__/page.marko", $template$1, $walks$1, $setup$1, $input$1);
 
 // template.marko
-const $template = "<p>A lead long enough that the document outweighs a flush revealing the page below it.</p><!><!>";
+const $template = "<!><!><!>";
 const $walks = "b%c";
 const $setup = () => {};
 const $if_content__input_items = /*@__PURE__*/ _if_closure("#text/0", 0, ($scope) => $input_items$1($scope["#childScope/0"], $scope._.input_items));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/html.bundle.debug.js
@@ -112,16 +112,15 @@ var page_default = _template_persisted("__tests__/page.marko", (input) => {
 }, 0, 1);
 
 // template.marko
-const $template = "<p>A lead long enough that the document outweighs a flush revealing the page below it.</p><!><!>";
+const $template = "<!><!><!>";
 const $walks = "b%c";
 _shells({
-	"__tests__/template.marko": "__tests__/template.marko;b%;<p>A lead long enough that the document outweighs a flush revealing the page below it.</p><!><!>",
+	"__tests__/template.marko": "__tests__/template.marko;b%;<!><!><!>",
 	"__tests__/template.marko_1*shell": /*@__PURE__*/ ((_w0, _w1) => `__tests__/template.marko_1*shell;${_w0};${_w1}`)(/*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks$1), /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template$1))
 });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html("<p>A lead long enough that the document outweighs a flush revealing the page below it.</p>");
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
@@ -132,7 +131,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 			_scope($scope1_id, {
 				_: _scope_with_id($scope0_id),
 				"#childScope/0": _existing_scope($childScope)
-			}, "__tests__/template.marko", "4:2");
+			}, "__tests__/template.marko", "3:2");
 			return 0;
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1*shell"], $scope0_owned, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/html.bundle.js
@@ -105,13 +105,12 @@ var page_default = _template_persisted("a", (input) => {
 
 // template.marko
 _shells({
-	b: "b;b%;<p>A lead long enough that the document outweighs a flush revealing the page below it.</p><!><!>",
+	b: "b;b%;<!><!><!>",
 	b0: /*@__PURE__*/ ((_w0, _w1) => `b0;${_w0};${_w1}`)(/*@__PURE__*/ ((_w0) => `b/${_w0}&b`)($walks), /*@__PURE__*/ ((_w0) => `<!>${_w0}<!>`)($template))
 });
 var template_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html("<p>A lead long enough that the document outweighs a flush revealing the page below it.</p>");
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/render.debug.md
@@ -1,15 +1,7 @@
 # Render `{"show":false,"items":[{"n":0}],"$global":{"data":{"base":0}}}`
-```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
-```
 
 # Update `{"show":true,"items":[{"n":0},{"n":1}],"$global":{"data":{"base":0}}}`
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -46,7 +38,7 @@
 ```
 ## Change
 ```
-INSERT: p + :is(.bonus, section, section)
+INSERT: .bonus, section, section
 UPDATE: section:nth-of-type(1) > div > button::text " " => "0"
 UPDATE: section:nth-of-type(2) > div > button::text " " => "1"
 ```
@@ -56,9 +48,6 @@ UPDATE: section:nth-of-type(2) > div > button::text " " => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -103,9 +92,6 @@ UPDATE: section:nth-of-type(1) > div > button::text "0" => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -148,9 +134,6 @@ UPDATE: section:nth-of-type(2) > div > button::text "1" => "6"
 
 # Update `{"show":true,"items":[{"n":1}],"$global":{"data":{"base":2}}}`
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/render.md
@@ -1,15 +1,7 @@
 # Render `{"show":false,"items":[{"n":0}],"$global":{"data":{"base":0}}}`
-```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
-```
 
 # Update `{"show":true,"items":[{"n":0},{"n":1}],"$global":{"data":{"base":0}}}`
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -46,7 +38,7 @@
 ```
 ## Change
 ```
-INSERT: p + :is(.bonus, section, section)
+INSERT: .bonus, section, section
 UPDATE: section:nth-of-type(1) > div > button::text " " => "0"
 UPDATE: section:nth-of-type(2) > div > button::text " " => "1"
 ```
@@ -56,9 +48,6 @@ UPDATE: section:nth-of-type(2) > div > button::text " " => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -103,9 +92,6 @@ UPDATE: section:nth-of-type(1) > div > button::text "0" => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -148,9 +134,6 @@ UPDATE: section:nth-of-type(2) > div > button::text "1" => "6"
 
 # Update `{"show":true,"items":[{"n":1}],"$global":{"data":{"base":2}}}`
 ```html
-<p>
-  A lead long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/writes.debug.html
@@ -1,5 +1,4 @@
-<p>A lead long enough that the document outweighs a flush revealing the page
-  below it.</p><!--M_]1 #text/0-->
+<!--M_]1 #text/0-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/__snapshots__/writes.html
@@ -1,5 +1,4 @@
-<p>A lead long enough that the document outweighs a flush revealing the page
-  below it.</p><!--M_]1 a-->
+<!--M_]1 a-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/sizes.json
@@ -14,8 +14,8 @@
     }
   },
   "html": {
-    "min": 425,
-    "brotli": 289
+    "min": 335,
+    "brotli": 243
   },
   "patch": {
     "min": 743,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/template.marko
@@ -1,6 +1,5 @@
 import Page from "./page.marko"
 
-<p>A lead long enough that the document outweighs a flush revealing the page below it.</p>
 <if=input.show>
   <Page items=input.items/>
 </if>

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/dom.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/dom.bundle.debug.js
@@ -65,7 +65,7 @@ const $input = ($scope, input) => $input_base($scope, input.base);
 var page_default = /*@__PURE__*/ _template("__tests__/page.marko", $template, $walks, $setup, $input);
 
 // template.marko
-const $template = "<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p><!><!>";
+const $template = "<!><!><!>";
 const $walks = "b%c";
 const $setup = () => {};
 _load_lazy("ready:__tests__/page.marko", () => import("./page.mjs").then(() => {}));

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/html.bundle.debug.js
@@ -103,16 +103,15 @@ var page_default = _template_persisted("__tests__/page.marko", (input) => {
 
 // template.marko
 const $Page_withLoadAssets = withLoadAssets(page_default, "ready:__tests__/page.marko", void 0, 1);
-const $template = "<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p><!><!>";
+const $template = "<!><!><!>";
 const $walks = "b%c";
 _shells({
-	"__tests__/template.marko": "__tests__/template.marko;b%;<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p><!><!>",
+	"__tests__/template.marko": "__tests__/template.marko;b%;<!><!><!>",
 	"__tests__/template.marko_1*shell": /*@__PURE__*/ ((_w0, _w1) => `__tests__/template.marko_1*shell;${_w0};${_w1}`)(/*@__PURE__*/ ((_w0) => `b%b/${_w0}&b`)($walks$1), /*@__PURE__*/ ((_w0) => `<!><!>${_w0}<!>`)($template$1))
 });
 var template_default = _template_persisted("__tests__/template.marko", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html("<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p>");
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();
@@ -123,7 +122,7 @@ var template_default = _template_persisted("__tests__/template.marko", (input) =
 			_scope($scope1_id, {
 				_: _scope_with_id($scope0_id),
 				"#childScope/1": _existing_scope($childScope)
-			}, "__tests__/template.marko", "4:2");
+			}, "__tests__/template.marko", "3:2");
 			return 0;
 		}
 	}, $scope0_id, "#text/0", 1, $sg__input_show, $sg__input_show, void 0, void 0, ["__tests__/template.marko_1*shell"], $scope0_owned, 1);

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/html.bundle.js
@@ -96,13 +96,12 @@ var page_default = _template_persisted("a", (input) => {
 // template.marko
 const $Page_withLoadAssets = withLoadAssets(page_default, "_a", void 0, 1);
 _shells({
-	b: "b;b%;<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p><!><!>",
+	b: "b;b%;<!><!><!>",
 	b0: /*@__PURE__*/ ((_w0, _w1) => `b0;${_w0};${_w1}`)(/*@__PURE__*/ ((_w0) => `b%b/${_w0}&b`)($walks), /*@__PURE__*/ ((_w0) => `<!><!>${_w0}<!>`)($template))
 });
 var template_default = _template_persisted("b", (input) => {
 	const $scope0_owned = _persisted_ownership(), $scope0_reason = _persisted_reason(), $sg__input_show = _source_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_html("<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p>");
 	_if(() => {
 		if (input.show) {
 			const $scope1_id = _scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/render.debug.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/render.debug.md
@@ -1,15 +1,7 @@
 # Render `{"show":false,"base":0}`
-```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
-```
 
 # Update `{"show":true,"base":0}`
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -32,7 +24,7 @@
 ```
 ## Change
 ```
-INSERT: p + :is(.bonus, section)
+INSERT: .bonus, section
 INSERT: .aside > .tick
 UPDATE: .tick::text " " => "0"
 ```
@@ -42,9 +34,6 @@ UPDATE: .tick::text " " => "0"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -75,9 +64,6 @@ UPDATE: .tick::text "0" => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/render.md
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/render.md
@@ -1,15 +1,7 @@
 # Render `{"show":false,"base":0}`
-```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
-```
 
 # Update `{"show":true,"base":0}`
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -32,7 +24,7 @@
 ```
 ## Change
 ```
-INSERT: p + :is(.bonus, section)
+INSERT: .bonus, section
 INSERT: .aside > .tick
 UPDATE: .tick::text " " => "0"
 ```
@@ -42,9 +34,6 @@ UPDATE: .tick::text " " => "0"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >
@@ -75,9 +64,6 @@ UPDATE: .tick::text "0" => "1"
 document.querySelector(sel).click();
 ```
 ```html
-<p>
-  A layout's static lead, long enough that the document outweighs a flush revealing the page below it.
-</p>
 <button
   class="bonus"
 >

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/writes.debug.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/writes.debug.html
@@ -1,5 +1,4 @@
-<p>A layout's static lead, long enough that the document outweighs a flush
-  revealing the page below it.</p><!--M_]1 #text/0-->
+<!--M_]1 #text/0-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/writes.html
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/__snapshots__/writes.html
@@ -1,5 +1,4 @@
-<p>A layout's static lead, long enough that the document outweighs a flush
-  revealing the page below it.</p><!--M_]1 a-->
+<!--M_]1 a-->
 <script>
   WALKER_RUNTIME("M")("_");
   M._.r = [_ => [1, {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/sizes.json
@@ -25,8 +25,8 @@
     }
   },
   "html": {
-    "min": 436,
-    "brotli": 287
+    "min": 329,
+    "brotli": 238
   },
   "patch": {
     "min": 692,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/template.marko
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/template.marko
@@ -1,6 +1,5 @@
 import Page from "./page.marko" with { load: "render" }
 
-<p>A layout's static lead, long enough that the document outweighs a flush revealing the page below it.</p>
 <if=input.show>
   <Page base=input.base/>
 </if>

--- a/packages/runtime-tags/src/__tests__/main.test.ts
+++ b/packages/runtime-tags/src/__tests__/main.test.ts
@@ -99,8 +99,9 @@ export type TestConfig = {
   runtime_id?: string;
   /** Compiles the fixture with the `persisted` compiler option. */
   persisted?: boolean;
-  /** Persisted: skip checking each patched page against a fresh render of
-   * the same input (client effects leave state a fresh render lacks). */
+  /** Persisted: never render a step's input as a document (client effects
+   * leave state a fresh render lacks, or an input no document can serialize),
+   * so patches compare against the initial document instead. */
   skip_fresh_render?: boolean;
 };
 
@@ -477,8 +478,11 @@ function testFixtures(interop?: true) {
             // Until a client-side step diverges the page from what the
             // server would render for the same input, every applied patch
             // must leave the DOM as a fresh render of that input would.
-            let diverged = hasFlush || !!config.skip_fresh_render;
-            const assertPatchedLikeFresh = async (input: Input) => {
+            let diverged = false;
+            const freshRenders = !hasFlush && !config.skip_fresh_render;
+            // The document for a step's input: what the step's patch must
+            // cost less than, diverged or not.
+            const renderFresh = async (input: Input) => {
               const capture = captureConsole();
               const freshChunks: string[] = [];
               try {
@@ -490,6 +494,13 @@ function testFixtures(interop?: true) {
                 resetResolveState();
                 capture.cleanup();
               }
+              freshDocs[patches.length - 1] = stripDefaultScript(
+                freshChunks.join(""),
+              );
+              return freshChunks;
+            };
+            const assertPatchedLikeFresh = async (input: Input) => {
+              const freshChunks = await renderFresh(input);
               // The fresh page resumes like the live one did, so client
               // effects and reorders land on both sides.
               const fresh = createBrowser(
@@ -498,9 +509,6 @@ function testFixtures(interop?: true) {
                 rejectLoad || undefined,
               );
               browsers.push(fresh);
-              freshDocs[patches.length - 1] = stripDefaultScript(
-                freshChunks.join(""),
-              );
               const freshFlush = fresh.stream(freshChunks);
               while (freshFlush());
               await fresh.runAsyncScripts();
@@ -565,8 +573,9 @@ function testFixtures(interop?: true) {
                     }
                     patches.push(flushes.join(""));
                     tracker.logUpdate(input);
-                    if (applied && !diverged && !betweenFlushes) {
-                      await assertPatchedLikeFresh(input);
+                    if (applied && !betweenFlushes && freshRenders) {
+                      if (diverged) await renderFresh(input);
+                      else await assertPatchedLikeFresh(input);
                     }
                     if (!applied) {
                       if (!config.expect_rejection) {
@@ -819,7 +828,11 @@ async function runSteps(
         tracker.logUpdate(update);
       }
     } else if (opts.onInput) {
-      const input = isNavigate(update) ? update.navigateInput : update;
+      const input = isNavigate(update)
+        ? typeof update.navigateInput === "function"
+          ? update.navigateInput()
+          : update.navigateInput
+        : update;
       const between = isNavigate(update) ? update.betweenFlushes : undefined;
       if ((await opts.onInput(input, between)) === false) break;
     } else {

--- a/packages/runtime-tags/src/__tests__/utils/resolve.ts
+++ b/packages/runtime-tags/src/__tests__/utils/resolve.ts
@@ -96,12 +96,14 @@ export function isThrows(value: any): value is Throws {
   return typeof value === "function" && value.throws;
 }
 
+// A function input is built as the step runs, so a promise it creates
+// (`resolveAfter`) starts pending at that render rather than at setup.
 export type Navigate = {
-  navigateInput: Record<string, unknown>;
+  navigateInput: Record<string, unknown> | (() => Record<string, unknown>);
   betweenFlushes?: (document: Document) => unknown;
 };
 export function navigate(
-  input: Record<string, unknown>,
+  input: Navigate["navigateInput"],
   betweenFlushes?: (document: Document) => unknown,
 ): Navigate {
   return { navigateInput: input, betweenFlushes };

--- a/packages/runtime-tags/src/dom/load.ts
+++ b/packages/runtime-tags/src/dom/load.ts
@@ -73,7 +73,7 @@ export const _load_template = /*@__PURE__*/ withLazy(
 let loadReady: ((branch: BranchScope) => void) | undefined;
 let loadReadyFailed: typeof loadReady;
 // Installed by the persisted ready feature, whose wrappers below are the
-// only callers: a plain page carries no site start.
+// only callers: a plain page carries no lazy tag start.
 let loadStart: ((branch: BranchScope, readyId: string) => void) | undefined;
 export function installLoadReady(
   onReady: typeof loadReady,
@@ -84,8 +84,8 @@ export function installLoadReady(
   loadReadyFailed = onFailed;
   loadStart = onStart;
 }
-// A persisted page's `<${Lazy}>` site: flush data for a child this template
-// constructs waits for its clone, so its setup reports the start.
+// A persisted page's `<${Lazy}>` tag: flush data for a child a flush
+// creates here waits for its clone, so its setup reports the start.
 export const _load_ready_template = (
   readyId: string,
   template: Template & Renderer,

--- a/packages/runtime-tags/src/dom/patch-boundary.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-boundary.feat.ts
@@ -35,7 +35,7 @@ import {
   getRegisteredWithScope,
   patchers,
   patchScope,
-  withConstructing,
+  withCreating,
 } from "./resume";
 import {
   collectScopes,
@@ -149,11 +149,11 @@ patchers[PatchKey.Pending] = (scope, key, value) => {
   const accessor = key.slice(PatchKey.Pending.length);
   const link = (AccessorPrefix.BranchScopes + accessor) as Accessor;
   // The server now owns this await flush. Invalidate a promise started while
-  // setting up a newly constructed parent body so its stale resolution drops.
+  // setting up a newly created parent body so its stale resolution drops.
   scope[(AccessorPrefix.Promise + accessor) as Accessor] = 0 as never;
   // A settle from an earlier response must not hide this flush's pending UI.
   settled.get(scope)?.delete(accessor);
-  // A construct has no live await branch: the entry's id names the body
+  // A created scope has no live await branch: the entry's id names the body
   // content shell its flush shipped. Mirrors `_await_content`.
   if (typeof value === "string" && !scope[link]) {
     const renderer = getShellContent(shells[value]);
@@ -198,7 +198,7 @@ function attachDetachedAwait(
     renderer[RendererProp.Setup]?.(awaitBranch);
     // A shell content's walk created the body's scopes with no setup.
     if ((renderer as { [RendererProp.Shell]?: 1 })[RendererProp.Shell]) {
-      withConstructing(applyChildPartial);
+      withCreating(applyChildPartial);
     } else {
       applyChildPartial();
     }
@@ -237,7 +237,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
     dismissPlaceholder(scope[link] as BranchScope);
   }
   // A boundary entry `[partial, contentId, catchId?, placeholderId?]`
-  // rebuilds a missing branch from its content id, then applies the partial.
+  // creates a missing branch from its content id, then applies the partial.
   if (Array.isArray(value)) {
     const [partial, contentId, catchId, placeholderId] = value;
     value = partial;
@@ -273,7 +273,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
         ) as never;
       }
       if (shell) {
-        withConstructing(() => patchScope(value as Scope, branch));
+        withCreating(() => patchScope(value as Scope, branch));
       } else {
         patchScope(value as Scope, branch);
       }
@@ -285,7 +285,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
     else patchScope(value as Scope, scope[link] as Scope);
     markSettled(scope, accessor);
   };
-  // A newly constructed await body may itself initialize nested boundaries.
+  // A newly created await body may itself initialize nested boundaries.
   // Run that setup before applying the settled child partial.
   if (!attachDetachedAwait(scope, accessor, apply)) {
     apply();

--- a/packages/runtime-tags/src/dom/patch-branch.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-branch.feat.ts
@@ -10,7 +10,7 @@ import {
 import { insertChildNodes } from "./dom";
 import { getShellContent, type Shell, shells } from "./patch-shells";
 import { createAndSetupBranch } from "./renderer";
-import { withConstructing, patchers, patchScope } from "./resume";
+import { withCreating, patchers, patchScope } from "./resume";
 import { removeAndDestroyBranch } from "./scope";
 
 declare module "./resume" {
@@ -59,11 +59,11 @@ patchers[PatchKey.Branch] = (scope, key, entry) => {
     patchScope(branchPartial, liveBranch as Scope);
   } else {
     // Every branch on the patch path ships a shell (`buildShells`).
-    construct(scope, branchKey, branchPartial, shells[shellId!]);
+    create(scope, branchKey, branchPartial, shells[shellId!]);
   }
 };
 
-function construct(
+function create(
   scope: Scope,
   branchKey: Accessor,
   branchPartial: Scope,
@@ -94,9 +94,9 @@ function construct(
   if (!branch[AccessorProp.StartNode].parentNode) {
     parentNode.cloneNode().appendChild(branch[AccessorProp.StartNode]);
   }
-  // Nested entries construct recursively (no live children); applied before
+  // Nested entries create recursively (no live children); applied before
   // insertion so a script's attributes (its nonce) are set when it runs.
-  withConstructing(() => patchScope(branchPartial, branch as Scope));
+  withCreating(() => patchScope(branchPartial, branch as Scope));
   insertChildNodes(
     parentNode,
     inside ? null : marker,

--- a/packages/runtime-tags/src/dom/patch-child.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-child.feat.ts
@@ -9,7 +9,7 @@ import {
   patchers,
   patchRun,
   patchScope,
-  withConstructing,
+  withCreating,
 } from "./resume";
 
 declare module "./resume" {
@@ -36,9 +36,9 @@ patchers[PatchKey.Child] = (scope, key, value) => {
   }
   child[AccessorProp.Owner] ??= scope;
   // A scope this flush's shell walk created is bare (no render set it up):
-  // its entries construct, like the branch's own; a live one pairs.
+  // its entries create, like the branch's own; a live one pairs.
   if (child[AccessorProp.Gen] >= patchRun) {
-    withConstructing(() => patchScope(value as Scope, child));
+    withCreating(() => patchScope(value as Scope, child));
   } else {
     patchScope(value as Scope, child);
   }

--- a/packages/runtime-tags/src/dom/patch-content.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-content.feat.ts
@@ -3,7 +3,7 @@ import type { Scope } from "../common/types";
 import { getShellContent, registerShell, shells } from "./patch-shells";
 import { _resume } from "./resume";
 
-// Rebuilds content from an in-band shell, so resume can dereference
+// Creates content from an in-band shell, so resume can dereference
 // a static body or boundary content with no template dom module.
 _resume(CONTENT_REGISTER_ID, (shell: string, owner?: Scope) => {
   const id = registerShell(shell);

--- a/packages/runtime-tags/src/dom/patch-control.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-control.feat.ts
@@ -10,7 +10,7 @@ import { queueRender } from "./queue";
 import { patchers } from "./resume";
 
 // Kind-keyed control applies (wire key `kind + accessor`), filled by the
-// per-kind feats; queued as a RENDER so fresh constructs take first-render.
+// per-kind feats; queued as a RENDER so freshly created scopes take first-render.
 export const patchControls: {
   [T in ControlledType]?: (
     scope: Scope,

--- a/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
@@ -12,12 +12,12 @@ import { _dynamic_tag } from "./control-flow";
 import "./patch-child.feat";
 import { getShellContent, shells } from "./patch-shells";
 import type { Renderer } from "./renderer";
-import { constructPatchers, getRegisteredWithScope, patchers } from "./resume";
+import { createPatchers, getRegisteredWithScope, patchers } from "./resume";
 
 // `[renderer, input, contentId, varId]`, a lone renderer bare; a native tag
 // name is `["div"]` alone or `>div` in a longer entry, array input is args,
 // and shipped content `^id` binds to the owner one `^` up per hop.
-patchers[PatchKey.DynamicTag] = constructPatchers[PatchKey.DynamicTag] = (
+patchers[PatchKey.DynamicTag] = createPatchers[PatchKey.DynamicTag] = (
   scope,
   key,
   entry,
@@ -73,7 +73,7 @@ patchers[PatchKey.DynamicTag] = constructPatchers[PatchKey.DynamicTag] = (
 };
 
 // A shipped shell builds the content, bound to a forwarded body's owner; a
-// registered one (the page has its renderer) binds to the site's scope,
+// registered one (the page has its renderer) binds to the tag's scope,
 // which owns body content.
 function resolveContent(id: string, owner: Scope, bind?: boolean) {
   const shell = shells[id];

--- a/packages/runtime-tags/src/dom/patch-load.ts
+++ b/packages/runtime-tags/src/dom/patch-load.ts
@@ -1,12 +1,12 @@
 import { ready, readyFailed } from "./resume";
 
-// Loaders of the lazy templates only flushes construct, by channel: the ready
+// Loaders of the lazy templates that only flushes create, by channel: the ready
 // feature starts one when a flush waits on its channel.
 export const loads: Record<string, () => void> = {};
 
 /**
- * The loader of a lazy template only flushes construct. Never pure: it
- * registers where no client code renders the site.
+ * The loader of a lazy template that only flushes create. Never pure: it
+ * registers where no client code renders the tag.
  */
 export function _load_lazy(id: string, load: () => Promise<unknown>) {
   let pending: Promise<unknown> | undefined;

--- a/packages/runtime-tags/src/dom/patch-loop.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-loop.feat.ts
@@ -2,7 +2,7 @@ import { encodeAccessor } from "../common/helpers";
 import { type Accessor, PatchKey, type Scope } from "../common/types";
 import { _for_of } from "./control-flow";
 import { shells } from "./patch-shells";
-import { patchers, patchScope, withConstructing } from "./resume";
+import { patchers, patchScope, withCreating } from "./resume";
 
 declare module "./resume" {
   interface PatchValues {
@@ -26,11 +26,11 @@ patchers[PatchKey.Loop] = (scope, key, value) => {
     partials.push(value[i++] as Scope);
   }
   const suffix = key.slice(PatchKey.Loop.length) as Accessor;
-  // A loop with a shell constructs additions; one whose items pair only
+  // A loop with a shell creates additions; one whose items pair only
   // (a stateful body) ships none and never adds.
   const [template, walks, setup] = shells[shellId!] || [];
   // The reconciler applies the patch: `params` walks each partial into its
-  // paired/constructed branch, and setup attaches effects to fresh ones.
+  // paired/created branch, and setup attaches effects to fresh ones.
   const apply = () =>
     _for_of(
       (MARKO_DEBUG ? suffix : encodeAccessor(suffix)) as never,
@@ -43,6 +43,6 @@ patchers[PatchKey.Loop] = (scope, key, value) => {
       scope,
       keys ? [partials, (_partial: unknown, i: number) => keys[i]] : [partials],
     );
-  if (shellId) withConstructing(apply);
+  if (shellId) withCreating(apply);
   else apply();
 };

--- a/packages/runtime-tags/src/dom/patch-ready.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-ready.feat.ts
@@ -34,7 +34,7 @@ interface ReadyPatch {
   [ReadyPatchProp.Run]: number;
 }
 const readyPatches = new Map<RenderData, ReadyPatch>();
-// Sites still cloning their child, by channel: the channel is unready
+// Lazy tags still cloning their child, by channel: the channel is unready
 // (its data blocks like a still-loading module's) until the last lands.
 const loading: Record<string, number> = {};
 
@@ -42,7 +42,7 @@ const loading: Record<string, number> = {};
 // import once per program with a lazy load import in a persisted build.
 installPatchReady(commitReady, pendingReady, discardReady);
 installReady(markReady, failReady);
-// Every lazy site of a persisted page stamps its channel as it starts cloning
+// Every lazy tag of a persisted page stamps its channel as it starts cloning
 // (`_load_ready`, `_load_ready_template`) and reports its insert or failure.
 installLoadReady(
   (branch) => {
@@ -62,12 +62,12 @@ installLoadReady(
   },
 );
 
-// The flush's run may construct a site of the channel (a returning lazy
+// The flush's run may create a tag of the channel (a returning lazy
 // tag), so a guard applies at commit, after the run, channels settled.
 let pendingGuards: Record<string, Guards> = {};
 patchers[PatchKey.Ready] = (scope, key, entries) => {
   const readyId = key.slice(PatchKey.Ready.length);
-  // A site whose module died at page load stays inert: a flush targeting
+  // A lazy tag whose module died at page load stays inert: a flush targeting
   // it could never apply, so it rejects (the caller navigates).
   if (failed.has(readyId)) {
     if (MARKO_DEBUG) {
@@ -131,7 +131,7 @@ function markReady(readyId: string) {
         patch[ReadyPatchProp.Run],
         () => {
           // Applied guards leave the map; channels they register (content
-          // nested in a lazy site) join it after this loop and hold the
+          // nested in a lazy tag) join it after this loop and hold the
           // patch open.
           for (const [id, channel] of channels) {
             channels.delete(id);

--- a/packages/runtime-tags/src/dom/patch-shells.ts
+++ b/packages/runtime-tags/src/dom/patch-shells.ts
@@ -9,10 +9,10 @@ import { queueEffect } from "./queue";
 import { _content as content } from "./renderer";
 import {
   _patch_shells,
-  constructing,
-  constructPatchers,
+  creating,
+  createPatchers,
   getRegisteredWithScope,
-  patchConstruct,
+  patchCreated,
   patchers,
   patchRun,
 } from "./resume";
@@ -29,16 +29,16 @@ declare module "./resume" {
 const _content = /*@__PURE__*/ withBranches(content);
 
 // A scope this flush created (`Gen` since the flush's run, met while
-// constructing) has no render coming, so its setup applies now; a fresh
+// creating) has no render coming, so its setup applies now; a fresh
 // branch's queued shell setup runs after, over the applied values.
 patchers[PatchKey.Setup] = (scope, _key, value) => {
-  if (constructing && scope[AccessorProp.Gen] >= patchRun) {
-    patchConstruct(value, scope);
+  if (creating && scope[AccessorProp.Gen] >= patchRun) {
+    patchCreated(value, scope);
   }
 };
 // Ids the flush asks a fresh scope to run, in the shell's grammar
 // (`inits…!effects…`): a child's mounts, a client-upstream local's inits.
-constructPatchers[PatchKey.Init] = (scope, _key, ids) =>
+createPatchers[PatchKey.Init] = (scope, _key, ids) =>
   runSetupIds(resolveSetupIds(ids), scope);
 
 type SetupFn = (branch: Scope) => void;

--- a/packages/runtime-tags/src/dom/patch-style.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-style.feat.ts
@@ -6,7 +6,7 @@ patchers[PatchKey.Style] = (scope, key, value) => {
   const at = key.indexOf(" ");
   const accessor = key.slice(PatchKey.Style.length, at) as Accessor;
   const element = scope[accessor] as HTMLStyleElement;
-  // A constructed scope ran no setup: its style still needs the shell rule.
+  // A created scope ran no setup: its style still needs the shell rule.
   if (!element.textContent) _style_shell(scope, accessor);
   _style_rule_item(element, key.slice(at + 1), value);
 };

--- a/packages/runtime-tags/src/dom/patch-value.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-value.feat.ts
@@ -3,7 +3,7 @@ import { type Opt, toArray } from "../common/opt";
 import type { Accessor, Scope } from "../common/types";
 import { AccessorProp, PatchKey } from "../common/types";
 import { queueEffect } from "./queue";
-import { constructPatchers, getRegisteredWithScope, patchers } from "./resume";
+import { createPatchers, getRegisteredWithScope, patchers } from "./resume";
 import { patchFills } from "./signals";
 
 declare module "./resume" {
@@ -17,14 +17,14 @@ declare module "./resume" {
 }
 
 // A soft miss is a fill whose intersection was tree-shaken: nothing to
-// update. A construct's seed is required, so a miss crashes to reject.
+// update. A created scope's seed is required, so a miss crashes to reject.
 patchers[PatchKey.Value] = (scope, key, value) =>
   patchFills[key.slice(PatchKey.Value.length)]?.(scope, value);
-constructPatchers[PatchKey.Value] = (scope, key, value) =>
+createPatchers[PatchKey.Value] = (scope, key, value) =>
   patchFills[key.slice(PatchKey.Value.length)](scope, value);
 
 // A bind installs a handler the way CSR setup does, after the apply so
-// freshly constructed targets exist. The path walks from the site to the
+// freshly created targets exist. The path walks from the tag's scope to the
 // registered scope: owner hops up, then links (keyed for loops) down.
 patchers[PatchKey.Bind] = (scope, _key, entry) => {
   queueEffect(scope, (scope) => {

--- a/packages/runtime-tags/src/dom/patch-var.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-var.feat.ts
@@ -1,5 +1,5 @@
 import { AccessorProp, PatchKey, type Scope } from "../common/types";
-import { constructPatchers, getRegisteredWithScope } from "./resume";
+import { createPatchers, getRegisteredWithScope } from "./resume";
 
 declare module "./resume" {
   interface PatchValues {
@@ -8,7 +8,7 @@ declare module "./resume" {
 }
 
 // The wiring a child's `_return` writes through, registered at its owner.
-constructPatchers[PatchKey.Var] = (scope, _key, id) => {
+createPatchers[PatchKey.Var] = (scope, _key, id) => {
   scope[AccessorProp.TagVariable] = getRegisteredWithScope<
     (owner: Scope) => unknown
   >(id)(scope[AccessorProp.Owner]!);

--- a/packages/runtime-tags/src/dom/patch-write.ts
+++ b/packages/runtime-tags/src/dom/patch-write.ts
@@ -1,10 +1,10 @@
 import type { Accessor } from "../common/types";
 import { PatchKey } from "../common/types";
 import { patchWrite } from "./patch";
-import { constructPatchers, patchers } from "./resume";
+import { createPatchers, patchers } from "./resume";
 
 // Plain patched writes, shared by every feat whose entries carry them.
-constructPatchers[PatchKey.Write] = patchers[PatchKey.Write] = (
+createPatchers[PatchKey.Write] = patchers[PatchKey.Write] = (
   scope,
   key,
   value,

--- a/packages/runtime-tags/src/dom/patch.ts
+++ b/packages/runtime-tags/src/dom/patch.ts
@@ -58,7 +58,7 @@ export function patch($global: PatchGlobal) {
     beginPatch(curRenders[$global.renderId]);
     // A flush writes ready batches as `R.b[id]=[...]`, into the bucket the
     // document's first batch created (`writeReady`). A document that never
-    // wrote one (no lazy site rendered) has no bucket, so the flush's first
+    // wrote one (no lazy tag rendered) has no bucket, so the flush's first
     // batch would throw; a flush cannot know, so the page ensures it.
     patchRender.b ||= {};
     try {

--- a/packages/runtime-tags/src/dom/resume.ts
+++ b/packages/runtime-tags/src/dom/resume.ts
@@ -85,21 +85,21 @@ export const _patch_shells = (handler: NonNullable<typeof onPatchShell>) =>
 export const failPatch = () => {
   throw 0;
 };
-// Construct application dispatch: everything in a setup envelope is
+// Created-scope application dispatch: everything in a setup envelope is
 // REQUIRED (a shaken fill via `patchers` is a correct no-op).
-export const constructPatchers: typeof patchers = {};
-export const patchConstruct = (setup: Scope, live: Scope) => {
+export const createPatchers: typeof patchers = {};
+export const patchCreated = (setup: Scope, live: Scope) => {
   for (const key in setup) {
     if (MARKO_DEBUG) {
       const kind =
         key.indexOf(":") > 0 ? key.slice(0, key.indexOf(":") + 1) : key[0];
-      if (!constructPatchers[kind as PatchKind]) {
+      if (!createPatchers[kind as PatchKind]) {
         throw new Error(
           `No patcher applies "${key}": the live page has no "${kind}" feature.`,
         );
       }
     }
-    constructPatchers[
+    createPatchers[
       (MARKO_DEBUG && key.indexOf(":") > 0
         ? key.slice(0, key.indexOf(":") + 1)
         : key[0]) as PatchKind
@@ -144,7 +144,7 @@ let lazyEnabled: undefined | 1;
 export let patchRender!: RenderData;
 let patching: 0 | 1 = 0;
 // The run the flush began on: a scope created since is the flush's own
-// construct (its entries construct); a deferred apply restores its flush's.
+// creation (its entries create); a deferred apply restores its flush's.
 export let patchRun = 0;
 
 export function beginPatch(render: RenderData, runAt = runId) {
@@ -161,13 +161,13 @@ export function abortPatch() {
 }
 // Set while a partial applies to a tree a shell's walk just created: fresh
 // scopes met then have no renderer to set them up (see `PatchKey.Setup`).
-export let constructing = 0;
-export function withConstructing<T>(fn: () => T) {
-  constructing++;
+export let creating = 0;
+export function withCreating<T>(fn: () => T) {
+  creating++;
   try {
     return fn();
   } finally {
-    constructing--;
+    creating--;
   }
 }
 
@@ -681,7 +681,7 @@ export function _resume<T>(id: string, obj: T): T {
   return (registeredValues[id] = obj);
 }
 
-// A fill closure's construct init is the arrival at each join downstream:
+// A fill closure's creation init is the arrival at each join downstream:
 // registered from the join's own fill wrapper, so it lives exactly as long.
 export function _init_join<T extends (scope: Scope) => void>(
   id: string,

--- a/packages/runtime-tags/src/dom/signals.ts
+++ b/packages/runtime-tags/src/dom/signals.ts
@@ -532,8 +532,8 @@ export function _closure_get(
   return closureSignal;
 }
 
-// Construct INIT registration fused into the closure helpers: pure call
-// sites let tree shaking drop signal and registration together (fail closed).
+// Creation INIT registration fused into the closure helpers: pure call
+// callers let tree shaking drop signal and registration together (fail closed).
 export function _init_closure_get(
   initId: string,
   valueAccessor: EncodedAccessor,

--- a/packages/runtime-tags/src/html/dynamic-tag.ts
+++ b/packages/runtime-tags/src/html/dynamic-tag.ts
@@ -52,17 +52,17 @@ export let _dynamic_tag = (
   content?: (() => void) | 0,
   inputIsArgs?: 1,
   serializeReason?: 1 | 0,
-  // How a patch treats the site: `1` pairs and re-renders it, `2` skips
+  // How a patch treats the tag: `1` pairs and re-renders it, `2` skips
   // it (a client-owned group is upstream of the renderer), absent never patches.
   patchPairing?: 1 | 2,
 ) => {
   const shouldResume = serializeReason !== 0;
-  // A patch entry may target this site: its branch marks and pairs, while
-  // the child's data still serializes on the site's own reason.
+  // A patch entry may target this tag: its branch marks and pairs, while
+  // the child's data still serializes on the tag's own reason.
   const marks = shouldResume || patchPairing;
   const renderer = normalizeDynamicRenderer<ServerRenderer>(tag);
   const state = getState()!;
-  // A patch render skips a site it never pairs (state or a client-owned
+  // A patch render skips a tag it never pairs (state or a client-owned
   // group upstream): the resumed page renders it, as with `writeBranch`.
   if (patchPairing !== 1 && state.writesPatches) return;
   const branchId = _peek_scope_id();
@@ -200,7 +200,7 @@ export let _dynamic_tag = (
         );
       }
     };
-    // A site no patch pairs renders unpatched: the resumed page
+    // A tag no patch pairs renders unpatched: the resumed page
     // re-renders it, so no patch fills its reads.
     if (patchPairing !== 1 && state.persisted) withUnpatched(renderNative);
     else renderNative();
@@ -260,7 +260,7 @@ export let _dynamic_tag = (
   }
 
   if (rendered) {
-    // A patched site keeps its key so a shell pairs by id alone.
+    // A patched tag keeps its key so a shell pairs by id alone.
     if (
       shouldResume ||
       (patchPairing &&
@@ -281,7 +281,7 @@ export let _dynamic_tag = (
 export function _content(id: string, fn: ServerRenderer, scopeId?: number) {
   // Also called at module load (template definitions), outside any render.
   const state = getChunk()?.boundary.state;
-  if (state?.writesPatches) (state.createdContents ??= new Set()).add(id);
+  if (state?.writesPatches) (state.definedContents ??= new Set()).add(id);
   return content(id, fn, scopeId);
 }
 

--- a/packages/runtime-tags/src/html/patch.ts
+++ b/packages/runtime-tags/src/html/patch.ts
@@ -225,7 +225,7 @@ class PatchState extends State {
   }
 
   // Ships the branch index, partial, and (once per response) the shell
-  // so the client can construct on divergence without bundling content.
+  // so the client can create on divergence without bundling content.
   override writeBranch(
     scopeId: number,
     accessor: string,
@@ -278,7 +278,7 @@ class PatchState extends State {
   }
 
   // Ships ordered item partials and keys: existing keys pair, new keys
-  // construct from the shell, absent keys destroy.
+  // create from the shell, absent keys destroy.
   override writeLoop(
     iterate: (
       each: (
@@ -452,7 +452,7 @@ export function _patch_value(
         );
       }
       // Setup entries nest under `s`: the client applies them only to
-      // freshly constructed scopes; only a scope below a branch constructs.
+      // freshly created scopes; only a scope below a branch is created.
       if (!isInResumedBranch()) return "";
       const partial = patchPartial(state, scopeId);
       ((partial[PatchKey.Setup] ??= {}) as Record<string, unknown>)[
@@ -496,7 +496,7 @@ export function _patch_control(
 }
 
 // Handler wiring: a scope-bound registration ships as a bind entry, any
-// other value rides the construct seeds as a plain write.
+// other value rides the creation seeds as a plain write.
 export function _patch_bind(
   scopeId: number,
   accessor: Accessor,
@@ -510,7 +510,7 @@ export function _patch_bind(
     const bound =
       registered && (registered.scope as ScopeInternals | undefined);
     if (bound) {
-      // A scope-bound registration is reached from the site: owner hops up
+      // A scope-bound registration is reached from the tag's scope: owner hops up
       // (a content body's owner is where it was defined) to the nearest
       // shared scope, then render links down to the bound scope.
       const links = state.patchLinks;
@@ -544,7 +544,7 @@ export function _patch_bind(
       });
     } else {
       // Both forms: the plain write clears paired scopes' slots, while the setup
-      // entry lands after a construct's seeds (which reset the change slot).
+      // entry lands after a created scope's seeds (which reset the change slot).
       writeEmbeddedBinds(state, value);
       const partial = patchPartial(state, scopeId);
       partial[PatchKey.Write + accessor] = value;
@@ -626,7 +626,7 @@ export function _patch_dynamic_tag(
       if (bound) writeEmbeddedBinds(state, renderer);
       const native = typeof renderer === "string";
       // Shipped content closes over its owner: a `^` per hop up from the
-      // site (a body forwarded through tags) rebuilds that link on construct.
+      // tag (a body forwarded through tags) restores that link on creation.
       const entry: unknown[] = [
         bound
           ? renderer
@@ -651,7 +651,7 @@ export function _patch_dynamic_tag(
       });
     }
   }
-  // How a patch treats the site (`_dynamic_tag`'s `patchPairing`): `1` pairs it,
+  // How a patch treats the tag (`_dynamic_tag`'s `patchPairing`): `1` pairs it,
   // `2` skips it (a client-owned group is upstream of the renderer).
   return _client_guard(owned, group!) ? 2 : 1;
 }
@@ -904,10 +904,10 @@ function patchStringAttr(
 }
 
 // Whether a consumer withheld a content renderer the flush handed it
-// (created, never invoked): server values inside fill then.
+// (handed over, never invoked): server values inside fill then.
 export function _content_withheld(id: string) {
   const state = getState() as PatchState;
-  return !!state.createdContents?.has(id) && !state.renderedContents?.has(id);
+  return !!state.definedContents?.has(id) && !state.renderedContents?.has(id);
 }
 
 function writeFilled(
@@ -922,7 +922,7 @@ function writeFilled(
 
 // Only a shell the server can ship rides an entry: a missing one makes a
 // divergence unapplyable and the client rejects the patch.
-// The owner chain from a site: each hop is the scope's client `_`.
+// The owner chain from a tag's scope: each hop is the scope's client `_`.
 function ownerHops(state: State, scopeId: number, ownerId?: number) {
   let up = 0;
   for (let cur: number | undefined = scopeId; cur !== ownerId; up++) {

--- a/packages/runtime-tags/src/html/shells.ts
+++ b/packages/runtime-tags/src/html/shells.ts
@@ -1,5 +1,5 @@
 // Shells (`id marker;walks;template`): raw for the server's static
-// renders, quoted once per response as flush list members for constructs.
+// renders, quoted once per response as flush list members to create from.
 export const rawShells: Record<string, string> = {};
 export const shells: Record<string, string> = {};
 

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -223,7 +223,7 @@ export function _script(
   $chunk.boundary.state.needsMainRuntime = true;
   $chunk.writeEffect(scopeId, registryId);
   // Paired scopes keep their effects and a branch's ride its shell; a scope
-  // a construct creates below a branch (a child instance) mounts from setup.
+  // a creation below a branch (a child instance) mounts from setup.
   const { state } = $chunk.boundary;
   if (
     state.writesPatches &&
@@ -440,7 +440,7 @@ export function patchPartial(
     const pending = link?.[2];
     if (serializeState.readyId && !pending) {
       // A channel's entries nest under their parent's entry in the channel's
-      // own tree (a parent the channel constructs must apply first), up to the
+      // own tree (a parent the channel creates must apply first), up to the
       // root, whose guard sits in the enclosing tree under the channel's key.
       if (scopeId === state.rootScopeId) {
         return (partials[scopeId] = (patchPartial(
@@ -461,13 +461,13 @@ export function patchPartial(
           {}) as Record<string, unknown>;
       }
       // No linkable hop (keyed loop items): the write rides the main tree, so
-      // construct data naming an unregistered id rejects at apply.
+      // creation data naming an unregistered id rejects at apply.
       return patchPartial(state, scopeId, state);
     }
     partial = partials[scopeId] = {};
     if (pending) {
       // A child links into its parent's entry on its first write; boundary
-      // construct ids ride it and a paired branch ignores them.
+      // creation ids ride it and a paired branch ignores them.
       const [parentScopeId, , key, contentId, slotIds] =
         link as Required<PatchLink>;
       if (contentId) {
@@ -586,7 +586,7 @@ export function _var(
   writeScopePassive(parentScopeId, { [scopeOffsetAccessor]: _scope_id() });
   // TODO: if the return value is already registered, use that.
   const wiring = _resume({}, registryId, parentScopeId);
-  // A constructed child gets the same wiring as a resumed one: a seed bound
+  // A created child gets the same wiring as a resumed one: a seed bound
   // to the parent's registration, so no separate init registers for it.
   const state = getState();
   if (state.writesPatches && isInResumedBranch()) {
@@ -837,7 +837,7 @@ function forBranches(
     iterate = (each) => withUnpatched(() => run(each));
   }
   // A patchable loop's markers must resume even on a page with no other
-  // client code: a patch pairs and constructs through them.
+  // client code: a patch pairs and creates through them.
   if (shellId !== undefined) $chunk.needsWalk = true;
   if (MARKO_DEBUG) {
     // eslint-disable-next-line no-var
@@ -941,7 +941,7 @@ export function _if(
   )
     return;
   // A patchable conditional's markers must resume even on a page with no
-  // other client code: a patch pairs and constructs through them.
+  // other client code: a patch pairs and creates through them.
   if (shellIds) $chunk.needsWalk = true;
   // A shell-less branch, or one with a client-owned group upstream, is the
   // resumed page's to render: no patch fills its reads.
@@ -1121,7 +1121,7 @@ export function _global_subscribe(id: string, scopeId: number, unfilled?: 1) {
   const { state } = $chunk.boundary;
   if (!unfilled && !inUnpatched()) return;
   // A flush's scopes are live already (paired) or subscribe as they render
-  // (constructed); the flush re-ships every global they could read.
+  // (created); the flush re-ships every global they could read.
   if (state.writesPatches) return;
   const key = AccessorPrefix.ClosureScopes + id;
   let subscribers = (state.globalSubscribers ??= {})[key];
@@ -1316,12 +1316,12 @@ export function _await<T>(
 ) {
   const writesPatches = $chunk.boundary.state.writesPatches;
   // `0`: a client-owned thenable, resolved by `_await_promise`. A string is
-  // the body's content id, letting a construct build the await branch.
+  // the body's content id, letting a created scope build the await branch.
   if (writesPatches && patchContent === 0) return;
   const resumeMarker = serializeMarker !== 0 || writesPatches;
-  // A construct resolves the body from this shipped shell (a settled value
+  // A created scope resolves the body from this shipped shell (a settled value
   // included); an always-pairing body outside divergent contexts never
-  // constructs.
+  // is created.
   const { boundary } = $chunk;
   const writePending = () => {
     const elide = alwaysPairs && !isInResumedBranch();
@@ -1447,7 +1447,7 @@ export function _try(
   // A patch shows `@placeholder`/`@catch` from received client state;
   // the document reorder/`<t hidden>` path must not ride the flush stream.
   const { writesPatches } = state;
-  // Construct payload (content id + slot ids, `0` = elided catch) rides the
+  // Creation payload (content id + slot ids, `0` = elided catch) rides the
   // pairing entry, except for always-pairing branches outside divergence.
   const elide = alwaysPairs && !isInResumedBranch();
   let trySlotIds: (string | 0 | undefined)[] | undefined;
@@ -1772,7 +1772,7 @@ export class State implements SerializeState {
   public globalSubscribers?: Record<string, Set<ScopeInternals>>;
   // Content renderers a flush created and invoked (by id): one created but
   // never invoked was withheld by its consumer, so its values fill.
-  public createdContents?: Set<string>;
+  public definedContents?: Set<string>;
   public renderedContents?: Set<string>;
   public flushScopes = false;
   public writeScopes: Record<number, PartialScope> = {};
@@ -1981,7 +1981,7 @@ export class Chunk {
 
   writeEffect(scopeId: number, registryId: string) {
     // A patch never ships effects: paired scopes attached theirs when the
-    // page resumed, and a fresh construct attaches its shell's.
+    // page resumed, and a freshly created scope attaches its shell's.
     if (this.boundary.state.writesPatches) return;
     countResumeWrite(this.boundary);
     if (this.lastEffect === registryId) {
@@ -2190,7 +2190,7 @@ export class Chunk {
     let needsWalk = state.walkOnNextFlush;
     if (needsWalk) {
       state.walkOnNextFlush = false;
-      // A walk with nothing else to resume (a persisted site that only
+      // A walk with nothing else to resume (a persisted lazy tag that only
       // records its node) still runs on the runtime.
       state.needsMainRuntime = true;
     }

--- a/packages/runtime-tags/src/translator/core/await.ts
+++ b/packages/runtime-tags/src/translator/core/await.ts
@@ -127,7 +127,7 @@ export default {
     // when this template module does not load (a scriptless persisted await).
     if (isPersisted()) {
       addRuntimeFeatureAsset("patch-boundary");
-      // A scriptless construct paints the settled body via text fills.
+      // A scriptless created scope paints the settled body via text fills.
       addRuntimeFeatureAsset("patch-text");
       (section.awaits ??= []).push({
         binding: tagExtra[kDOMBinding]!,
@@ -215,7 +215,7 @@ export default {
                     ),
                 patchContent,
                 // An always-pairing body's Pending entry drops its
-                // construct id outside divergent contexts.
+                // creation id outside divergent contexts.
                 ...(isPersisted() &&
                 bodySection &&
                 boundaryAlwaysPairs(bodySection)
@@ -263,7 +263,7 @@ export default {
             t.variableDeclaration("const", [
               t.variableDeclarator(
                 t.identifier(bodySection.name),
-                // Constructs resolve body content from the flush's shipped
+                // Created scopes resolve body content from the flush's shipped
                 // shell; registering here would bundle html resume elides.
                 awaitContent,
               ),

--- a/packages/runtime-tags/src/translator/core/for.ts
+++ b/packages/runtime-tags/src/translator/core/for.ts
@@ -373,7 +373,7 @@ export default {
           }
 
           if (persistedPatch) {
-            // Item body shell id so patches can construct additions; the two
+            // Item body shell id so patches can create additions; the two
             // optional marker args are always unset here.
             const id = getShellId(bodySection);
             forTagArgs.push(

--- a/packages/runtime-tags/src/translator/core/if.ts
+++ b/packages/runtime-tags/src/translator/core/if.ts
@@ -208,7 +208,7 @@ export const IfTag = {
           const persistedPatch =
             isPersisted() && !stateful && isBranchPathSection(ifTagSection);
           // A patched chain pairs and reports its branch even with a
-          // source-less test (a constant pick): a construct needs the entry.
+          // source-less test (a constant pick): a created scope needs the entry.
           let branchSerializeReasons: SerializeReasons | undefined =
             persistedPatch || undefined;
           if (persistedPatch) {
@@ -320,7 +320,7 @@ export const IfTag = {
                     : undefined,
                 singleChild ? t.numericLiteral(1) : undefined,
                 // Shell ids per branch index: a patch ships the shell so the
-                // client constructs diverged branches without bundling them.
+                // client creates diverged branches without bundling them.
                 persistedPatch
                   ? t.arrayExpression(
                       branches.map(([, branchBody]) => {

--- a/packages/runtime-tags/src/translator/core/let.ts
+++ b/packages/runtime-tags/src/translator/core/let.ts
@@ -134,7 +134,7 @@ export default {
         );
       }
     } else if (isPersisted()) {
-      // A never-assigned let re-evaluates its initializer on construct, so
+      // A never-assigned let re-evaluates its initializer on creation, so
       // its sources resolve from it (never downstream: no re-derivation).
       setBindingValueExprs(binding, tagExtra);
     } else {

--- a/packages/runtime-tags/src/translator/core/try.ts
+++ b/packages/runtime-tags/src/translator/core/try.ts
@@ -182,7 +182,7 @@ export default {
                 contentProp?.value,
                 propsToExpression(translatedAttrs.properties),
                 // An always-pairing branch drops its pairing entry's
-                // construct payload outside divergent contexts.
+                // creation payload outside divergent contexts.
                 ...(isPersisted() &&
                 boundaryAlwaysPairs(getSectionForBody(tagBody)!)
                   ? [t.numericLiteral(1)]

--- a/packages/runtime-tags/src/translator/util/entry-builder.ts
+++ b/packages/runtime-tags/src/translator/util/entry-builder.ts
@@ -34,8 +34,8 @@ interface EntryState {
   bundledAssets: Set<string>;
   /** Whether each reached file was only ever seen below a bundled template. */
   visited: Map<string, boolean>;
-  /** Lazy sites of persisted templates reached eagerly, by channel, with
-   * whether the site's template is a root: the entry registers the loaders
+  /** Lazy children of persisted templates reached eagerly, by channel, with
+   * whether the parent template is a root: the entry registers the loaders
    * of the templates it never links, so a flush can still load them. */
   lazyLoads: Map<string, [request: string, root: boolean]>;
 }
@@ -88,7 +88,7 @@ const builder = {
 
       const linked = state.init || state.load;
       // Only a persisted page collects lazy loads (a flush can reveal a lazy
-      // site the client never rendered); a plain page's output is unchanged.
+      // child the client never rendered); a plain page's output is unchanged.
       const lazyLoads = [...state.lazyLoads].filter(
         ([, [, root]]) => !root || !linked,
       );
@@ -257,7 +257,7 @@ const builder = {
       }
     }
 
-    // A flush revealing a lazy site of a template the bundle never links
+    // A flush revealing a lazy child of a template the bundle never links
     // still needs its module: the entry registers the loader itself.
     if (entryFile.markoOpts.persisted && !state.bundled) {
       for (const tag of (loadImports as Set<string> | undefined) || []) {

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -175,8 +175,8 @@ export function knownTagAnalyze(
     onFinalizePersisted(() => {
       if (!inStatefulBranch(section)) {
         addRuntimeFeatureAsset("patch-child");
-        // A construct seeds the tag var through the bind channel; the
-        // child may hand resumed content to a patched site.
+        // A created scope seeds the tag var through the bind channel; the
+        // child may hand resumed content to a patched tag.
         if (hasVar || contentResumesForPatch(getSectionForBody(tagBody))) {
           addRuntimeFeatureAsset("patch-value-bind");
         }
@@ -443,7 +443,7 @@ export function knownTagTranslateHTML(
     );
     if (varStatement) {
       statements.push(varStatement);
-      // A construct seeds the var (only there) unless the child's return is
+      // A created scope seeds the var (only there) unless the child's return is
       // state-fed: its own fill then returns through the wired registration.
       if (isPersisted()) {
         for (const name in t.getBindingIdentifiers(tag.node.var!)) {
@@ -549,7 +549,7 @@ export function knownTagTranslateDOM(
       }
       return t.callExpression(importRuntime("_var_change"), changeArgs);
     };
-    // A flush constructing the child seeds the wiring through its setup.
+    // A flush creating the child seeds the wiring through its setup.
     if (isPersisted()) importRuntimeFeature("patch-var");
     const wireVar = callRuntime(
       "_var",
@@ -660,7 +660,7 @@ export function hasParamSource(sources: Sources | undefined) {
 
 // Per-group sources for a known templated call site, aligned
 // with the child's `paramReasonGroups` indices.
-// A tag analyzed as a known child template (vs a `<define>` site).
+// A tag analyzed as a known child template (vs a `<define>` var's tag).
 export function isKnownTagExtra(tagExtra: t.MarkoTagExtra) {
   return !!tagExtra[kKnownExprs];
 }

--- a/packages/runtime-tags/src/translator/util/persisted/refresh.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/refresh.ts
@@ -83,7 +83,7 @@ function isPatchRefreshableBinding(binding: Binding) {
   );
 }
 
-// A scope a flush writes into: the root, or a paired/constructed branch
+// A scope a flush writes into: the root, or a paired/created branch
 // on the branch path (a stateful branch is the client's alone).
 function isPatchWrittenSection(section: Section) {
   return (
@@ -97,13 +97,13 @@ function isPatchWrittenSection(section: Section) {
 // A potential fill: a server-sourced value whose reads intersect client
 // state; the server writes all, tree-shaking decides which apply.
 export function isPatchFillBinding(binding: Binding) {
-  // State of a scope a construct may create (a branch body, a non-page
+  // State of a scope a patch may create (a branch body, a non-page
   // root) seeds through its fill signal — assigned state only (retention).
   if (
     isPersisted() &&
     ((!binding.section.parent && !isPage()) ||
       (binding.section.isBranch && isBranchPathSection(binding.section))) &&
-    // Stateful branches never construct from flushes, so their
+    // Flushes never create stateful branches, so their
     // state needs no seed fill.
     !isStatefulBranch(binding.section) &&
     getCanonicalBinding(binding) === binding &&
@@ -184,13 +184,13 @@ function computeFillReadKind(
     if (!effect && getSerializeSourcesForRef(read.referencedBindings)?.state) {
       return true;
     }
-    // A `<define>` body reads as if at each direct site of its var; a
-    // recursive define reaches its own sites once.
-    const sites = [read.section];
-    for (const site of sites) {
+    // A `<define>` body reads as if at each tag downstream of its var; a
+    // recursive define reaches its own once.
+    const readSections = [read.section];
+    for (const readAt of readSections) {
       // No patch write reaches a skipped region: reads inside stateful
       // structure (and interactive boundary content) promote to owner fills.
-      let readSection: Section | undefined = site;
+      let readSection: Section | undefined = readAt;
       let content: Section | undefined;
       while (readSection && readSection !== binding.section) {
         if (isStatefulBranch(readSection)) return true;
@@ -209,9 +209,11 @@ function computeFillReadKind(
         ) {
           content = readSection;
         }
-        if (readSection.defineSites) {
-          for (const defineSite of readSection.defineSites) {
-            if (!sites.includes(defineSite)) sites.push(defineSite);
+        if (readSection.downstreamSections) {
+          for (const downstream of readSection.downstreamSections) {
+            if (!readSections.includes(downstream)) {
+              readSections.push(downstream);
+            }
           }
           break;
         }
@@ -230,7 +232,7 @@ function computeFillReadKind(
       // Only structure with OTHER params upstream can leave this read client-owned;
       // a page's root params always come from the request.
       if (!isPage()) {
-        for (const sources of getParamUpstreamChain(site) || []) {
+        for (const sources of getParamUpstreamChain(readAt) || []) {
           if (!upstreamThrough(sources, binding)) {
             conditions = mergeConditions(conditions, { upstreams: [sources] });
           }
@@ -254,7 +256,7 @@ function upstreamThrough(sources: Sources, binding: Binding) {
 // client-fed upstream, so the runtime decides; `false`: server-owned.
 function consumerMayWithhold(content: Section) {
   const consumer = content.downstream!.tag;
-  // A `<define>` var passed on (its direct sites classify on their own)
+  // A `<define>` var passed on (its direct tags classify on their own)
   // may reach any consumer, so the runtime decides.
   if (!isKnownTagExtra(consumer)) {
     for (const read of content.downstream!.binding?.reads || []) {
@@ -313,8 +315,13 @@ export function isPatchWriteBinding(binding: Binding) {
 // id when a patch changes what they saw.
 export function hasPatchEffectReads(binding: Binding): boolean {
   for (const read of binding.reads) {
-    // A serialized spread's set is its own refresh.
-    if (read.isEffect && !read.attrSetSpread) return true;
+    // A patched spread's set is its own refresh.
+    if (
+      read.isEffect &&
+      !(read.attrSetSpread && isBranchPathSection(read.section))
+    ) {
+      return true;
+    }
   }
   for (const alias of binding.aliases) {
     if (getCanonicalBinding(alias) === binding && hasPatchEffectReads(alias)) {
@@ -337,19 +344,19 @@ function hasRegisteredFnCapture(binding: Binding): boolean {
   return false;
 }
 
-// Closures whose construct INITs render a fresh scope; a lazy child's
+// Closures whose creation INITs render a fresh scope; a lazy child's
 // server-owned input arrives through its ready channel.
-export function getConstructInitClosures(section: Section) {
+export function getCreateInitClosures(section: Section) {
   return filter(section.referencedClosures as Opt<Binding>, (closure) =>
-    closureInitsConstruct(closure, section),
+    closureInitsCreated(closure, section),
   );
 }
 
-// A closure a construct of `section` runs as an init: state (the shell
+// A closure a created scope of `section` runs as an init: state (the shell
 // names it), a fill feeding a state join (the flush's `_init_join`), or any
 // other member of such a join, since the join fires once every member
-// arrives and a construct runs only registered inits.
-export function closureInitsConstruct(closure: Binding, section: Section) {
+// arrives and a created scope runs only registered inits.
+export function closureInitsCreated(closure: Binding, section: Section) {
   return (
     !!closure.sources?.state ||
     fillJoinsIn(closure, section) ||
@@ -471,22 +478,22 @@ function patchFills(binding: Binding, seen = new Set<Binding>()): boolean {
   return every(root.sources?.param, (param) => patchFills(param, seen));
 }
 
-// Whether a patch may rebuild this content: its site can diverge, a consumer
-// renders it in constructible structure, or an enclosing branch constructs.
-const mayConstruct = new WeakMap<Section, boolean>();
-export function contentMayConstruct(section: Section): boolean {
-  let result = mayConstruct.get(section);
+// Whether a patch may create this content: its tag can diverge, a consumer
+// renders it in creatable structure, or an enclosing branch is created.
+const mayCreate = new WeakMap<Section, boolean>();
+export function contentMayCreate(section: Section): boolean {
+  let result = mayCreate.get(section);
   if (result === undefined) {
-    mayConstruct.set(section, false);
+    mayCreate.set(section, false);
     result =
-      sectionMayConstruct(section) ||
-      (!!section.parent && enclosingMayConstruct(section.parent));
-    mayConstruct.set(section, result);
+      sectionMayCreate(section) ||
+      (!!section.parent && enclosingMayCreate(section.parent));
+    mayCreate.set(section, result);
   }
   return result;
 }
 
-// Whether any consumer's site names this content in a patch entry (a
+// Whether any consumer's tag names this content in a patch entry (a
 // boundary's shells name what they render); an unknown consumer may.
 const isPatched = new WeakMap<Section, boolean>();
 export function contentIsPatched(section: Section): boolean {
@@ -509,11 +516,11 @@ export function contentIsPatched(section: Section): boolean {
   return result;
 }
 
-function sectionMayConstruct(section: Section): boolean {
+function sectionMayCreate(section: Section): boolean {
   if (section.isBranch) return !inResumedStructure(section);
-  if (section.isBoundary) return enclosingMayConstruct(section);
+  if (section.isBoundary) return enclosingMayCreate(section);
   if (section.upstreamExpression) {
-    // A dynamic tag body: the site re-renders it when its upstream changes.
+    // A dynamic tag body: the tag re-renders it when its upstream changes.
     return (
       !isStableExpr(section.upstreamExpression) && !inResumedStructure(section)
     );
@@ -524,26 +531,26 @@ function sectionMayConstruct(section: Section): boolean {
   return (
     !downstream?.binding ||
     someContentRead(downstream.binding, downstream.properties, (read) =>
-      enclosingMayConstruct(read.section),
+      enclosingMayCreate(read.section),
     )
   );
 }
 
-function enclosingMayConstruct(section: Section): boolean {
+function enclosingMayCreate(section: Section): boolean {
   for (let cur: Section | undefined = section; cur; cur = cur.parent) {
     if (cur.isBranch) return !inResumedStructure(cur);
     if (cur.upstreamExpression || cur.downstream) {
-      return contentMayConstruct(cur);
+      return contentMayCreate(cur);
     }
   }
   // A caller composes any template but the page into its own shell (a lazy
-  // page under a layout, a child in a branch), so the root constructs; a
-  // consumer's root reduces to this template's site, which the walk from
-  // the site settles.
+  // page under a layout, a child in a branch), so the root is created; a
+  // consumer's root reduces to this template's tag, which the walk from
+  // that tag settles.
   return !isPage();
 }
 
-// Resumed content (registered, no shell stands in) that a patched site
+// Resumed content (registered, no shell stands in) that a patched tag
 // names: the flush hands it over as a bind to the owner's registration.
 export function contentResumesForPatch(bodySection: Section | undefined) {
   return (

--- a/packages/runtime-tags/src/translator/util/persisted/structure.ts
+++ b/packages/runtime-tags/src/translator/util/persisted/structure.ts
@@ -19,12 +19,12 @@ import { onFinalizePersisted } from "./lifecycle";
 import { isPatchFillBinding } from "./refresh";
 
 // A boundary branch live on every persisted page (serialized on every page
-// render, nothing on the chain diverges), so it pairs without a construct.
+// render, nothing on the chain diverges), so it pairs without creating.
 export function boundaryAlwaysPairs(bodySection: Section) {
   if (!bodySection.serializeReason) return false;
   for (let s: Section | undefined = bodySection; s; s = s.parent) {
     if (s.isBranch || s.boundaryContent) return false;
-    // A content section can materialize at any site (or none), so nothing
+    // A content section can materialize at any consumer (or none), so nothing
     // below it is provably live and unique on every page.
     if (s !== bodySection && !s.isBoundary && s.parent) return false;
   }

--- a/packages/runtime-tags/src/translator/util/sections.ts
+++ b/packages/runtime-tags/src/translator/util/sections.ts
@@ -110,8 +110,9 @@ export interface StructureChild {
   name: string;
   hasVar: boolean;
   renderer?: StructureRef;
-  // A lazy site: its import's load config.
+  // A lazy child: its import's load config and its marker binding.
   load?: LoadImportConfig;
+  marker?: Binding;
 }
 
 export interface Section {
@@ -149,8 +150,9 @@ export interface Section {
   returnSerializeReason: SerializeReason | undefined;
   isHoistThrough: true | undefined;
   upstreamExpression: t.NodeExtra | undefined;
-  /** For a `<define>` body: the sections of its direct `<${var}>` sites. */
-  defineSites: Section[] | undefined;
+  /** For a `<define>` body: the sections of the `<${var}>` tags downstream
+   * of its var. */
+  downstreamSections: Section[] | undefined;
   /** The content's rendering tag (its extra), and the child binding the
    * content is upstream of when the child can serialize it. */
   downstream:
@@ -168,19 +170,17 @@ export interface Section {
   readsOwner: boolean;
   isBranch: boolean;
   /** An `<await>`/`<try>` body: always-rendered like the branch path, but
-   * paired (never constructed) by patches. */
+   * paired (never created) by patches. */
   isBoundary: boolean;
   /** A content renderer slot-serialized by register id (`<try>` bodies):
    * static ones re-register from entry data, others load the dom module. */
   boundaryContent: boolean;
   /** A content body shipped as a shell: `"static"` rides its slot
-   * in-band, a dynamic one is constructed by id from a dynamic tag entry. */
+   * in-band, a dynamic one is created by id from a dynamic tag entry. */
   contentShell: false | true | "static";
   /** The section's awaits: each marker binding and body section. */
   awaits: { binding: Binding; body: Section }[] | undefined;
-  /** Lazily loaded child sites in this section, by their marker binding. */
-  loadSites: { site: Binding; load: LoadImportConfig }[] | undefined;
-  /** Branch whose shell would construct unfaithfully: the first blocker's
+  /** Branch whose shell would create unfaithfully: the first blocker's
    * reason code sticks, no shell ships, patches fail closed. */
   content: null | {
     startType: ContentType;
@@ -262,7 +262,7 @@ export function startSection(
       returnSerializeReason: undefined,
       content: getContentInfo(path),
       upstreamExpression: undefined,
-      defineSites: undefined,
+      downstreamSections: undefined,
       downstream: undefined,
       hasAbortSignal: false,
       abortSignalExprs: 0,
@@ -272,7 +272,6 @@ export function startSection(
       boundaryContent: false,
       contentShell: false,
       awaits: undefined,
-      loadSites: undefined,
       structure: parentSection && !parentSection.structure ? null : [],
     };
     section.program = parentSection ? parentSection.program : section;

--- a/packages/runtime-tags/src/translator/util/serialize-guard.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-guard.ts
@@ -204,7 +204,7 @@ function ensureScopeOwned(section: Section) {
 }
 
 // Ownership args for an expression's write; a value fixed for the scope's
-// lifetime (constant, `<id>`, `<define>`) only seeds a construct.
+// lifetime (constant, `<id>`, `<define>`) only seeds a created scope.
 export function getExprWriteOwnership(extra: t.NodeExtra | undefined) {
   return getPatchWriteOwnership(
     getSerializeSourcesForExpr(extra || {}),
@@ -227,7 +227,7 @@ export function getPatchWriteOwnership(
   sources: Sources | undefined,
   stable?: boolean,
 ): [t.Expression, t.Expression] | [] {
-  // Never changes: the write only seeds a construct, like a client-owned
+  // Never changes: the write only seeds a created scope, like a client-owned
   // group's (mask `0`).
   if (stable) return [t.numericLiteral(0), t.numericLiteral(0)];
   for (const [paramsSection, params] of groupParamsBySection(sources?.param)) {

--- a/packages/runtime-tags/src/translator/util/shell.ts
+++ b/packages/runtime-tags/src/translator/util/shell.ts
@@ -2,7 +2,7 @@ import { types as t } from "@marko/compiler";
 import { getFile, getProgram } from "@marko/compiler/babel-utils";
 
 import normalizeStringExpression from "./normalize-string-expression";
-import { contentIsPatched, contentMayConstruct } from "./persisted/refresh";
+import { contentIsPatched, contentMayCreate } from "./persisted/refresh";
 import { isBranchPathSection, isStatefulBranch } from "./persisted/structure";
 import { addRuntimeFeatureAsset } from "./runtime";
 import {
@@ -49,7 +49,7 @@ export function buildShells() {
   // boundary content is a shell too.
   forEachSectionReverse((section) => {
     // Kept root awaits let `Pending` carry a body shell id; the root
-    // ships under the template id so a dynamic tag entry can construct it.
+    // ships under the template id so a dynamic tag entry can create it.
     if (!section.parent) {
       const chain: Section[] = [];
       const bodyShells: Record<string, Section> = {};
@@ -66,8 +66,8 @@ export function buildShells() {
     if (section.isBranch || isStatefulBranch(section)) {
       return;
     }
-    // A boundary constructs from its content shell; an inexpressible one
-    // stays shell-less, so a construct reaching it rejects.
+    // A boundary creates from its content shell; an inexpressible one
+    // stays shell-less, so a creation reaching it rejects.
     if (section.isBoundary) {
       const chain: Section[] = [];
       const bodyShells: Record<string, Section> = {};
@@ -113,7 +113,7 @@ export function buildShells() {
   });
   forEachSection((section) => {
     // Every branch-path body ships a shell, except
-    // stateful bodies: they never construct from a flush.
+    // stateful bodies: a flush never creates them.
     if (
       !section.isBranch ||
       !isBranchPathSection(section) ||
@@ -141,7 +141,7 @@ export function buildShells() {
 }
 
 // Body shells reuse the branch grammar; nested awaits recurse so a
-// constructed body can itself construct the awaits it contains.
+// created body can itself create the awaits it contains.
 function buildAwaitBodyShells(
   section: Section,
   shells: Record<string, Section>,
@@ -183,7 +183,7 @@ function isStructureExpressible(section: Section, visiting: Set<Section>) {
       // Static text is plain markup, expressible like a markup string.
       op.kind !== StructureKind.Text &&
       // A known child (a template's root or a sibling define body) composes
-      // when expressible; a lazy site expresses as its marker (the shell
+      // when expressible; a lazy child expresses as its marker (the shell
       // composes a server-only one).
       !(
         op.kind === StructureKind.Child &&
@@ -209,37 +209,37 @@ function isStructureExpressible(section: Section, visiting: Set<Section>) {
       !child.isBoundary &&
       !child.contentShell &&
       !(child.boundaryContent && interactive) &&
-      // Content nothing names or rebuilds leaves nothing for a shell to lack.
+      // Content nothing names or creates leaves nothing for a shell to lack.
       contentNeedsShell(child, interactive),
   );
 }
 
 // A scriptless page has only shells; elsewhere a shell serves content a
-// site names or a patch may rebuild, or a renderer that cannot mount a child.
+// tag names or a patch may create, or a renderer that cannot mount a child.
 function contentNeedsShell(section: Section, interactive: boolean | undefined) {
   return (
     !interactive ||
     (!getSectionRegisterReasons(section) &&
-      (contentIsPatched(section) || contentMayConstruct(section))) ||
-    (hasPatchedChild(section) && contentMayConstruct(section))
+      (contentIsPatched(section) || contentMayCreate(section))) ||
+    (hasPatchedChild(section) && contentMayCreate(section))
   );
 }
 
-// A known child site in a non-stateful section pairs from patches; the
-// section's client renderer never mounts it, so a construct needs the shell.
+// A known child in a non-stateful section pairs from patches; the
+// section's client renderer never mounts it, so a creation needs the shell.
 function hasPatchedChild(section: Section) {
   return !!section.structure?.some(
     (op) => typeof op === "object" && op.kind === StructureKind.Child,
   );
 }
 
-// Await bodies ship as their construct's `await` shells, never as
+// Await bodies ship as their await's `await` shells, never as
 // standalone content shells nothing references.
 function isAwaitBody(section: Section) {
   return !!section.parent?.awaits?.some((s) => s.body === section);
 }
 
-// A shell the client rebuilds from its template alone: static markup with
+// A shell the client creates from its template alone: static markup with
 // no walk. A child always walks, so resolving never reaches its imports.
 function isStaticShell(section: Section) {
   if (

--- a/packages/runtime-tags/src/translator/util/signals.ts
+++ b/packages/runtime-tags/src/translator/util/signals.ts
@@ -25,8 +25,8 @@ import {
   toArray,
 } from "./optional";
 import {
-  closureInitsConstruct,
-  contentMayConstruct,
+  closureInitsCreated,
+  contentMayCreate,
   fillJoinsIn,
   getFillRoot,
   getFillConditions,
@@ -447,9 +447,9 @@ export function getSignal(
         const closure = referencedBindings;
         const render = getSignalFn(signal);
         const closureSignal = getClosureSignal(section);
-        // The construct INIT registers on the closure signal itself (pure
-        // fused helpers), so shaking the signal makes a construct fail closed.
-        const initId = constructsWithInit(section, closure)
+        // The creation INIT registers on the closure signal itself (pure
+        // fused helpers), so shaking the signal makes a creation fail closed.
+        const initId = createsWithInit(section, closure)
           ? getResumeRegisterId(section, closure, "init")
           : undefined;
 
@@ -523,7 +523,7 @@ export function initGlobalRead(binding: Binding) {
 // Client work reading a `$global` key, keyed by the scope a changed key
 // queues it on (a closure: the owner its chain dispatches from). A join is
 // `unfilled` when resumed code renders the read wherever the scope sits (an
-// effect, a state-mixed read, resumed structure); otherwise the site decides
+// effect, a state-mixed read, resumed structure); otherwise the tag decides
 // at render (a patch fills a hole under server-owned structure).
 export function getGlobalJoins(section: Section) {
   let root = section;
@@ -1456,12 +1456,12 @@ export function writeSignals(section: Section) {
                   hopExprs = [t.arrowFunctionExpression([joinId], dispatch)];
                 }
               }
-              // A constructible body's fill closure inits as the arrival at this
+              // A creatable body's fill closure inits as the arrival at this
               // join, registered under the closure's init id.
               if (
                 member.section !== signal.section &&
                 !member.sources?.state &&
-                sectionConstructs(signal.section)
+                patchCreates(signal.section)
               ) {
                 value = callRuntime(
                   "_init_join",
@@ -1816,25 +1816,25 @@ function toSequenceExpression(exprs: t.Expression[]) {
   return exprs.length === 1 ? exprs[0] : t.sequenceExpression(exprs);
 }
 
-// A closure into a body that ships a shell whose init a construct may run,
+// A closure into a body that ships a shell whose init a created scope may run,
 // registered on its closure get: a fill feeding a state join registers on
 // the join (`_init_join`) instead, a local fill's upstream by the flush.
-function constructsWithInit(section: Section, closure: Binding) {
+function createsWithInit(section: Section, closure: Binding) {
   return (
-    sectionConstructs(section) &&
-    ((closureInitsConstruct(closure, section) &&
+    patchCreates(section) &&
+    ((closureInitsCreated(closure, section) &&
       !fillJoinsIn(closure, section)) ||
       includes(getLocalFillUpstreams(section), closure))
   );
 }
 
 // A branch body that ships a shell, or content whose shell a patch may
-// rebuild (a shell kept only for reference never constructs).
-export function sectionConstructs(section: Section) {
+// create (a shell kept only for reference never creates).
+export function patchCreates(section: Section) {
   return (
     isPersisted() &&
     (section.isBranch ||
-      (section.contentShell === true && contentMayConstruct(section))) &&
+      (section.contentShell === true && contentMayCreate(section))) &&
     !inResumedStructure(section) &&
     !sectionHasServerEffect(section)
   );
@@ -1895,14 +1895,20 @@ function isSerializedSpreadEffect(refs: ReferencedBindings) {
     !!refs &&
     some(refs, (binding) => {
       for (const read of binding.reads) {
-        if (read.referencedBindings === refs && read.attrSetSpread) return true;
+        if (
+          read.referencedBindings === refs &&
+          read.attrSetSpread &&
+          isBranchPathSection(read.section)
+        ) {
+          return true;
+        }
       }
       return false;
     })
   );
 }
 
-// An effect read the wire cannot keep current blocks constructs; fills,
+// An effect read the wire cannot keep current blocks creation; fills,
 // wire writes and direct `$global` reads stay current.
 export function sectionHasServerEffect(section: Section) {
   const hasServerEffect = (binding: Binding) => {
@@ -2298,7 +2304,7 @@ export function writeHTMLResumeStatements(
   forEach(section.referencedLocalClosures, writeSerializedBinding);
 
   // A `<return>` change handler wires like a controllable's: the bind
-  // installs it on a constructed scope, a paired one keeps its own.
+  // installs it on a created scope, a paired one keeps its own.
   if (persisted) {
     const change = serializedLookup.get(getAccessorProp().TagVariableChange);
     if (change) {
@@ -2315,7 +2321,7 @@ export function writeHTMLResumeStatements(
     }
   }
 
-  // A constructible branch (or a non-page root a parent may construct)
+  // A creatable branch (or a non-page root a parent may create)
   // seeds its state onto fresh scopes as SETUP fills.
   if (
     persisted &&

--- a/packages/runtime-tags/src/translator/util/structure.ts
+++ b/packages/runtime-tags/src/translator/util/structure.ts
@@ -10,6 +10,7 @@ import { isOutputHTML } from "./marko-config";
 import normalizeStringExpression, {
   appendLiteral,
 } from "./normalize-string-expression";
+import type { Binding } from "./references";
 import {
   ContentType,
   getSection,
@@ -56,6 +57,7 @@ export function child(
   name: string,
   renderer?: StructureRef,
   load?: LoadImportConfig,
+  marker?: Binding,
 ) {
   getSection(tag).structure?.push({
     kind: StructureKind.Child,
@@ -63,6 +65,7 @@ export function child(
     hasVar: !!tag.node.var,
     renderer,
     load,
+    marker,
   });
 }
 
@@ -128,8 +131,8 @@ export function resolveStructure(section: Section) {
     steps: startDynamic ? [Step.Enter, Step.Exit] : [],
   };
   let textEdge: undefined | "own" | "child";
-  // Shells are html output: a server-only lazy child composes into its
-  // site's shell like a known child (the page has no client render of it).
+  // Shells are html output: a server-only lazy child composes into the
+  // shell like a known child (the page has no client render of it).
   const html = isOutputHTML();
   let skipSteps = 0;
 
@@ -160,12 +163,12 @@ export function resolveStructure(section: Section) {
           }
           break;
         case StructureKind.Child: {
-          // A lazy site composes its child only when a flush constructs it.
-          const composed = html && op.load?.sitesConstruct;
+          // A lazy child composes into the shell only when a flush creates it.
+          const composed = html && op.load?.downstreamCreated;
           const renderer = op.load && !composed ? undefined : op.renderer;
           if (composed) {
-            // The walk steps over the site's marker into the composed child;
-            // the site's own shallow steps after the child are dropped.
+            // The walk steps over the marker into the composed child; the
+            // tag's own shallow steps after the child are dropped.
             resolved.steps.push(Step.Enter, Step.Exit);
             skipSteps = 2;
           }

--- a/packages/runtime-tags/src/translator/visitors/import-declaration.ts
+++ b/packages/runtime-tags/src/translator/visitors/import-declaration.ts
@@ -26,7 +26,7 @@ import {
   importRuntimeFeature,
 } from "../util/runtime";
 import { getSection } from "../util/sections";
-import { sectionConstructs } from "../util/signals";
+import { patchCreates } from "../util/signals";
 import { createProgramState } from "../util/state";
 import { toMemberExpression } from "../util/to-property-name";
 import type { TemplateVisitor } from "../util/visitors";
@@ -52,20 +52,20 @@ export type LoadImportConfig = (
   | { render: true; triggers?: never }
   | { render: false; triggers: LoadTrigger[] }
 ) & {
-  /** Every site of a page's rendered import sits in structure a patch
-   * constructs, with no state upstream: only a construct ever meets it. */
-  sitesConstruct?: true;
+  /** Every tag downstream of a page's rendered import sits in structure a
+   * patch creates, with no state upstream: only creation meets it. */
+  downstreamCreated?: true;
 };
 const triggerRegExp = /\s*([\w-]+)\s*([^?|]+?)?\s*(?:\?([^|]*?))?\s*(?:\||$)/g;
 const [getHtmlLoadWrapped] = createProgramState(
   () => new Map<string, string>(),
 );
 
-// Records which of a page's rendered imports only constructs meet, once
+// Records which of a page's rendered imports only created scopes meet, once
 // every section's shell is decided. A trigger keeps its channel, so a
 // navigation never forces a load; an import is a module binding, so its
 // uses (tag names, values passed along) are its babel references.
-export function recordConstructedLoadImports(program: t.NodePath<t.Program>) {
+export function recordCreatedLoadImports(program: t.NodePath<t.Program>) {
   if (!isPersisted() || !isPage()) return;
   for (const node of program.node.body) {
     const loadImport = node.extra?.loadImport;
@@ -74,8 +74,8 @@ export function recordConstructedLoadImports(program: t.NodePath<t.Program>) {
     if (
       program.scope.getBinding(local.name)!.referencePaths.every(
         (ref) =>
-          sectionConstructs(getSection(ref)) &&
-          // State upstream of a site re-renders it on the client.
+          patchCreates(getSection(ref)) &&
+          // State upstream of a tag re-renders it on the client.
           !(
             t.isMarkoTag(ref.parent) &&
             getAllTagReferenceNodes(ref.parent).some((node) =>
@@ -84,7 +84,7 @@ export function recordConstructedLoadImports(program: t.NodePath<t.Program>) {
           ),
       )
     ) {
-      loadImport.sitesConstruct = true;
+      loadImport.downstreamCreated = true;
     }
   }
 }
@@ -152,7 +152,7 @@ export default {
       }
 
       (node.extra ??= {}).loadImport = loadImport;
-      // A flush revealing the site needs its channel and the bind feature on
+      // A flush revealing the tag needs its channel and the bind feature on
       // the page, interactive or not.
       if (isPersisted()) {
         addRuntimeFeatureAsset("patch-ready");
@@ -228,7 +228,7 @@ export default {
             );
             // Flushes name a server-only template; the page registers its
             // loader only, for the registrations its flushes need.
-            if (loadImport.sitesConstruct) {
+            if (loadImport.downstreamCreated) {
               importDecl.replaceWith(
                 t.expressionStatement(
                   callRuntime(
@@ -286,7 +286,7 @@ export default {
                 t.variableDeclaration("const", [
                   t.variableDeclarator(
                     local,
-                    // A flush's data for a site this template constructs
+                    // A flush's data for a tag this template creates
                     // waits for its clone; the wrapper reports the start.
                     isPersisted()
                       ? callRuntime(

--- a/packages/runtime-tags/src/translator/visitors/program/html.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/html.ts
@@ -16,7 +16,7 @@ import {
   scopeReasonRuntime,
 } from "../../util/persisted/intrinsics";
 import {
-  getConstructInitClosures,
+  getCreateInitClosures,
   getPatchFillBindings,
   isPatchFillBinding,
 } from "../../util/persisted/refresh";
@@ -34,6 +34,7 @@ import {
   getScopeIdIdentifier,
   getSection,
   type Section,
+  StructureKind,
 } from "../../util/sections";
 import { getScopeReasonDeclaration } from "../../util/serialize-guard";
 import {
@@ -47,7 +48,7 @@ import {
   getHTMLSectionStatements,
   getResumeRegisterId,
   getSectionEffectRegisterIds,
-  sectionConstructs,
+  patchCreates,
   sectionHasServerEffect,
   setSerializedValue,
   writeHTMLResumeStatements,
@@ -227,7 +228,7 @@ export default {
 
       const shells = getShells();
       if (persisted && shells) {
-        // Branch shells register at server module load so patches can construct
+        // Branch shells register at server module load so patches can create
         // them without the client bundling conditional content.
         const active = { ...shells };
         // The one translate-side blocker: `hasHTMLEffect` only exists once
@@ -246,20 +247,27 @@ export default {
           if (
             id === getShellId(section) ||
             !section.parent ||
-            (section.contentShell === true && sectionConstructs(section))
+            (section.contentShell === true && patchCreates(section))
           ) {
-            forEach(getConstructInitClosures(section), (closure) => {
+            forEach(getCreateInitClosures(section), (closure) => {
               marker +=
                 (marker && " ") + getResumeRegisterId(section, closure, "init");
             });
-            // Lazy sites wire their load (and channel) as construct inits;
-            // a server-only site's child sits in the shell itself.
-            for (const { site, load } of section.loadSites || []) {
-              if (load.sitesConstruct) continue;
-              marker +=
-                (marker && " ") + getResumeRegisterId(section, site, "init");
+            // Lazy children wire their load (and channel) as creation
+            // inits; a server-only one sits in the shell itself.
+            for (const op of section.structure || []) {
+              if (
+                typeof op === "object" &&
+                op.kind === StructureKind.Child &&
+                op.marker &&
+                !op.load?.downstreamCreated
+              ) {
+                marker +=
+                  (marker && " ") +
+                  getResumeRegisterId(section, op.marker, "init");
+              }
             }
-            // An effect the construct's own renders queue (an init, seed,
+            // An effect the created scope's own renders queue (an init, seed,
             // or item write cascades into it) is not replayed.
             const effectIds = getSectionEffectRegisterIds(
               section,

--- a/packages/runtime-tags/src/translator/visitors/program/index.ts
+++ b/packages/runtime-tags/src/translator/visitors/program/index.ts
@@ -40,7 +40,7 @@ import {
 import { sectionHasSetupStatements } from "../../util/setup-statements";
 import { buildShells } from "../../util/shell";
 import type { TemplateVisitor } from "../../util/visitors";
-import { recordConstructedLoadImports } from "../import-declaration";
+import { recordCreatedLoadImports } from "../import-declaration";
 import programDOM from "./dom";
 import programHTML from "./html";
 import { preAnalyze } from "./pre-analyze";
@@ -130,7 +130,7 @@ export default {
 
       if (isPersisted()) {
         buildShells();
-        recordConstructedLoadImports(program);
+        recordCreatedLoadImports(program);
       }
       if (!section.hoistedTo && !sectionHasSetupStatements(section)) {
         // The setup export will be a noop, letting parent templates skip
@@ -277,7 +277,7 @@ export default {
       }
 
       if (isPersisted()) {
-        // A static shell slot rebuilds client-side; the import rides both
+        // A static shell slot is created client-side; the import rides both
         // outputs (an interactive page gets assets through its dom program).
         forEachSection((section) => {
           if (section.contentShell === "static") {

--- a/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/custom-tag.ts
@@ -49,7 +49,7 @@ import {
   addStatement,
   getResumeRegisterId,
   getSignal,
-  sectionConstructs,
+  patchCreates,
 } from "../../util/signals";
 import { createProgramState } from "../../util/state";
 import * as structure from "../../util/structure";
@@ -108,10 +108,6 @@ export default {
           BindingType.dom,
           section,
         );
-        (section.loadSites ??= []).push({
-          site: tagExtra[kLoadTagBinding]!,
-          load: tagExtra.tagNameLoad,
-        });
       }
 
       if (tagExtra.tagNameLoad || !childExtra.domExports?.setupEmpty) {
@@ -141,6 +137,7 @@ export default {
             hint: tagName,
           },
           tagExtra.tagNameLoad,
+          tagExtra[kLoadTagBinding],
         );
         structure.enterShallow(tag);
       } else {
@@ -205,9 +202,9 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
   const isLoad = !!loadConfig;
   const tagName = getStaticTagName(node);
 
-  // A server-only site has no client render: a flush's shell builds it
-  // and its setup entries seed it.
-  if (loadConfig?.sitesConstruct) {
+  // A child only created scopes meet has no client render: a flush's shell
+  // builds it and its setup entries seed it.
+  if (loadConfig?.downstreamCreated) {
     importRuntimeFeature("patch-child");
     tag.remove();
     return;
@@ -297,7 +294,7 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
               )
             : setupLoadExpr,
         );
-        // A construct's client-side load drives the child's ready channel
+        // A created scope's client-side load drives the child's ready channel
         // (stamped on its branch), so deferred flush data drains after insert.
         if (isPersisted() && getReadyId(childFile) !== undefined) {
           loadSetupCall = callRuntime(
@@ -311,9 +308,9 @@ function translateDOM(tag: t.NodePath<t.MarkoTag>) {
           t.variableDeclaration("let", [
             t.variableDeclarator(
               setupIdent,
-              // A constructing branch runs the site's load wiring as a shell
+              // A branch being created runs the tag's load wiring as a shell
               // init; `_resume` (impure) survives tree-shaking to carry it.
-              isPersisted() && sectionConstructs(section)
+              isPersisted() && patchCreates(section)
                 ? callRuntime(
                     "_resume",
                     t.stringLiteral(

--- a/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/dynamic-tag.ts
@@ -152,8 +152,10 @@ export default {
       const { node } = tag;
       const definedBodySection = node.extra?.defineBodySection;
       if (definedBodySection) {
-        // The body reads as if at each site; the site's section exists here.
-        (definedBodySection.defineSites ??= []).push(getOrCreateSection(tag));
+        // The body reads as if at each downstream tag, whose section exists here.
+        (definedBodySection.downstreamSections ??= []).push(
+          getOrCreateSection(tag),
+        );
         addSetupStatement(getOrCreateSection(tag));
         knownTagAnalyze(
           tag,
@@ -225,7 +227,7 @@ export default {
       }
 
       const bodySection = startSection(tagBody);
-      // The body depends on the whole site as a branch body on its
+      // The body depends on the whole tag as a branch body on its
       // condition. Persisted only: the closure walk then stops forcing it.
       if (bodySection && isPersisted())
         bodySection.upstreamExpression = tagExtra;
@@ -505,13 +507,13 @@ export default {
           serializeReason,
           true,
         );
-        // The dynamic tag entry rides the tag site, ownership gated; the tag
-        // marks its branch for it whatever the site's own reason.
-        // The entry writer returns how a patch treats the site (`1` pairs,
+        // The dynamic tag entry rides the tag, ownership gated; the tag
+        // marks its branch for it whatever the tag's own reason.
+        // The entry writer returns how a patch treats the tag (`1` pairs,
         // `2` skips: a client-owned group upstream); the render takes it.
         let patchPairingArg: t.Expression | undefined;
         if (writesPatchDynamicTag(tag, tagSection)) {
-          // The site's renderer and input evaluate once: hoisted, both the
+          // The tag's renderer and input evaluate once: hoisted, both the
           // render and the entry read them.
           if (!t.isIdentifier(tagExpression)) {
             const tagId = generateUidIdentifier("tag");

--- a/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
+++ b/packages/runtime-tags/src/translator/visitors/tag/native-tag.ts
@@ -340,17 +340,16 @@ export default {
           getProgram().node.extra.isInteractive = true;
         }
 
-        if (
-          isPersisted() &&
-          seen.content &&
-          tagName !== "meta" &&
-          !node.body.body.length &&
-          isBranchPathSection(tagSection)
-        ) {
+        if (seen.content && tagName !== "meta" && !node.body.body.length) {
           const contentExtra = (seen.content.value.extra ??= {});
           contentExtra.contentAttr = true;
-          ensurePersistedWriteGroups(() => contentExtra);
-          addRuntimeFeatureAsset("patch-dynamic-tag");
+          if (isPersisted() && isBranchPathSection(tagSection)) {
+            ensurePersistedWriteGroups(() => contentExtra);
+            addRuntimeFeatureAsset("patch-dynamic-tag");
+          }
+        }
+        if (spreadReferenceNodes && isAttrSetSpread(tagName)) {
+          (node.extra ??= {}).attrSetSpread = true;
         }
 
         if (
@@ -380,7 +379,6 @@ export default {
               addRuntimeFeatureAsset("patch-dynamic-tag");
             }
             ensurePersistedWriteGroups(() => node.extra || {});
-            (node.extra ??= {}).attrSetSpread = true;
           }
         }
 
@@ -975,7 +973,7 @@ export default {
           tagExtra[kTagContentAttr] = true;
           const contentStatements: t.Statement[] = [];
           // A server-owned `content=` re-renders from a dynamic tag entry,
-          // like a dynamic tag site (the client signal shape is the same).
+          // like a dynamic tag (the client signal shape is the same).
           const patched =
             isPersisted() &&
             isBranchPathSection(tagSection) &&


### PR DESCRIPTION
A `content=` attribute and an attribute-set spread were marked on the extra only under persisted and on the branch path, so a missing mark meant either "not that shape" or "not in a patched region". The marks now record the shape alone; the readers that care whether a patch writes the tag test the section themselves. A section also listed its lazy children beside the structure op that already carried each one's load config; the op now carries the child's marker binding.

The test harness's response-size gate compared a patch against the initial document once a client step diverged the page, so a flush revealing a section was measured against a document that hid it, and two fixtures carried a padding paragraph to pass. Every applied patch now renders its own step's document for the gate; only the DOM comparison stays gated on divergence, and `skip_fresh_render` opts a fixture out of both.

Seven async fixtures hand-rolled a thenable so a patch's await would start pending at render rather than at setup. `navigate` now accepts a function that builds its input as the step runs, so those fixtures use the shared `resolveAfter`/`rejectAfter` promises with stable ordering; their patches are unchanged.

Vocabulary: the branch had coined two words. A tag or read was a "site"; the glossary's terms are upstream, downstream, and a call site's expressions. A scope a patch builds from a shell was a "construct"; the runtime and glossary already say a scope is created, and the patch is just who creates it. Names and comments now follow (`downstreamCreated`, `downstreamSections`, `patchCreates`, `createPatchers`, `creating`, a lazy child's `marker`), `createdContents` is `definedContents` (it records renderers a patch defined, not created), and CONTEXT.md defines a created scope and lists both words under Avoid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)