### PR TITLE
Encode a call site's serialize reason as two bits per group

### DIFF
--- a/.changeset/serialize-reason-groups.md
+++ b/.changeset/serialize-reason-groups.md
@@ -1,0 +1,5 @@
+---
+"@marko/runtime-tags": patch
+---
+
+Encode a call site's serialize reason as two bits per param-reason group, composing dynamic guards arithmetically instead of allocating a keyed object.

--- a/packages/runtime-tags/RESUMABILITY.md
+++ b/packages/runtime-tags/RESUMABILITY.md
@@ -82,9 +82,10 @@ combined work becomes relevant.
 
 Across known tags, `finalizeParamSerializeReasonGroups()` groups child parameter
 dependencies. The parent calls `_set_serialize_reason(...)`; the child consumes
-and clears it with `_scope_reason()`. HTML runtime encoding is `1` for all,
-`0`/missing for none, a bitmask from bit 1 for static groups, or a keyed object
-for dynamic guards. `serialize-guard.ts` emits/hoists `_serialize_if` and
+and clears it with `_scope_reason()`. HTML runtime encoding is two bits per
+group at `1 + 2 * group` (the low bit says the group serializes; a dynamic
+guard shifts into its place), a keyed object of group values past fifteen
+groups, or none. `serialize-guard.ts` emits/hoists `_serialize_if` and
 `_serialize_guard` calls.
 
 ### Signal lowering

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ const $content = (input) => {
 				_await($scope2_id, "#text/0", resolveAfter(0), () => {
 					const $scope3_id = _scope_id();
 					$si__input_level && _script($scope3_id, "__tests__/tags/recurse.marko_3_input_level#3/pending", $sg__input_level);
-					_set_serialize_reason($sg__input_level);
+					_set_serialize_reason($sg__input_level << 1);
 					const $childScope = _peek_scope_id();
 					$content({ level: input.level - 1 });
 					$si__input_level && _scope($scope3_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/async-deep-recursive/__snapshots__/html.bundle.js
@@ -13,7 +13,7 @@ const $content = (input) => {
 				_await($scope2_id, "a", resolveAfter(0), () => {
 					const $scope3_id = _scope_id();
 					$si__input_level && _script($scope3_id, "b0", $sg__input_level);
-					_set_serialize_reason($sg__input_level);
+					_set_serialize_reason($sg__input_level << 1);
 					const $childScope = _peek_scope_id();
 					$content({ level: input.level - 1 });
 					$si__input_level && _scope($scope3_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-handler-dynamic-tag-spread-cross-file/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-handler-dynamic-tag-spread-cross-file/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = new Set();
 	let count = 0;
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	child_default({
 		tag: "button",

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-handler-dynamic-tag-spread-cross-file/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-handler-dynamic-tag-spread-cross-file/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = /* @__PURE__ */ new Set();
 	let count = 0;
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	child_default({
 		tag: "button",

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.debug.js
@@ -13,11 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { x } = input;
-	_set_serialize_reason({
-		0: $sg__input_x,
-		1: $sg__input_x,
-		2: $sg__input_x
-	});
+	_set_serialize_reason($sg__input_x << 1 | $sg__input_x << 3 | $sg__input_x << 5);
 	let $thing;
 	if (x) {
 		$thing = attrTag({

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tag-inside-if-tag/__snapshots__/html.bundle.js
@@ -13,11 +13,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_x = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { x } = input;
-	_set_serialize_reason({
-		0: $sg__input_x,
-		1: $sg__input_x,
-		2: $sg__input_x
-	});
+	_set_serialize_reason($sg__input_x << 1 | $sg__input_x << 3 | $sg__input_x << 5);
 	let $thing;
 	if (x) $thing = attrTag({
 		x: 1,

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let x = true;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	if (x) {
 		$item = attrTag({ content: _content("__tests__/template.marko_1*content", (y) => {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-dynamic-with-params/__snapshots__/html.bundle.js
@@ -11,7 +11,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let x = true;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	$item = attrTag({ content: _content("a0", (y) => {
 		const $scope1_reason = _scope_reason(), $sg__y = _serialize_guard($scope1_reason, 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clicked = "";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	forOf(["a", "b"], (foo) => {
 		$item = attrTags($item, {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-for-loop-param-event-handler/__snapshots__/html.bundle.js
@@ -18,7 +18,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clicked = "";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	forOf(["a", "b"], (foo) => {
 		$item = attrTags($item, {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.debug.js
@@ -12,11 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_cond = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { cond } = input;
-	_set_serialize_reason({
-		0: $sg__input_cond,
-		1: $sg__input_cond,
-		2: $sg__input_cond
-	});
+	_set_serialize_reason($sg__input_cond << 1 | $sg__input_cond << 3 | $sg__input_cond << 5);
 	let $x;
 	let $y;
 	if (cond) {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-multiple-dynamic-in-if/__snapshots__/html.bundle.js
@@ -12,11 +12,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_cond = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { cond } = input;
-	_set_serialize_reason({
-		0: $sg__input_cond,
-		1: $sg__input_cond,
-		2: $sg__input_cond
-	});
+	_set_serialize_reason($sg__input_cond << 1 | $sg__input_cond << 3 | $sg__input_cond << 5);
 	let $x;
 	let $y;
 	if (cond) {

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $scope;
 	if (cond) {
 		$scope = attrTag({ a: 1 });

--- a/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/at-tags-name-shadows-generated-uid/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $scope;
 	$scope = attrTag({ a: 1 });
 	const $childScope = _peek_scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.debug.js
@@ -35,10 +35,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { c, d, e, f, g, h } = input;
 	_html(`<div class=${$class[(c ? 1 : 0) + (d ? 2 : 0)]}></div>${_el_resume($scope0_id, "#div/0", $sg__input_c__OR__input_d)}<div class="a b"></div><div class="a b c"></div><div${c ? " class=active" : ""}></div>${_el_resume($scope0_id, "#div/1", $sg__input_c)}<div${_attr_class("base" + (c ? " c" : "") + (d ? " d" : "") + (e ? " e" : "") + (f ? " f" : "") + (g ? " g" : "") + (h ? " h" : ""))}></div>${_el_resume($scope0_id, "#div/2", $sg__input_c__OR__input_d__OR__input_e__OR__input_f__OR__input_g__OR__input_h)}`);
-	_set_serialize_reason({
-		0: $sg__input_c__OR__input_d,
-		2: $sg__input_c__OR__input_d
-	});
+	_set_serialize_reason($sg__input_c__OR__input_d << 1 | $sg__input_c__OR__input_d << 5);
 	const $childScope = _peek_scope_id();
 	custom_tag_default({ class: ["a", {
 		b: c,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-class/__snapshots__/html.bundle.js
@@ -32,10 +32,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const { c, d, e, f, g, h } = input;
 	_html(`<div class=${$class[(c ? 1 : 0) + (d ? 2 : 0)]}></div>${_el_resume($scope0_id, "a", $sg__input_c__OR__input_d)}<div class="a b"></div><div class="a b c"></div><div${c ? " class=active" : ""}></div>${_el_resume($scope0_id, "b", $sg__input_c)}<div${_attr_class("base" + (c ? " c" : "") + (d ? " d" : "") + (e ? " e" : "") + (f ? " f" : "") + (g ? " g" : "") + (h ? " h" : ""))}></div>${_el_resume($scope0_id, "c", $sg__input_c__OR__input_d__OR__input_e__OR__input_f__OR__input_g__OR__input_h)}`);
-	_set_serialize_reason({
-		0: $sg__input_c__OR__input_d,
-		2: $sg__input_c__OR__input_d
-	});
+	_set_serialize_reason($sg__input_c__OR__input_d << 1 | $sg__input_c__OR__input_d << 5);
 	const $childScope = _peek_scope_id();
 	custom_tag_default({ class: ["a", {
 		b: c,

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.debug.js
@@ -28,10 +28,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_color = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<div${_attr_style({ color: input.color })}></div>${_el_resume($scope0_id, "#div/0", $sg__input_color)}<div style=width:100px></div><div style="color: green"></div><div${input.color ? " style=color:red" : ""}></div>${_el_resume($scope0_id, "#div/1", $sg__input_color)}`);
-	_set_serialize_reason({
-		0: $sg__input_color,
-		2: $sg__input_color
-	});
+	_set_serialize_reason($sg__input_color << 1 | $sg__input_color << 5);
 	const $childScope = _peek_scope_id();
 	custom_tag_default({ style: { color: input.color } });
 	custom_tag_default({ style: { width: "100px" } });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-style/__snapshots__/html.bundle.js
@@ -25,10 +25,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_color = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<div${_attr_style({ color: input.color })}></div>${_el_resume($scope0_id, "a", $sg__input_color)}<div style=width:100px></div><div style="color: green"></div><div${input.color ? " style=color:red" : ""}></div>${_el_resume($scope0_id, "b", $sg__input_color)}`);
-	_set_serialize_reason({
-		0: $sg__input_color,
-		2: $sg__input_color
-	});
+	_set_serialize_reason($sg__input_color << 1 | $sg__input_color << 5);
 	const $childScope = _peek_scope_id();
 	custom_tag_default({ style: { color: input.color } });
 	custom_tag_default({ style: { width: "100px" } });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.debug.js
@@ -8,7 +8,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", input.cell.label, $sg__input_cell_label)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "1:2");
 	}, $scope0_id) };
-	_set_serialize_reason($sg__input_obj_label);
+	_set_serialize_reason($sg__input_obj_label << 1);
 	const $childScope = _peek_scope_id();
 	Row.content({ cell: attrTag({ ...input.obj }) });
 	_html(`<div>added=${_text_resume($scope0_id, "#text/1", Object.getOwnPropertySymbols(input.obj).length, $sg__input_obj * 2)}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-lone-spread/__snapshots__/html.bundle.js
@@ -8,7 +8,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", input.cell.label, $sg__input_cell_label)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason($sg__input_obj_label);
+	_set_serialize_reason($sg__input_obj_label << 1);
 	const $childScope = _peek_scope_id();
 	Row.content({ cell: attrTag({ ...input.obj }) });
 	_html(`<div>added=${_text_resume($scope0_id, "b", Object.getOwnPropertySymbols(input.obj).length, $sg__input_obj * 2)}</div>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	let $item;
 	forUntil(1, 0, 1, (i) => {
 		$item = attrTags($item, { value: i });

--- a/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/attr-tag-params-spread-reference/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	let $item;
 	forUntil(1, 0, 1, (i) => {
 		$item = attrTags($item, { value: i });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-attrs/__snapshots__/html.bundle.js
@@ -13,7 +13,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-alias/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		value: { text: clickCount },
@@ -22,7 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			clickCount++;
 		}, "__tests__/template.marko_0/onClick", $scope0_id)
 	});
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	my_button_default({
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias-within-pattern/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		value: { text: clickCount },
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 			clickCount++;
 		}, "a0", $scope0_id)
 	});
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	my_button_default({
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input-same-source-alias/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-component-input/__snapshots__/html.bundle.js
@@ -13,7 +13,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let clickCount = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_button_default({
 		text: clickCount,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.debug.js
@@ -11,11 +11,7 @@ const $content = (input) => {
 		_if(() => {
 			if (comment.comments) {
 				const $scope2_id = _scope_id();
-				_set_serialize_reason({
-					0: $sg__input_comments__OR__input_path,
-					1: $sg__input_comments,
-					2: _serialize_guard($scope0_reason, 2)
-				});
+				_set_serialize_reason($sg__input_comments__OR__input_path << 1 | $sg__input_comments << 3 | _serialize_guard($scope0_reason, 2) << 5);
 				const $childScope = _peek_scope_id();
 				$content({
 					comments: comment.comments,
@@ -51,11 +47,7 @@ var comments_default = _template("__tests__/tags/comments.marko", $content);
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_comments__OR__input_path = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input_comments__OR__input_path,
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason($sg__input_comments__OR__input_path << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope = _peek_scope_id();
 	comments_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-inert-collapsible-tree/__snapshots__/html.bundle.js
@@ -11,11 +11,7 @@ const $content = (input) => {
 		_if(() => {
 			if (comment.comments) {
 				const $scope2_id = _scope_id();
-				_set_serialize_reason({
-					0: $sg__input_comments__OR__input_path,
-					1: $sg__input_comments,
-					2: _serialize_guard($scope0_reason, 2)
-				});
+				_set_serialize_reason($sg__input_comments__OR__input_path << 1 | $sg__input_comments << 3 | _serialize_guard($scope0_reason, 2) << 5);
 				const $childScope = _peek_scope_id();
 				$content({
 					comments: comment.comments,
@@ -46,11 +42,7 @@ var comments_default = _template("b", $content);
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_comments__OR__input_path = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input_comments__OR__input_path,
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason($sg__input_comments__OR__input_path << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope = _peek_scope_id();
 	comments_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		const $scope1_id = _scope_id();
 		_for_of(items, (inner) => {
 			const $scope2_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ name: `${outer}.${inner}` });
 			_scope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:4");

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-for/__snapshots__/html.bundle.js
@@ -17,7 +17,7 @@ var template_default = _template("a", (input) => {
 		const $scope1_id = _scope_id();
 		_for_of(items, (inner) => {
 			const $scope2_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ name: `${outer}.${inner}` });
 			_scope($scope2_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let x = 1;
 	let y = 2;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: x,

--- a/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/basic-nested-params/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var template_default = _template("a", (input) => {
 	let x = 1;
 	let y = 2;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: x,

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.debug.js
@@ -27,7 +27,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $x__closures = new Set();
 	let x = 0;
-	_set_serialize_reason(8);
+	_set_serialize_reason(32);
 	const $childScope = _peek_scope_id();
 	counter_default({
 		count: x,
@@ -42,7 +42,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_subscribe($x__closures, _scope($scope1_id, { _: _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2"));
 		}, $scope0_id)
 	});
-	_set_serialize_reason(8);
+	_set_serialize_reason(32);
 	const $childScope2 = _peek_scope_id();
 	counter_default({
 		count: x,

--- a/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bind-to-input/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $x__closures = /* @__PURE__ */ new Set();
 	let x = 0;
-	_set_serialize_reason(8);
+	_set_serialize_reason(32);
 	const $childScope = _peek_scope_id();
 	counter_default({
 		count: x,
@@ -37,7 +37,7 @@ var template_default = _template("a", (input) => {
 			_subscribe($x__closures, _scope($scope1_id, { _: _scope_with_id($scope0_id) }));
 		}, $scope0_id)
 	});
-	_set_serialize_reason(8);
+	_set_serialize_reason(32);
 	const $childScope2 = _peek_scope_id();
 	counter_default({
 		count: x,

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id) };
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	Wrap.content({ a: "z" + n });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/bound-attr-pattern-repeated/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var template_default = _template("a", (input) => {
 	}, $scope0_id) };
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	Wrap.content({ a: "z1" });
 	_script($scope0_id, "a2");

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.debug.js
@@ -30,7 +30,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/0")}<div></div>${_el_resume($scope0_id, "#div/1")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-n-child-for-shallow/__snapshots__/html.bundle.js
@@ -27,7 +27,7 @@ var template_default = _template("a", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "a")}<div></div>${_el_resume($scope0_id, "b")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.debug.js
@@ -31,7 +31,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_for_of(items, (outerItem) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,
@@ -40,7 +40,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_for_of(items, (middleItem) => {
 			const $scope2_id = _scope_id();
 			_html("<div>");
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope2 = _peek_scope_id();
 			child_default({
 				write,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-deep/__snapshots__/html.bundle.js
@@ -28,7 +28,7 @@ var template_default = _template("a", (input) => {
 	_for_of(items, (outerItem) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,
@@ -37,7 +37,7 @@ var template_default = _template("a", (input) => {
 		_for_of(items, (middleItem) => {
 			const $scope2_id = _scope_id();
 			_html("<div>");
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope2 = _peek_scope_id();
 			child_default({
 				write,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.debug.js
@@ -30,7 +30,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/0")}<div></div>${_el_resume($scope0_id, "#div/1")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,

--- a/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/cleanup-single-child-for-shallow/__snapshots__/html.bundle.js
@@ -27,7 +27,7 @@ var template_default = _template("a", (input) => {
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "a")}<div></div>${_el_resume($scope0_id, "b")}`);
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		child_default({
 			write,

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	display_intersection_default({ value: count });
 	_html(`<button></button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/component-attrs-intersection/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	display_intersection_default({ value: count });
 	_html(`<button></button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = new Set();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	sections_default({ section: attrTag({
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/conditional-dynamic-tag-in-loop-closure/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const $count__closures = /* @__PURE__ */ new Set();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	sections_default({ section: attrTag({
 		onClick: _resume(function() {

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.debug.js
@@ -11,10 +11,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id) };
 	let n = 2;
 	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	Wrap.content([undefined, n]);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope2 = _peek_scope_id();
 	Wrap.content([n, 10]);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/content-params-array-defaults/__snapshots__/html.bundle.js
@@ -10,10 +10,10 @@ var template_default = _template("a", (input) => {
 	}, $scope0_id) };
 	let n = 2;
 	_html(`<button>inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	Wrap.content([void 0, n]);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope2 = _peek_scope_id();
 	Wrap.content([n, 10]);
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.debug.js
@@ -11,10 +11,10 @@ var row_default = _template("__tests__/tags/row/index.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 1), $sg__input_quantity = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
 	_html("<div class=row>");
-	_set_serialize_reason($sg__input_name);
+	_set_serialize_reason($sg__input_name << 1);
 	const $childScope = _peek_scope_id();
 	cell_default({ value: input.name });
-	_set_serialize_reason($sg__input_quantity);
+	_set_serialize_reason($sg__input_quantity << 1);
 	const $childScope2 = _peek_scope_id();
 	cell_default({ value: input.quantity });
 	_html("</div>");
@@ -30,7 +30,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let quantity = 2;
 	_html(`<button>add</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	row_default({
 		name: "Widget",

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-empty-setup/__snapshots__/html.bundle.js
@@ -11,10 +11,10 @@ var row_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_name = _serialize_guard($scope0_reason, 1), $sg__input_quantity = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
 	_html("<div class=row>");
-	_set_serialize_reason($sg__input_name);
+	_set_serialize_reason($sg__input_name << 1);
 	const $childScope = _peek_scope_id();
 	cell_default({ value: input.name });
-	_set_serialize_reason($sg__input_quantity);
+	_set_serialize_reason($sg__input_quantity << 1);
 	const $childScope2 = _peek_scope_id();
 	cell_default({ value: input.quantity });
 	_html("</div>");
@@ -30,7 +30,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let quantity = 2;
 	_html(`<button>add</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	row_default({
 		name: "Widget",

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	show_result_default({ get: function() {
 		return count;

--- a/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/custom-tag-input-observed-read/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 0;
 	_html(`<button class=inc>inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	show_result_default({ get: function() {
 		return count;

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			_html("<span>The thing</span>");
 		}, $scope0_id)
 	};
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	child_default({ thing: myThing });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-for-attribute-tag/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("a", (input) => {
 			_html("<span>The thing</span>");
 		}, $scope0_id)
 	};
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	child_default({ thing: myThing });
 	_html(`<button>Toggle</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.debug.js
@@ -8,10 +8,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
-				_set_serialize_reason({
-					0: $sg__input_bar,
-					2: $sg__input_bar
-				});
+				_set_serialize_reason($sg__input_bar << 1 | $sg__input_bar << 5);
 				const $childScope = _peek_scope_id();
 				Foo.content({ message: input.bar });
 				$si__input_bar && _scope($scope2_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-recursive-known/__snapshots__/html.bundle.js
@@ -7,10 +7,7 @@ var template_default = _template("a", (input) => {
 		_if(() => {
 			if (input.bar) {
 				const $scope2_id = _scope_id();
-				_set_serialize_reason({
-					0: $sg__input_bar,
-					2: $sg__input_bar
-				});
+				_set_serialize_reason($sg__input_bar << 1 | $sg__input_bar << 5);
 				const $childScope = _peek_scope_id();
 				Foo.content({ message: input.bar });
 				$si__input_bar && _scope($scope2_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", a, $sg__a)}|${_text_resume($scope1_id, "#text/1", JSON.stringify(rest), $sg__rest * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	MyTag.content(x, "two", "three");
 	_html(`<button>${_text_resume($scope0_id, "#text/2", x)}</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-rest-param/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", a, $sg__a)}|${_text_resume($scope1_id, "b", JSON.stringify(rest), $sg__rest * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	MyTag.content(x, "two", "three");
 	_html(`<button>${_text_resume($scope0_id, "c", x)}</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", b, $sg__b)}|${_text_resume($scope1_id, "#text/1", c, $sg__c * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}, $scope0_id) };
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_text_resume($scope0_id, "#text/2", x)}</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args-unused-param/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", b, $sg__b)}|${_text_resume($scope1_id, "b", c, $sg__c * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_text_resume($scope0_id, "c", x)}</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", a, $sg__a)}|${_text_resume($scope1_id, "#text/1", b, $sg__b * 2)}|${_text_resume($scope1_id, "#text/2", c, $sg__c * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}, $scope0_id) };
-	_set_serialize_reason(18);
+	_set_serialize_reason(130);
 	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_text_resume($scope0_id, "#text/2", x)}</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-args/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", a, $sg__a)}|${_text_resume($scope1_id, "b", b, $sg__b * 2)}|${_text_resume($scope1_id, "c", c, $sg__c * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(18);
+	_set_serialize_reason(130);
 	const $childScope = _peek_scope_id();
 	MyTag.content(1, "Hello", x);
 	_html(`<button>${_text_resume($scope0_id, "c", x)}</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.debug.js
@@ -9,7 +9,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", number, $sg__number)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "2:2");
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	MyTag.content({ number: x });
 	_html(`<button>${_text_resume($scope0_id, "#text/2", x)}</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-attr-signal/__snapshots__/html.bundle.js
@@ -9,7 +9,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", number, _serialize_guard($scope1_reason, 0))}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	MyTag.content({ number: x });
 	_html(`<button>${_text_resume($scope0_id, "c", x)}</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			MyTag.content({ value: x });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "8:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-conditional/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			MyTag.content({ value: x });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>Hello ${_text_resume($scope1_id, "#text/0", name, $sg__name * 2)} ${_text_resume($scope1_id, "#text/1", count, $sg__count * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "6:2");
 	}, $scope0_id) };
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	MyTag.content({
 		name: "Ryan",

--- a/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/define-tag-render-stateful/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>Hello ${_text_resume($scope1_id, "a", name, $sg__name * 2)} ${_text_resume($scope1_id, "b", count, $sg__count * 2)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	MyTag.content({
 		name: "Ryan",

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,7 @@ var parent_default = _template("__tests__/tags/parent.marko", (input) => {
 		if (true) {
 			const $scope1_id = _scope_id();
 			const label = shut ? `${prefix}:shut` : `${prefix}:open`;
-			_set_serialize_reason(1);
+			_set_serialize_reason(10);
 			const $childScope = _peek_scope_id();
 			child_default({
 				label,
@@ -58,7 +58,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	parent_default({
 		count,

--- a/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/derived-from-closures-updates-tag-input/__snapshots__/html.bundle.js
@@ -18,7 +18,7 @@ var parent_default = _template("c", (input) => {
 		{
 			const $scope1_id = _scope_id();
 			const label = shut ? `${prefix}:shut` : `${prefix}:open`;
-			_set_serialize_reason(1);
+			_set_serialize_reason(10);
 			const $childScope = _peek_scope_id();
 			child_default({
 				label,
@@ -52,7 +52,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	parent_default({
 		count,

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ show });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/dynamic-tag-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ show });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			list_default({ count });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-cleanup-free-branch/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			list_default({ count });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -22,7 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ count });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/for-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -22,7 +22,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ count });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.debug.js
@@ -24,7 +24,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			leaf_default({ n });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-cleanup-free-branch/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			leaf_default({ n });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.debug.js
@@ -33,7 +33,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			wrapper_default({ show });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-link-via-nested-component-cleanup/__snapshots__/html.bundle.js
@@ -33,7 +33,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			wrapper_default({ show });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.debug.js
@@ -25,7 +25,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (outer) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ show });
 			_scope($scope1_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/if-resume-owns-branch-cleanup/__snapshots__/html.bundle.js
@@ -25,7 +25,7 @@ var template_default = _template("a", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			child_default({ show });
 			_scope($scope1_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let quiet = whisper;
 	let message = "Hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}<button>whisper</button>${_el_resume($scope0_id, "#button/1")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-aliased-exported-registered-function/__snapshots__/html.bundle.js
@@ -20,7 +20,7 @@ var template_default = _template("a", (input) => {
 	let quiet = whisper;
 	let message = "Hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}<button>whisper</button>${_el_resume($scope0_id, "b")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let message = "hello";
 	_html(`<button>add</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message: shout(message) });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-non-registered-function/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let message = "hello";
 	_html(`<button>add</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message: shout(message) });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var panel_default = _template("__tests__/tags/panel.marko", (input) => {
 	let format = shout;
 	let message = "panel";
 	_html(`<button>panel</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "__tests__/tags/panel.marko_0");
@@ -39,7 +39,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let format = shout;
 	let message = "page";
 	_html(`<button>page</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	panel_default({});

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function-shared/__snapshots__/html.bundle.js
@@ -17,7 +17,7 @@ var panel_default = _template("c", (input) => {
 	let format = shout;
 	let message = "panel";
 	_html(`<button>panel</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "c0");
@@ -36,7 +36,7 @@ var template_default = _template("a", (input) => {
 	let format = shout;
 	let message = "page";
 	_html(`<button>page</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	panel_default({});

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let format = shout;
 	let message = "hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-exported-registered-function/__snapshots__/html.bundle.js
@@ -17,7 +17,7 @@ var template_default = _template("a", (input) => {
 	let format = shout;
 	let message = "hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.debug.js
@@ -24,7 +24,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let format = shout;
 	let message = "hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-re-exported-registered-function/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 	let format = shout;
 	let message = "hello";
 	_html(`<button>shout</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	greeting_default({ message });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-cycle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-cycle/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var cyc_a_default = _template("__tests__/tags/cyc-a.marko", (input) => {
 	_if(() => {
 		if (input.depth < 2) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			cyc_b_default({ depth: input.depth + 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -34,7 +34,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 0;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	cyc_a_default({ depth: n });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/import-tag-cycle/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/import-tag-cycle/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var cyc_a_default = _template("b", (input) => {
 	_if(() => {
 		if (input.depth < 2) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			cyc_b_default({ depth: input.depth + 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -34,7 +34,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 0;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	cyc_a_default({ depth: n });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.debug.js
@@ -25,7 +25,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 			"ClosureScopes:input_name": $si__input_name && $Child_content__input_name__closures
 		}, "__tests__/template.marko", "6:2", { input_name: ["input.name", "6:15"] });
 	}, $scope0_id) };
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	Child.content({ count });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-missing-property/__snapshots__/html.bundle.js
@@ -25,7 +25,7 @@ var template_default = _template("a", (input) => {
 			f: $si__input_name && $Child_content__input_name__closures
 		});
 	}, $scope0_id) };
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	Child.content({ count });
 	_script($scope0_id, "a1");

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.debug.js
@@ -11,10 +11,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "1:1");
 	}, $scope0_id) };
 	const { text } = input;
-	_set_serialize_reason({
-		0: $sg__input_text2,
-		1: $sg__input_text2
-	});
+	_set_serialize_reason($sg__input_text2 << 1 | $sg__input_text2 << 3);
 	const $childScope = _peek_scope_id();
 	Child.content({
 		text: input.text,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-property-alias-closure/__snapshots__/html.bundle.js
@@ -11,10 +11,7 @@ var template_default = _template("a", (input) => {
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
 	const { text } = input;
-	_set_serialize_reason({
-		0: $sg__input_text2,
-		1: $sg__input_text2
-	});
+	_set_serialize_reason($sg__input_text2 << 1 | $sg__input_text2 << 3);
 	const $childScope = _peek_scope_id();
 	Child.content({
 		text: input.text,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = "hi";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_input_default({
 		value,

--- a/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/input-spread-value-also-read/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = "hi";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	my_input_default({
 		value,

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let n = 1;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_default({ n });
 	_html(`<button>inc</button>${_el_resume($scope0_id, "#button/1")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/intersection-collapse-input-param/__snapshots__/html.bundle.js
@@ -11,7 +11,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let n = 1;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_default({ n });
 	_html(`<button>inc</button>${_el_resume($scope0_id, "b")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.debug.js
@@ -10,11 +10,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_a2 = _serialize_guard($scope0_reason, 1), $sg__input_b2 = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input_a__OR__input_b,
-		1: $sg__input_a2,
-		2: $sg__input_b2
-	});
+	_set_serialize_reason($sg__input_a__OR__input_b << 1 | $sg__input_a2 << 3 | $sg__input_b2 << 5);
 	const $childScope = _peek_scope_id();
 	child_default({
 		a: input.a,
@@ -26,11 +22,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "#text/0", input.a, $sg__input_a)}</div><div>${_text_resume($scope1_id, "#text/1", input.b, $sg__input_b)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "3:2");
 	}, $scope0_id) };
-	_set_serialize_reason({
-		0: $sg__input_a__OR__input_b,
-		1: $sg__input_a2,
-		2: $sg__input_b2
-	});
+	_set_serialize_reason($sg__input_a__OR__input_b << 1 | $sg__input_a2 << 3 | $sg__input_b2 << 5);
 	const $childScope2 = _peek_scope_id();
 	Child.content({
 		a: input.a,

--- a/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/isolated-known-tag-param-serialize-groups/__snapshots__/html.bundle.js
@@ -10,11 +10,7 @@ var child_default = _template("b", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_a__OR__input_b = _serialize_guard($scope0_reason, 0), $sg__input_a2 = _serialize_guard($scope0_reason, 1), $sg__input_b2 = _serialize_guard($scope0_reason, 2);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input_a__OR__input_b,
-		1: $sg__input_a2,
-		2: $sg__input_b2
-	});
+	_set_serialize_reason($sg__input_a__OR__input_b << 1 | $sg__input_a2 << 3 | $sg__input_b2 << 5);
 	const $childScope = _peek_scope_id();
 	child_default({
 		a: input.a,
@@ -26,11 +22,7 @@ var template_default = _template("a", (input) => {
 		_html(`<div>${_text_resume($scope1_id, "a", input.a, $sg__input_a)}</div><div>${_text_resume($scope1_id, "b", input.b, $sg__input_b)}</div>`);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason({
-		0: $sg__input_a__OR__input_b,
-		1: $sg__input_a2,
-		2: $sg__input_b2
-	});
+	_set_serialize_reason($sg__input_a__OR__input_b << 1 | $sg__input_a2 << 3 | $sg__input_b2 << 5);
 	const $childScope2 = _peek_scope_id();
 	Child.content({
 		a: input.a,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.debug.js
@@ -12,11 +12,11 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		(_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _subscribe($si__input && $input__closures, _scope($scope1_id, { _: $si__input && _scope_with_id($scope0_id) }, "__tests__/template.marko", "3:2"));
 		$sg__input || $sg__a || $sg__b || (_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _resume_branch($scope1_id);
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	MyTag.content(...args);
 	MyTag.content(7, 8, 9);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	let $cgrp;
 	if (x) {
 		$cgrp = attrTag({ y: 1 });

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-args-spread/__snapshots__/html.bundle.js
@@ -12,11 +12,11 @@ var template_default = _template("a", (input) => {
 		(_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _subscribe($si__input && $input__closures, _scope($scope1_id, { _: $si__input && _scope_with_id($scope0_id) }));
 		$sg__input || $sg__a || $sg__b || (_serialize_if($scope0_reason, 0) || _serialize_if($scope1_reason, 0)) && _resume_branch($scope1_id);
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	const $childScope = _peek_scope_id();
 	MyTag.content(...args);
 	MyTag.content(7, 8, 9);
-	_set_serialize_reason(1);
+	_set_serialize_reason(42);
 	let $cgrp;
 	$cgrp = attrTag({ y: 1 });
 	const $childScope2 = _peek_scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		first: n,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest-order/__snapshots__/html.bundle.js
@@ -13,7 +13,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		first: n,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.debug.js
@@ -17,12 +17,7 @@ var child_default = _template("__tests__/tags/child/index.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { title, ...rest } = input;
 	_html(`<h1>${_text_resume($scope0_id, "#text/0", title, $sg__input_title)}</h1>`);
-	_set_serialize_reason({
-		0: $sg__rest,
-		1: $sg__rest,
-		2: $sg__rest,
-		3: $sg__rest
-	});
+	_set_serialize_reason($sg__rest << 1 | $sg__rest << 3 | $sg__rest << 5 | $sg__rest << 7);
 	const $childScope = _peek_scope_id();
 	inner_default({ stuff: rest });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _serialize_if($scope0_reason, 2) && _existing_scope($childScope) }, "__tests__/tags/child/index.marko", 0);
@@ -34,7 +29,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	let $cond;
 	if (cond) {
 		$cond = attrTag({ a: 1 });

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-rest/__snapshots__/html.bundle.js
@@ -17,12 +17,7 @@ var child_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	const { title, ...rest } = input;
 	_html(`<h1>${_text_resume($scope0_id, "a", title, $sg__input_title)}</h1>`);
-	_set_serialize_reason({
-		0: $sg__rest,
-		1: $sg__rest,
-		2: $sg__rest,
-		3: $sg__rest
-	});
+	_set_serialize_reason($sg__rest << 1 | $sg__rest << 3 | $sg__rest << 5 | $sg__rest << 7);
 	const $childScope = _peek_scope_id();
 	inner_default({ stuff: rest });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _serialize_if($scope0_reason, 2) && _existing_scope($childScope) });
@@ -34,7 +29,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let cond = true;
 	_html(`<button>toggle</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	let $cond;
 	$cond = attrTag({ a: 1 });
 	const $childScope = _peek_scope_id();

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	if (true) {} else if (false) {} else {}
 	const $childScope = _peek_scope_id();
 	child_default({

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-attr-tags-unused/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_default({
 		a: n,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var mid_default = _template("__tests__/tags/mid.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const { first, group: { keep, ...rest } } = input;
 	_html(`<p>${_text_resume($scope0_id, "#text/0", first, $sg__input_first)} ${_text_resume($scope0_id, "#text/1", keep, $sg__input_group_keep * 2)}</p>`);
-	_set_serialize_reason($sg__rest);
+	_set_serialize_reason($sg__rest << 1);
 	const $childScope = _peek_scope_id();
 	leaf_default({ data: rest });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/2": _serialize_if($scope0_reason, 3) && _existing_scope($childScope) }, "__tests__/tags/mid.marko", 0);
@@ -24,7 +24,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(26);
+	_set_serialize_reason(162);
 	const $childScope = _peek_scope_id();
 	mid_default({
 		first: "f",

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-nested-rest/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var mid_default = _template("c", (input) => {
 	const $scope0_id = _scope_id();
 	const { first, group: { keep, ...rest } } = input;
 	_html(`<p>${_text_resume($scope0_id, "a", first, $sg__input_first)} ${_text_resume($scope0_id, "b", keep, $sg__input_group_keep * 2)}</p>`);
-	_set_serialize_reason($sg__rest);
+	_set_serialize_reason($sg__rest << 1);
 	const $childScope = _peek_scope_id();
 	leaf_default({ data: rest });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { c: _serialize_if($scope0_reason, 3) && _existing_scope($childScope) });
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(26);
+	_set_serialize_reason(162);
 	const $childScope = _peek_scope_id();
 	mid_default({
 		first: "f",

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.debug.js
@@ -11,10 +11,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		_script($scope1_id, "__tests__/template.marko_1_a#8", $sg__input_a || $sg__b);
 		_scope($scope1_id, { input_a: input.a }, "__tests__/template.marko", "1:2", { input_a: ["input.a", "1:15"] });
 	}, $scope0_id) };
-	_set_serialize_reason({
-		0: _serialize_guard($scope0_reason, 1),
-		1: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1) << 1 | _serialize_guard($scope0_reason, 2) << 3);
 	const $childScope = _peek_scope_id();
 	Child.content({
 		a: input.a,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-param-serialize-alias/__snapshots__/html.bundle.js
@@ -11,10 +11,7 @@ var template_default = _template("a", (input) => {
 		_script($scope1_id, "a2", $sg__input_a || $sg__b);
 		_scope($scope1_id, { e: input.a });
 	}, $scope0_id) };
-	_set_serialize_reason({
-		0: _serialize_guard($scope0_reason, 1),
-		1: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason(_serialize_guard($scope0_reason, 1) << 1 | _serialize_guard($scope0_reason, 2) << 3);
 	const $childScope = _peek_scope_id();
 	Child.content({
 		a: input.a,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const j2 = { a: 6 };
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_b_default({
 		...j1,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-dropped-refs/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 	const j2 = { a: 6 };
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_b_default({
 		...j1,

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const Bar = { content: _content("__tests__/template.marko_2*content", (input) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason(), $sg__input_foo2 = _serialize_guard($scope2_reason, 0);
-		_set_serialize_reason($sg__input_foo2);
+		_set_serialize_reason($sg__input_foo2 << 1);
 		const $childScope = _peek_scope_id();
 		Foo.content(input);
 		_serialize_if($scope2_reason, 0) && _scope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "5:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread-unused/__snapshots__/html.bundle.js
@@ -11,7 +11,7 @@ var template_default = _template("a", (input) => {
 	({ content: _content("a1", (input) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		_set_serialize_reason(_serialize_guard($scope2_reason, 0) << 1);
 		const $childScope = _peek_scope_id();
 		Foo.content(input);
 		_serialize_if($scope2_reason, 0) && _scope($scope2_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.debug.js
@@ -24,23 +24,19 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	};
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(170);
 	const $childScope = _peek_scope_id();
 	child_a_default({
 		a: n,
 		...extras
 	});
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope2 = _peek_scope_id();
 	child_a_default({
 		...extras,
 		a: n
 	});
-	_set_serialize_reason({
-		0: _serialize_guard($scope0_reason, 0),
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope3 = _peek_scope_id();
 	child_c_default(input.settings);
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/known-tag-spread/__snapshots__/html.bundle.js
@@ -24,23 +24,19 @@ var template_default = _template("a", (input) => {
 	};
 	let n = 1;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(170);
 	const $childScope = _peek_scope_id();
 	child_a_default({
 		a: n,
 		...extras
 	});
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope2 = _peek_scope_id();
 	child_a_default({
 		...extras,
 		a: n
 	});
-	_set_serialize_reason({
-		0: _serialize_guard($scope0_reason, 0),
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope3 = _peek_scope_id();
 	child_c_default(input.settings);
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-attrs-update/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (count % 2 === 0) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(10);
+			_set_serialize_reason(34);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({
 				label: "x",

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-conditional-child-inert/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(10);
+			_set_serialize_reason(34);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({
 				label: "x",

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-attrs-update/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-auto/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-auto/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button class=load>load</button>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-class/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button class=load>load</button>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button id=load>load</button>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-selector-id/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_html("<button id=load>load</button>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			_scope($scope1_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event-unmount-before-load/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			_scope($scope1_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-event/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<!DOCTYPE html><html><head><title>Head Flush Test</title>${_flush_head()}</head><body>`);
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_trailers("</body></html>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-head/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	_html(`<!DOCTYPE html><html><head><title>Head Flush Test</title>${_flush_head()}</head><body>`);
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_trailers("</body></html>");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-attrs-update/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			_scope($scope1_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", "6:2");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle-unmount-before-load/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("b", (input) => {
 	_if(() => {
 		{
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			$Child_withLoadAssets({ value });
 			_scope($scope1_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-idle/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
-		_set_serialize_reason($sg__input_label);
+		_set_serialize_reason($sg__input_label << 1);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ label: input.label });
 		$si__input_label && _subscribe($input_label__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-entry-error/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("b", (input) => {
 	_try($scope0_id, "a", _content_resume("b1", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_set_serialize_reason($sg__input_label);
+		_set_serialize_reason($sg__input_label << 1);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ label: input.label });
 		$si__input_label && _subscribe($input_label__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
-		_set_serialize_reason($sg__input_label);
+		_set_serialize_reason($sg__input_label << 1);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ label: input.label });
 		$si__input_label && _subscribe($input_label__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-load-script-error/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("b", (input) => {
 	_try($scope0_id, "a", _content_resume("b1", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_set_serialize_reason($sg__input_label);
+		_set_serialize_reason($sg__input_label << 1);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ label: input.label });
 		$si__input_label && _subscribe($input_label__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/2")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-marker-walk-offset/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ var template_default = _template("b", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let value = 0;
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "c")}`);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-media/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	let show = true;
 	let value = 0;
 	_html(`<button class=toggle>Toggle</button>${_el_resume($scope0_id, "#button/0")}<button class=inc>Inc</button>${_el_resume($scope0_id, "#button/1")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_dynamic_tag($scope0_id, "#text/4", show ? $Child_withLoadAssets : null, { value });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-mixed-known-and-dynamic/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("b", (input) => {
 	let show = true;
 	let value = 0;
 	_html(`<button class=toggle>Toggle</button>${_el_resume($scope0_id, "a")}<button class=inc>Inc</button>${_el_resume($scope0_id, "b")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_dynamic_tag($scope0_id, "e", $Child_withLoadAssets, { value });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-attrs-update/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-fallback/__snapshots__/html.bundle.js
@@ -18,7 +18,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button id=inc>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger-visible-wins/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button id=inc>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.debug.js
@@ -18,7 +18,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multi-trigger/__snapshots__/html.bundle.js
@@ -18,7 +18,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.debug.js
@@ -24,10 +24,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$ChildA_withLoadAssets({ value });
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	$ChildB_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-multiple/__snapshots__/html.bundle.js
@@ -24,10 +24,10 @@ var template_default = _template("c", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$ChildA_withLoadAssets({ value });
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	$ChildB_withLoadAssets({ value });
 	_script($scope0_id, "c0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var child_default = _template("__tests__/child.marko", (input) => {
 	_await($scope0_id, "#text/2", resolveAfter(10, 1), (value) => {
 		const $scope1_id = _scope_id();
 		_html(`<span id=child-await>${_escape(value)}</span>`);
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		$GrandChild_withLoadAssets({ value: count });
 		_subscribe($count__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested-async/__snapshots__/html.bundle.js
@@ -23,7 +23,7 @@ var child_default = _template("a", (input) => {
 	_await($scope0_id, "c", resolveAfter(10, 1), (value) => {
 		const $scope1_id = _scope_id();
 		_html(`<span id=child-await>${_escape(value)}</span>`);
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		$GrandChild_withLoadAssets({ value: count });
 		_subscribe($count__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ const $GrandChild_withLoadAssets = withLoadAssets(grand_child_default, "ready:__
 var child_default = _template("__tests__/child.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$GrandChild_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/child.marko", 0);
@@ -23,7 +23,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-nested/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ const $GrandChild_withLoadAssets = withLoadAssets(grand_child_default, "_b");
 var child_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$GrandChild_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });
@@ -23,7 +23,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a");
 var template_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button class=parent>parent: ${_text_resume($scope0_id, "#text/1", value, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-parent-scope-child-state/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button class=parent>parent: ${_text_resume($scope0_id, "b", value, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_try($scope0_id, "#text/0", _content_resume("__tests__/template.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ value: count });
 		_subscribe($count__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-placeholder/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("b", (input) => {
 	_try($scope0_id, "a", _content_resume("b1", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		$Child_withLoadAssets({ value: count });
 		_subscribe($count__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.debug.js
@@ -12,7 +12,7 @@ const $Child_withLoadAssets$1 = withLoadAssets(child_default, "ready:__tests__/t
 var parent_a_default = _template("__tests__/tags/parent-a.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets$1({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/tags/parent-a.marko", 0);
@@ -23,7 +23,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/tag
 var parent_b_default = _template("__tests__/tags/parent-b.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value * 2 });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/tags/parent-b.marko", 0);
@@ -35,10 +35,10 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 1;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	parent_a_default({ value });
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	parent_b_default({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-shared-parent/__snapshots__/html.bundle.js
@@ -12,7 +12,7 @@ const $Child_withLoadAssets$1 = withLoadAssets(child_default, "_b");
 var parent_a_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets$1({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });
@@ -23,7 +23,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_b");
 var parent_b_default = _template("d", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value * 2 });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });
@@ -35,10 +35,10 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 1;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	parent_a_default({ value });
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	parent_b_default({ value });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-var-return-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-var-return-attrs-update/__snapshots__/html.bundle.debug.js
@@ -36,7 +36,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_if(() => {
 		if (mounted) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason(1);
+			_set_serialize_reason(2);
 			const $childScope = _peek_scope_id();
 			let focusChild = $Child_withLoadAssets({ label: `x${n}` });
 			_var($scope1_id, "#scopeOffset/2", $childScope, "__tests__/template.marko_1_focusChild#4/var");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-attrs-update/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("b", (input) => {
 	const $scope0_id = _scope_id();
 	let value = 0;
 	_html(`<button>Inc</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value });
 	_script($scope0_id, "b0");

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-auto/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-auto/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_try($scope0_id, "#text/2", _content_resume("__tests__/template.marko_1*content", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible-target-after-flush/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_try($scope0_id, "c", _content_resume("b1", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "ready:__tests__/chi
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/1": _existing_scope($childScope) }, "__tests__/template.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/lazy-tag-visible/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ const $Child_withLoadAssets = withLoadAssets(child_default, "_a", [{
 var template_default = _template("b", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_value);
+	_set_serialize_reason($sg__input_value << 1);
 	const $childScope = _peek_scope_id();
 	$Child_withLoadAssets({ value: input.value });
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { b: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.debug.js
@@ -19,7 +19,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 3;
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-bind-to-undefined/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 3;
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.debug.js
@@ -20,7 +20,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let initial = 1;
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		initial,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-change-handler-unassigned/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let initial = 1;
-	_set_serialize_reason(6);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		initial,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.debug.js
@@ -33,7 +33,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let source = 1;
-	_set_serialize_reason(1);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: source,

--- a/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/let-tag-controllable-child/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let source = 1;
-	_set_serialize_reason(1);
+	_set_serialize_reason(10);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value: source,

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.debug.js
@@ -11,13 +11,13 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const B = { content: _content("__tests__/template.marko_2*content", ({ value }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason(), $sg__value_length = _serialize_guard($scope2_reason, 0);
-		_set_serialize_reason($sg__value_length);
+		_set_serialize_reason($sg__value_length << 1);
 		const $childScope = _peek_scope_id();
 		A.content({ value: value.length });
 		_serialize_if($scope2_reason, 0) && _scope($scope2_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/template.marko", "4:1");
 	}, $scope0_id) };
 	let value = "";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	B.content({ value });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/merged-define-tag-templates/__snapshots__/html.bundle.js
@@ -11,13 +11,13 @@ var template_default = _template("a", (input) => {
 	const B = { content: _content("a1", ({ value }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		_set_serialize_reason(_serialize_guard($scope2_reason, 0));
+		_set_serialize_reason(_serialize_guard($scope2_reason, 0) << 1);
 		const $childScope = _peek_scope_id();
 		A.content({ value: value.length });
 		_serialize_if($scope2_reason, 0) && _scope($scope2_id, { a: _existing_scope($childScope) });
 	}, $scope0_id) };
 	let value = "";
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope2 = _peek_scope_id();
 	B.content({ value });
 	_script($scope0_id, "a2");

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.debug.js
@@ -33,7 +33,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count1 = 0;
 	let count2 = 0;
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	_2counters_default({
 		count1,

--- a/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/multiple-bound-values/__snapshots__/html.bundle.js
@@ -24,7 +24,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count1 = 0;
 	let count2 = 0;
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	_2counters_default({
 		count1,

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.debug.js
@@ -16,7 +16,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		}, 0, $scope1_id, "#text/0", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {}, "__tests__/template.marko", "3:2");
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	forUntil(size, 0, 1, (i) => {
 		$item = attrTags($item, { content: _content_resume("__tests__/template.marko_3*content", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-local-closures/__snapshots__/html.bundle.js
@@ -16,7 +16,7 @@ var template_default = _template("a", (input) => {
 		}, 0, $scope1_id, "a", $sg__input_item, $sg__input_item, $sg__input_item, 0, 1);
 		_serialize_if($scope1_reason, 0) && _scope($scope1_id, {});
 	}, $scope0_id) };
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	let $item;
 	forUntil(size, 0, 1, (i) => {
 		$item = attrTags($item, { content: _content_resume("a2", () => {

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_html("<div");
 	_attrs_content(input.head, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	echo_default(input.head);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input_head#4");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-attr-tag-also-custom/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var my_box_default = _template("c", (input) => {
 	_html("<div");
 	_attrs_content(input.head, "a", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	echo_default(input.head);
 	_script($scope0_id, "c0");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_html("<div");
 	_attrs_content(input, "#div/0", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "#div/0")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	echo_default(input);
 	_script($scope0_id, "__tests__/tags/my-box.marko_0_input#3");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-also-custom/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var my_box_default = _template("c", (input) => {
 	_html("<div");
 	_attrs_content(input, "a", $scope0_id, "div");
 	_html(`</div>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	echo_default(input);
 	_script($scope0_id, "c0");

--- a/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/native-tag-spread-content-opaque/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var my_box_default = _template("__tests__/tags/my-box.marko", (input) => {
 	_if(() => {
 		if (show) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input);
+			_set_serialize_reason($sg__input << 1);
 			const $childScope = _peek_scope_id();
 			render_input_default({ data: input });
 			_scope($scope1_id, { "#childScope/0": _serialize_if($scope0_reason, 0) && _existing_scope($childScope) }, "__tests__/tags/my-box.marko", "8:4");

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.debug.js
@@ -30,7 +30,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	const output = _el($scope0_id, "__tests__/template.marko_0_#div#0");
 	_html(`<div></div>${_el_resume($scope0_id, "#div/0")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		foo: input.foo,

--- a/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/no-render-content-conditional/__snapshots__/html.bundle.js
@@ -26,7 +26,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	const output = _el($scope0_id, "a0");
 	_html(`<div></div>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(_serialize_guard($scope0_reason, 0));
+	_set_serialize_reason(_serialize_guard($scope0_reason, 0) << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		foo: input.foo,

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.debug.js
@@ -14,7 +14,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let label = "a";
 	_html("<main>");
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	echo_default({
 		skip: "k",

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-of-rest-patch/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let label = "a";
 	_html("<main>");
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	echo_default({
 		skip: "k",

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.debug.js
@@ -13,7 +13,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let label = "a";
 	_html("<main>");
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	echo_default({ label });
 	_html(`<button>+</button>${_el_resume($scope0_id, "#button/1")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/rest-only-input/__snapshots__/html.bundle.js
@@ -13,7 +13,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let label = "a";
 	_html("<main>");
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	echo_default({ label });
 	_html(`<button>+</button>${_el_resume($scope0_id, "b")}</main>`);

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.debug.js
@@ -31,7 +31,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		_set_serialize_reason(1);
+		_set_serialize_reason(42);
 		const $childScope = _peek_scope_id();
 		child_default({
 			item,

--- a/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/resume-multi-branch-deferred-owner-adoption/__snapshots__/html.bundle.js
@@ -28,7 +28,7 @@ var template_default = _template("a", (input) => {
 	_for_of(items, (item) => {
 		const $scope1_id = _scope_id();
 		_html("<div>");
-		_set_serialize_reason(1);
+		_set_serialize_reason(42);
 		const $childScope = _peek_scope_id();
 		child_default({
 			item,

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.debug.js
@@ -23,7 +23,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(4);
+	_set_serialize_reason(8);
 	const $childScope = _peek_scope_id();
 	let setCount = setter_default({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/return-serialize-circular/__snapshots__/html.bundle.js
@@ -19,7 +19,7 @@ var template_default = _template("a", (input) => {
 	_scope_reason();
 	const $scope0_id = _scope_id();
 	let count = 0;
-	_set_serialize_reason(4);
+	_set_serialize_reason(8);
 	const $childScope = _peek_scope_id();
 	let setCount = setter_default({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/wrap.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-input/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.debug.js
@@ -19,10 +19,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__rest_option = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	_set_serialize_reason({
-		0: $sg__input_class__OR__rest_option,
-		1: _serialize_guard($scope0_reason, 1)
-	});
+	_set_serialize_reason($sg__input_class__OR__rest_option << 1 | _serialize_guard($scope0_reason, 1) << 3);
 	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-custom-tag/__snapshots__/html.bundle.js
@@ -19,10 +19,7 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__rest_option = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	_set_serialize_reason({
-		0: $sg__input_class__OR__rest_option,
-		1: _serialize_guard($scope0_reason, 1)
-	});
+	_set_serialize_reason($sg__input_class__OR__rest_option << 1 | _serialize_guard($scope0_reason, 1) << 3);
 	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.debug.js
@@ -19,10 +19,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const Wrap = { content: _content("__tests__/template.marko_2*content", ({ class: _class, ...rest }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason(), $sg___class__OR__rest_option = _serialize_guard($scope2_reason, 0);
-		_set_serialize_reason({
-			0: $sg___class__OR__rest_option,
-			1: _serialize_guard($scope2_reason, 1)
-		});
+		_set_serialize_reason($sg___class__OR__rest_option << 1 | _serialize_guard($scope2_reason, 1) << 3);
 		const $childScope = _peek_scope_id();
 		Child.content({
 			class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-attr-tag-define-tag/__snapshots__/html.bundle.js
@@ -19,10 +19,7 @@ var template_default = _template("a", (input) => {
 	({ content: _content("a2", ({ class: _class, ...rest }) => {
 		const $scope2_id = _scope_id();
 		const $scope2_reason = _scope_reason();
-		_set_serialize_reason({
-			0: _serialize_guard($scope2_reason, 0),
-			1: _serialize_guard($scope2_reason, 1)
-		});
+		_set_serialize_reason(_serialize_guard($scope2_reason, 0) << 1 | _serialize_guard($scope2_reason, 1) << 3);
 		const $childScope = _peek_scope_id();
 		Child.content({
 			class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.debug.js
@@ -13,11 +13,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__rest_content = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	_set_serialize_reason({
-		0: $sg__input_class__OR__rest_content,
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason($sg__input_class__OR__rest_content << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-content/__snapshots__/html.bundle.js
@@ -13,11 +13,7 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__rest_content = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { class: _class, ...rest } = input;
-	_set_serialize_reason({
-		0: $sg__input_class__OR__rest_content,
-		1: _serialize_guard($scope0_reason, 1),
-		2: _serialize_guard($scope0_reason, 2)
-	});
+	_set_serialize_reason($sg__input_class__OR__rest_content << 1 | _serialize_guard($scope0_reason, 1) << 3 | _serialize_guard($scope0_reason, 2) << 5);
 	const $childScope = _peek_scope_id();
 	child_default({
 		class: _class,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.debug.js
@@ -10,13 +10,13 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0), $sg__input_class = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class);
+	_set_serialize_reason($sg__input_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		value: "override"
 	});
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	const $childScope2 = _peek_scope_id();
 	child_default({
 		value: "default",

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-defaults/__snapshots__/html.bundle.js
@@ -10,13 +10,13 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0), $sg__input_class = _serialize_guard($scope0_reason, 1);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class);
+	_set_serialize_reason($sg__input_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		...input,
 		value: "override"
 	});
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	const $childScope2 = _peek_scope_id();
 	child_default({
 		value: "default",

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.debug.js
@@ -10,10 +10,10 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope2 = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-children/__snapshots__/html.bundle.js
@@ -10,10 +10,10 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope2 = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		...input,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-multiple-spread-exprs/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input);
+	_set_serialize_reason($sg__input << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		...input,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value__OR__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__input_value__OR__rest_class);
+	_set_serialize_reason($sg__input_value__OR__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value,
@@ -25,7 +25,7 @@ var wrap_outer_default = _template("__tests__/tags/wrap-outer.marko", (input) =>
 	const $scope0_reason = _scope_reason(), $sg__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__rest_class);
+	_set_serialize_reason($sg__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		value: "abcd",

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-deep/__snapshots__/html.bundle.js
@@ -11,7 +11,7 @@ var wrap_default = _template("d", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value__OR__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__input_value__OR__rest_class);
+	_set_serialize_reason($sg__input_value__OR__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value,
@@ -25,7 +25,7 @@ var wrap_outer_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__rest_class);
+	_set_serialize_reason($sg__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		value: "abcd",

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.debug.js
@@ -27,7 +27,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	}, _content_resume("__tests__/tags/wrap.marko_1*content", () => {
 		const $scope1_id = _scope_id();
 		const $scope1_reason = _scope_reason();
-		_set_serialize_reason($sg__input_foo);
+		_set_serialize_reason($sg__input_foo << 1);
 		const $childScope = _peek_scope_id();
 		child_default({ foo: input.foo });
 		_subscribe($si__input_foo && $input_foo__closures, _scope($scope1_id, {
@@ -52,11 +52,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input,
-		2: $sg__input,
-		3: $sg__input
-	});
+	_set_serialize_reason($sg__input << 1 | $sg__input << 5 | $sg__input << 7);
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		"data-one": 2,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest-input-with-attr-tags-deopt/__snapshots__/html.bundle.js
@@ -27,7 +27,7 @@ var wrap_default = _template("c", (input) => {
 	}, _content_resume("c0", () => {
 		const $scope1_id = _scope_id();
 		_scope_reason();
-		_set_serialize_reason($sg__input_foo);
+		_set_serialize_reason($sg__input_foo << 1);
 		const $childScope = _peek_scope_id();
 		child_default({ foo: input.foo });
 		_subscribe($si__input_foo && $input_foo__closures, _scope($scope1_id, {
@@ -48,11 +48,7 @@ var wrap_default = _template("c", (input) => {
 var template_default = _template("a", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason({
-		0: $sg__input,
-		2: $sg__input,
-		3: $sg__input
-	});
+	_set_serialize_reason($sg__input << 1 | $sg__input << 5 | $sg__input << 7);
 	const $childScope = _peek_scope_id();
 	wrap_default({
 		"data-one": 2,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.debug.js
@@ -11,7 +11,7 @@ var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value__OR__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__input_value__OR__rest_class);
+	_set_serialize_reason($sg__input_value__OR__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known-rest/__snapshots__/html.bundle.js
@@ -11,7 +11,7 @@ var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_value__OR__rest_class = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
 	const { value, ...rest } = input;
-	_set_serialize_reason($sg__input_value__OR__rest_class);
+	_set_serialize_reason($sg__input_value__OR__rest_class << 1);
 	const $childScope = _peek_scope_id();
 	child_default({
 		value,

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.debug.js
@@ -10,7 +10,7 @@ var child_default = _template("__tests__/tags/child.marko", (input) => {
 var wrap_default = _template("__tests__/tags/wrap.marko", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { "#childScope/0": _existing_scope($childScope) }, "__tests__/tags/wrap.marko", 0);

--- a/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/spread-to-known/__snapshots__/html.bundle.js
@@ -10,7 +10,7 @@ var child_default = _template("b", (input) => {
 var wrap_default = _template("c", (input) => {
 	const $scope0_reason = _scope_reason(), $sg__input_class__OR__input_value = _serialize_guard($scope0_reason, 0);
 	const $scope0_id = _scope_id();
-	_set_serialize_reason($sg__input_class__OR__input_value);
+	_set_serialize_reason($sg__input_class__OR__input_value << 1);
 	const $childScope = _peek_scope_id();
 	child_default(input);
 	_serialize_if($scope0_reason, 0) && _scope($scope0_id, { a: _existing_scope($childScope) });

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.debug.js
@@ -17,7 +17,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		});
 	}, $scope0_id) };
 	_html(`<button>Increment</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	Foo.content({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-param-if-closure/__snapshots__/html.bundle.js
@@ -14,7 +14,7 @@ var template_default = _template("a", (input) => {
 		});
 	}, $scope0_id) };
 	_html(`<button>Increment</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(10);
+	_set_serialize_reason(34);
 	const $childScope = _peek_scope_id();
 	Foo.content({
 		value: count,

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.debug.js
@@ -21,7 +21,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 1;
 	_html(`<button>${_text_resume($scope0_id, "#text/1", count)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	let x = child_default({ value: count });
 	_var($scope0_id, "#scopeOffset/3", $childScope, "__tests__/template.marko_0_x#6/var");

--- a/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tag-var-with-serialize-reason/__snapshots__/html.bundle.js
@@ -21,7 +21,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let count = 1;
 	_html(`<button>${_text_resume($scope0_id, "b", count)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	child_default({ value: count });
 	_var($scope0_id, "d", $childScope, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-cycle/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-cycle/__snapshots__/html.bundle.debug.js
@@ -15,7 +15,7 @@ var cyc_a_default = _template("__tests__/tags/cyc-a/index.marko", (input) => {
 	_if(() => {
 		if (input.depth < 2) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			cyc_b_default({ depth: input.depth + 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -34,7 +34,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 0;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	cyc_a_default({ depth: n });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-cycle/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-cycle/__snapshots__/html.bundle.js
@@ -15,7 +15,7 @@ var cyc_a_default = _template("b", (input) => {
 	_if(() => {
 		if (input.depth < 2) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			cyc_b_default({ depth: input.depth + 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -34,7 +34,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 0;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	cyc_a_default({ depth: n });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.debug.js
@@ -6,7 +6,7 @@ const $content = (input) => {
 	_if(() => {
 		if (input.depth) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			$content({ depth: input.depth - 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -27,7 +27,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 2;
 	_html(`<button>inc ${_text_resume($scope0_id, "#text/1", n, 2)}</button>${_el_resume($scope0_id, "#button/0")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	tree_default({ depth: n });
 	_script($scope0_id, "__tests__/template.marko_0");

--- a/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/tags-dir-recursive/__snapshots__/html.bundle.js
@@ -6,7 +6,7 @@ const $content = (input) => {
 	_if(() => {
 		if (input.depth) {
 			const $scope1_id = _scope_id();
-			_set_serialize_reason($sg__input_depth);
+			_set_serialize_reason($sg__input_depth << 1);
 			const $childScope = _peek_scope_id();
 			$content({ depth: input.depth - 1 });
 			$si__input_depth && _scope($scope1_id, {
@@ -27,7 +27,7 @@ var template_default = _template("a", (input) => {
 	const $scope0_id = _scope_id();
 	let n = 2;
 	_html(`<button>inc ${_text_resume($scope0_id, "b", n, 2)}</button>${_el_resume($scope0_id, "a")}`);
-	_set_serialize_reason(1);
+	_set_serialize_reason(2);
 	const $childScope = _peek_scope_id();
 	tree_default({ depth: n });
 	_script($scope0_id, "a0");

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-nested/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-nested/__snapshots__/html.bundle.debug.js
@@ -28,7 +28,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 				_await($scope3_id, "#text/0", resolveAfter("inner", 4), (inner) => {
 					const $scope4_id = _scope_id();
 					_script($scope4_id, "__tests__/template.marko_4_clicks#3/pending");
-					_set_serialize_reason(1);
+					_set_serialize_reason(2);
 					const $childScope = _peek_scope_id();
 					note_default({ label: `${inner} ${clicks}` });
 					_scope($scope4_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-nested/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-nested/__snapshots__/html.bundle.js
@@ -28,7 +28,7 @@ var template_default = _template("a", (input) => {
 				_await($scope3_id, "a", resolveAfter("inner", 4), (inner) => {
 					const $scope4_id = _scope_id();
 					_script($scope4_id, "a0");
-					_set_serialize_reason(1);
+					_set_serialize_reason(2);
 					const $childScope = _peek_scope_id();
 					note_default({ label: `${inner} ${clicks}` });
 					_scope($scope4_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-template-id-collision/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-template-id-collision/__snapshots__/html.bundle.debug.js
@@ -53,7 +53,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("__tests__/template.marko_1*content", () => {
 		_scope_reason();
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		n1_default({ label: `placeholder ${clicks}` });
 		_subscribe($clicks__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-template-id-collision/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/try-placeholder-stateful-template-id-collision/__snapshots__/html.bundle.js
@@ -53,7 +53,7 @@ var template_default = _template("a", (input) => {
 	}, $scope0_id), { placeholder: attrTag({ content: _content_resume("a2", () => {
 		_scope_reason();
 		const $scope1_id = _scope_id();
-		_set_serialize_reason(1);
+		_set_serialize_reason(2);
 		const $childScope = _peek_scope_id();
 		n1_default({ label: `placeholder ${clicks}` });
 		_subscribe($clicks__closures, _scope($scope1_id, {

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.debug.js
@@ -32,7 +32,7 @@ var template_default = _template("__tests__/template.marko", (input) => {
 		});
 	}, $scope0_id) };
 	let x = 1;
-	_set_serialize_reason(26);
+	_set_serialize_reason(162);
 	const $childScope = _peek_scope_id();
 	Wrap.content({
 		as: "div",

--- a/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
+++ b/packages/runtime-tags/src/__tests__/fixtures/unused-dynamic-tag-body-serialize-reason/__snapshots__/html.bundle.js
@@ -25,7 +25,7 @@ var template_default = _template("a", (input) => {
 		});
 	}, $scope0_id) };
 	let x = 1;
-	_set_serialize_reason(26);
+	_set_serialize_reason(162);
 	const $childScope = _peek_scope_id();
 	Wrap.content({
 		as: "div",

--- a/packages/runtime-tags/src/html/compat.ts
+++ b/packages/runtime-tags/src/html/compat.ts
@@ -12,6 +12,7 @@ import {
   _scope_id,
   _script,
   _set_serialize_reason,
+  CLIENT_ALL,
   $global,
   Boundary,
   Chunk,
@@ -157,7 +158,7 @@ export const compat = {
         _script(scopeId, SET_SCOPE_REGISTER_ID);
       }
 
-      _set_serialize_reason(willRerender ? 1 : 0);
+      _set_serialize_reason(willRerender ? CLIENT_ALL : 0);
       try {
         renderer(normalizedInput);
       } finally {

--- a/packages/runtime-tags/src/html/dynamic-tag.ts
+++ b/packages/runtime-tags/src/html/dynamic-tag.ts
@@ -22,6 +22,7 @@ import {
   _scope_id,
   _script,
   _set_serialize_reason,
+  CLIENT_ALL,
   applyBranchStart,
   deferBranchStart,
   getChunk,
@@ -184,7 +185,7 @@ export let _dynamic_tag = (
       if (renderer) {
         try {
           _set_serialize_reason(
-            shouldResume && inputOrArgs !== undefined ? 1 : 0,
+            shouldResume && inputOrArgs !== undefined ? CLIENT_ALL : 0,
           );
           return inputIsArgs
             ? renderer(...(inputOrArgs as unknown[]))

--- a/packages/runtime-tags/src/html/writer.ts
+++ b/packages/runtime-tags/src/html/writer.ts
@@ -833,10 +833,22 @@ export function _subscribe(
 }
 
 // A reason is 1, empty, an offset group bitmask, or a keyed dynamic guard.
+// A reason: two bits per param-reason group at `1 + 2 * group` (the low
+// bit says the group serializes), a keyed object of group values, or none.
 export type SerializeReasonValue =
   | undefined
   | number
-  | Partial<Record<string, 0 | 1>>;
+  | Partial<Record<string, number>>;
+
+// Every group serializes: for a child whose groups the caller cannot see.
+export const CLIENT_ALL = 0x2aaaaaaa;
+
+// A group's 2-bit value; no mask at all means nothing serializes.
+export function maskGroup(mask: SerializeReasonValue, group: number) {
+  return typeof mask === "number"
+    ? (mask >>> (1 + 2 * group)) & 3
+    : ((mask as Partial<Record<number, number>>)[group] ?? 0);
+}
 
 export function _set_serialize_reason(reason: SerializeReasonValue) {
   $chunk.boundary.state.serializeReason = reason;
@@ -849,13 +861,7 @@ export function _scope_reason() {
 }
 
 export function _serialize_if(condition: SerializeReasonValue, key: number) {
-  return condition &&
-    (condition === 1 ||
-      (typeof condition === "number"
-        ? (condition >>> (key + 1)) & 1
-        : condition[key]))
-    ? 1
-    : undefined;
+  return condition && maskGroup(condition, key) ? 1 : undefined;
 }
 
 export function _serialize_guard(condition: SerializeReasonValue, key: number) {

--- a/packages/runtime-tags/src/translator/util/known-tag.ts
+++ b/packages/runtime-tags/src/translator/util/known-tag.ts
@@ -50,7 +50,7 @@ import {
   type Section,
   startSection,
 } from "./sections";
-import { getSerializeGuard } from "./serialize-guard";
+import { buildGroupMask, getSerializeGuard } from "./serialize-guard";
 import {
   addSerializeExpr,
   addSerializeReason,
@@ -78,7 +78,6 @@ import {
   translateAttrs,
 } from "./translate-attrs";
 import translateVar from "./translate-var";
-import { withLeadingComment } from "./with-comment";
 import * as writer from "./writer";
 
 type AttrTagGroup = AttrTagLookup[string]["group"];
@@ -231,66 +230,21 @@ export function knownTagTranslateHTML(
   }
 
   if (contentSection.paramReasonGroups) {
-    let childSerializeReasonExpr: t.Expression | undefined;
-    if (contentSection.paramReasonGroups.length === 1) {
-      // Special case single reason to pass either 1 or undefined.
-      const [group] = contentSection.paramReasonGroups;
-      const reason = getSerializeReason(section, childScopeBinding, group.id);
-      childSerializeReasonExpr =
-        reason && getSerializeGuard(section, reason, false);
-    } else {
-      const props: t.ObjectExpression["properties"] = [];
-      // Reason groups whose guard is statically `1` are encoded as a bitmask
-      // (offset by one bit so a lone group 0 cannot collide with the plain
-      // `1` "serialize everything" sentinel); -1 means a group's guard was
-      // dynamic or out of bit range and an object must be used instead.
-      let bitmask = 0;
-      let bitmaskNames = "";
-      let hasDynamicReasons = false;
-      let hasSkippedReasons = false;
-      for (let i = 0; i < contentSection.paramReasonGroups.length; i++) {
-        const group = contentSection.paramReasonGroups[i];
+    // Each group's serialize guard is its bit.
+    const childSerializeReasonExpr = buildGroupMask(
+      contentSection.paramReasonGroups.map((group) => {
         const reason = getSerializeReason(section, childScopeBinding, group.id);
-        if (reason) {
-          hasDynamicReasons ||= reason !== true && !reason.state;
-          const guard = getSerializeGuard(section, reason, false)!;
-          if (bitmask >= 0) {
-            if (
-              guard.type === "NumericLiteral" &&
-              guard.value === 1 &&
-              i < 30
-            ) {
-              bitmask |= 1 << (i + 1);
-              const names = getDebugNames(group.reason);
-              if (names) {
-                bitmaskNames += bitmaskNames ? ` | ${names}` : names;
-              }
-            } else {
-              bitmask = -1;
-            }
-          }
-          props.push(
-            t.objectProperty(
-              withLeadingComment(
-                t.numericLiteral(i),
-                getDebugNames(group.reason),
-              ),
-              guard,
-            ),
-          );
-        } else {
-          hasSkippedReasons = true;
-        }
-      }
-
-      if (props.length) {
-        childSerializeReasonExpr = !(hasDynamicReasons || hasSkippedReasons)
-          ? t.numericLiteral(1)
-          : bitmask > 0
-            ? withLeadingComment(t.numericLiteral(bitmask), bitmaskNames)
-            : t.objectExpression(props);
-      }
-    }
+        const guard = reason && getSerializeGuard(section, reason, false)!;
+        return {
+          value: !guard
+            ? undefined
+            : guard.type === "NumericLiteral"
+              ? guard.value
+              : guard,
+          names: getDebugNames(group.reason),
+        };
+      }),
+    );
 
     if (childSerializeReasonExpr) {
       tag.insertBefore(

--- a/packages/runtime-tags/src/translator/util/serialize-guard.ts
+++ b/packages/runtime-tags/src/translator/util/serialize-guard.ts
@@ -52,6 +52,54 @@ const [getSectionReasonState] = createSectionState<SectionReasonState>(
   }),
 );
 
+// A call site's reason from its groups' 2-bit values: static ones fold into
+// a literal, a dynamic one shifts into its place; only a group past the
+// bit range (15) makes it a keyed object. A group with no value contributes
+// nothing; one known unfed (`0`) still makes the reason an explicit `0`.
+export function buildGroupMask(
+  groups: { value: number | t.Expression | undefined; names: string }[],
+): t.Expression | undefined {
+  let mask = 0;
+  let maskNames = "";
+  let dynamic: t.Expression | undefined;
+  const props: t.ObjectExpression["properties"] = [];
+  let needsObject = false;
+  let any = false;
+  for (let i = 0; i < groups.length; i++) {
+    const { value, names } = groups[i];
+    if (value === undefined) continue;
+    any = true;
+    if (value === 0) continue;
+    if (i >= 15) {
+      needsObject = true;
+    } else if (typeof value === "number") {
+      mask |= value << (1 + 2 * i);
+      if (names) maskNames += maskNames ? ` | ${names}` : names;
+    } else {
+      const shifted = t.binaryExpression(
+        "<<",
+        value,
+        withLeadingComment(t.numericLiteral(1 + 2 * i), names),
+      );
+      dynamic = dynamic ? t.binaryExpression("|", dynamic, shifted) : shifted;
+    }
+    props.push(
+      t.objectProperty(
+        withLeadingComment(t.numericLiteral(i), names),
+        typeof value === "number" ? t.numericLiteral(value) : value,
+      ),
+    );
+  }
+  if (needsObject) return t.objectExpression(props);
+  if (!any) return;
+  const literal = mask
+    ? withLeadingComment(t.numericLiteral(mask), maskNames)
+    : undefined;
+  return literal && dynamic
+    ? t.binaryExpression("|", literal, dynamic)
+    : literal || dynamic || t.numericLiteral(0);
+}
+
 export function getScopeReasonDeclaration(
   section: Section,
 ): t.VariableDeclaration {


### PR DESCRIPTION
A call site's serialize reason for a child was a bit per param-reason group, with `1` as the serialize-everything sentinel, a raw guard for a lone group, and a keyed object whenever any group's guard was dynamic. That object allocated on every render of such a call site, and the runtime sites that render a child without seeing its groups (a dynamic tag, the class compat bridge) leaned on the sentinel.

Each group now owns two bits at `1 + 2 * group`, the low one saying the group serializes, and a dynamic guard shifts into its place (`guard << 1`, `2 | guard << 3`), so a keyed object only appears past fifteen groups. The sentinel is a well-formed mask (`CLIENT_ALL`). Across the fixture bundles the keyed-object call sites go from 17 to 0; rendering, wire, and client bundles are unchanged. The layout leaves room for a second bit per group, which the persisted-pages branch uses for ownership so both ship one reason value.

🤖 Generated with [Claude Code](https://claude.com/claude-code)