### PR TITLE
Register shells as content in the resume registry

### DIFF
--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain-global/sizes.json
@@ -2,16 +2,16 @@
   "dom": {
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 3069,
-        "brotli": 1475
+        "min": 3023,
+        "brotli": 1437
       },
       "files": {
         "layout.marko": 261,
@@ -20,15 +20,15 @@
     },
     "page-a.mjs": {
       "min": 173,
-      "brotli": 126
+      "brotli": 127
     },
     "page-b.mjs": {
       "min": 409,
-      "brotli": 269
+      "brotli": 276
     },
     "shared": {
-      "min": 11188,
-      "brotli": 4878
+      "min": 11186,
+      "brotli": 4900
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-app-chain/sizes.json
@@ -2,16 +2,16 @@
   "dom": {
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 3069,
-        "brotli": 1469
+        "min": 3026,
+        "brotli": 1429
       },
       "files": {
         "layout.marko": 261,
@@ -20,15 +20,15 @@
     },
     "page-a.mjs": {
       "min": 173,
-      "brotli": 126
+      "brotli": 127
     },
     "page-b.mjs": {
       "min": 173,
-      "brotli": 126
+      "brotli": 127
     },
     "shared": {
-      "min": 11174,
-      "brotli": 4883
+      "min": 11177,
+      "brotli": 4884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-mount/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-mount/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11499,
-        "brotli": 4843
+        "min": 11411,
+        "brotli": 4798
       },
       "files": {
         "tags/counter.marko": 372,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-pending-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11326,
-      "brotli": 4780
+      "min": 11238,
+      "brotli": 4733
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-child-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9260,
-      "brotli": 3994
+      "min": 9204,
+      "brotli": 3951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9260,
-      "brotli": 3994
+      "min": 9204,
+      "brotli": 3951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10791,
-      "brotli": 4614
+      "min": 10704,
+      "brotli": 4561
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-in-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11593,
-      "brotli": 5075
+      "min": 11523,
+      "brotli": 4974
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-inexpressible-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-inexpressible-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9732,
-      "brotli": 4171
+      "min": 9676,
+      "brotli": 4132
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy-client/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12517,
-      "brotli": 5281
+      "min": 12408,
+      "brotli": 5236
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-lazy/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10507,
-      "brotli": 4521
+      "min": 10399,
+      "brotli": 4478
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-nested-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10340,
-      "brotli": 4421
+      "min": 10253,
+      "brotli": 4382
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending-twice/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8796,
-      "brotli": 3834
+      "min": 8743,
+      "brotli": 3795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8796,
-      "brotli": 3834
+      "min": 8743,
+      "brotli": 3795
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-reject-try/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-await-settled/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10327,
-      "brotli": 4451
+      "min": 10243,
+      "brotli": 4389
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-fill/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11560,
-      "brotli": 4905
+      "min": 11474,
+      "brotli": 4852
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-global-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11666,
-      "brotli": 4941
+      "min": 11580,
+      "brotli": 4893
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9531,
-      "brotli": 4118
+      "min": 9478,
+      "brotli": 4081
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-catch-server-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9531,
-      "brotli": 4118
+      "min": 9478,
+      "brotli": 4081
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-placeholder-fill/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11520,
-      "brotli": 4890
+      "min": 11434,
+      "brotli": 4831
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-shared-value/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10226,
-        "brotli": 4381
+        "min": 10119,
+        "brotli": 4327
       },
       "files": {
         "child.marko": 200,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-catch-only/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-in-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-in-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10081,
-      "brotli": 4323
+      "min": 9972,
+      "brotli": 4261
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-nested-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-async-try-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4158
+      "min": 9511,
+      "brotli": 4099
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-in-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13897,
-      "brotli": 5763
+      "min": 13767,
+      "brotli": 5707
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-patch-while-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10490,
-      "brotli": 4506
+      "min": 10382,
+      "brotli": 4459
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-script-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-script-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9819,
-      "brotli": 4233
+      "min": 9712,
+      "brotli": 4182
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-await-settled-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-await-settled-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9260,
-      "brotli": 3994
+      "min": 9204,
+      "brotli": 3951
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-content-owner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-content-owner/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12762,
-        "brotli": 5361
+        "min": 12704,
+        "brotli": 5336
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-dynamic-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-dynamic-tag/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9138,
-        "brotli": 3969
+        "min": 9102,
+        "brotli": 3947
       },
       "files": {
         "tags/child.marko": 523,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-fresh-scope/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8748,
-        "brotli": 3838
+        "min": 8712,
+        "brotli": 3825
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-hoisted-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-hoisted-in-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12676,
-        "brotli": 5305
+        "min": 12618,
+        "brotli": 5270
       },
       "files": {
         "tags/store.marko": 218,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-loop-sibling/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-loop-sibling/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11052,
-        "brotli": 4878
+        "min": 11030,
+        "brotli": 4844
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-nested-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-nested-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12766,
-        "brotli": 5359
+        "min": 12708,
+        "brotli": 5332
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-source-per-frame/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12228,
-      "brotli": 5088
+      "min": 12143,
+      "brotli": 5043
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-through-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-bind-through-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9138,
-        "brotli": 3981
+        "min": 9102,
+        "brotli": 3957
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-boundary/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-boundary/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9260,
-      "brotli": 3989
+      "min": 9204,
+      "brotli": 3952
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-paired/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7029,
-      "brotli": 3168
+      "min": 7028,
+      "brotli": 3155
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9484,
-      "brotli": 4068
+      "min": 9449,
+      "brotli": 4039
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6850,
-      "brotli": 3106
+      "min": 6849,
+      "brotli": 3094
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-nested/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9015,
-        "brotli": 3978
+        "min": 8980,
+        "brotli": 3962
       },
       "files": {
         "tags/badge.marko": 185,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-siblings/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6816,
-      "brotli": 3096
+      "min": 6815,
+      "brotli": 3085
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8185,
-      "brotli": 3617
+      "min": 8152,
+      "brotli": 3594
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7654,
-      "brotli": 3452
+      "min": 7621,
+      "brotli": 3415
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-child-var/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8450,
-        "brotli": 3745
+        "min": 8414,
+        "brotli": 3724
       },
       "files": {
         "tags/box.marko": 73,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-inner/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9261,
-      "brotli": 4071
+      "min": 9225,
+      "brotli": 4049
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-loop-outer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-client-loop-outer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10371,
-      "brotli": 4581
+      "min": 10460,
+      "brotli": 4605
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8108,
-      "brotli": 3632
+      "min": 8075,
+      "brotli": 3612
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-derived/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7842,
-      "brotli": 3501
+      "min": 7809,
+      "brotli": 3473
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8268,
-      "brotli": 3638
+      "min": 8235,
+      "brotli": 3621
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7737,
-      "brotli": 3470
+      "min": 7704,
+      "brotli": 3450
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8559,
-      "brotli": 3775
+      "min": 8525,
+      "brotli": 3758
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7757,
-      "brotli": 3484
+      "min": 7724,
+      "brotli": 3456
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-constant-test-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-constant-test-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12400,
-      "brotli": 5320
+      "min": 12389,
+      "brotli": 5322
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-constant-test-static-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-constant-test-static-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8596,
-      "brotli": 3887
+      "min": 8608,
+      "brotli": 3890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-derived-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-derived-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7886,
-      "brotli": 3527
+      "min": 7853,
+      "brotli": 3498
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-fill-local-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-fill-local-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8745,
-      "brotli": 3832
+      "min": 8710,
+      "brotli": 3811
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-frozen-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7109,
-      "brotli": 3214
+      "min": 7076,
+      "brotli": 3190
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-global-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-global-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10053,
-      "brotli": 4459
+      "min": 10033,
+      "brotli": 4467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-handler-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7347,
-      "brotli": 3316
+      "min": 7314,
+      "brotli": 3295
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-chain/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8783,
-      "brotli": 3849
+      "min": 8747,
+      "brotli": 3833
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9042,
-      "brotli": 3978
+      "min": 9007,
+      "brotli": 3984
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8542,
-      "brotli": 3770
+      "min": 8508,
+      "brotli": 3754
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-accept/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8296,
-      "brotli": 3653
+      "min": 8261,
+      "brotli": 3633
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-cross/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8286,
-      "brotli": 3650
+      "min": 8251,
+      "brotli": 3629
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-ref/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8288,
-      "brotli": 3651
+      "min": 8253,
+      "brotli": 3631
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-sibling/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change-sibling/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8978,
-        "brotli": 3916
+        "min": 8942,
+        "brotli": 3894
       },
       "files": {
         "tags/store.marko": 258,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-change/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8315,
-      "brotli": 3669
+      "min": 8282,
+      "brotli": 3660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8430,
-      "brotli": 3706
+      "min": 8395,
+      "brotli": 3688
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-siblings/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8175,
-      "brotli": 3596
+      "min": 8140,
+      "brotli": 3575
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6754,
-      "brotli": 3071
+      "min": 6753,
+      "brotli": 3066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8089,
-      "brotli": 3587
+      "min": 8056,
+      "brotli": 3565
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7110,
-      "brotli": 3224
+      "min": 7077,
+      "brotli": 3201
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-effect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7102,
-      "brotli": 3217
+      "min": 7069,
+      "brotli": 3195
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-local-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7369,
-      "brotli": 3321
+      "min": 7336,
+      "brotli": 3305
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-param-const-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-param-const-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8413,
-      "brotli": 3731
+      "min": 8380,
+      "brotli": 3707
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-recursive-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-recursive-child/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8596,
-      "brotli": 3887
+      "min": 8608,
+      "brotli": 3890
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-el/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6874,
-      "brotli": 3130
+      "min": 6841,
+      "brotli": 3103
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-global/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7588,
-      "brotli": 3402
+      "min": 7555,
+      "brotli": 3373
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-input/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7102,
-      "brotli": 3216
+      "min": 7069,
+      "brotli": 3194
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-mixed/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7796,
-      "brotli": 3497
+      "min": 7763,
+      "brotli": 3467
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7699,
-      "brotli": 3457
+      "min": 7666,
+      "brotli": 3441
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-script/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6934,
-      "brotli": 3142
+      "min": 6901,
+      "brotli": 3135
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7762,
-      "brotli": 3482
+      "min": 7729,
+      "brotli": 3460
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-static-const-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-static-const-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8408,
-      "brotli": 3723
+      "min": 8375,
+      "brotli": 3700
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-unassigned-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch-unassigned-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7726,
-      "brotli": 3467
+      "min": 7693,
+      "brotli": 3445
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7558,
-      "brotli": 3406
+      "min": 7525,
+      "brotli": 3386
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-structure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11706,
-      "brotli": 4970
+      "min": 11620,
+      "brotli": 4928
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-catch-then-pending/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11706,
-      "brotli": 4970
+      "min": 11620,
+      "brotli": 4928
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-arg-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-arg-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8032,
-        "brotli": 3643
+        "min": 7999,
+        "brotli": 3609
       },
       "files": {
         "tags/struct/index.marko": 300,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8022,
-        "brotli": 3640
+        "min": 7989,
+        "brotli": 3611
       },
       "files": {
         "helper.ts": 61,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-attr-tag-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8592,
-        "brotli": 3876
+        "min": 8558,
+        "brotli": 3854
       },
       "files": {
         "tags/tabs/index.marko": 487,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-branch-const/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-branch-const/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7364,
-      "brotli": 3277
+      "min": 7363,
+      "brotli": 3270
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7654,
-      "brotli": 3450
+      "min": 7621,
+      "brotli": 3414
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-const-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7654,
-      "brotli": 3450
+      "min": 7621,
+      "brotli": 3414
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-attr-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-attr-tags/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12115,
-        "brotli": 5180
+        "min": 12060,
+        "brotli": 5146
       },
       "files": {
         "tags/panel/index.marko": 180,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-deep/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12234,
-        "brotli": 5193
+        "min": 12179,
+        "brotli": 5167
       },
       "files": {
         "tags/card/index.marko": 173,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-in-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-in-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11852,
-      "brotli": 5006
+      "min": 11795,
+      "brotli": 4976
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-open/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-open/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12136,
-        "brotli": 5164
+        "min": 12081,
+        "brotli": 5130
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content-structure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12213,
-        "brotli": 5193
+        "min": 12158,
+        "brotli": 5163
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-content/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12136,
-        "brotli": 5164
+        "min": 12081,
+        "brotli": 5130
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-loop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10144,
-        "brotli": 4458
+        "min": 10123,
+        "brotli": 4455
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-passthrough/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8391,
-        "brotli": 3697
+        "min": 8355,
+        "brotli": 3673
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-poison/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10263,
-        "brotli": 4531
+        "min": 10242,
+        "brotli": 4505
       },
       "files": {
         "tags/counter/index.marko": 309,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-siblings/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8448,
-        "brotli": 3712
+        "min": 8412,
+        "brotli": 3697
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable-swap/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8410,
-        "brotli": 3706
+        "min": 8374,
+        "brotli": 3678
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-controllable/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8391,
-        "brotli": 3697
+        "min": 8355,
+        "brotli": 3673
       },
       "files": {
         "tags/counter/index.marko": 301,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-global-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12757,
-        "brotli": 5397
+        "min": 12699,
+        "brotli": 5364
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-import-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-import-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8882,
-        "brotli": 3939
+        "min": 8847,
+        "brotli": 3950
       },
       "files": {
         "tags/badge/index.marko": 310,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-input-object-method-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-input-object-method-global/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 7583,
-        "brotli": 3420
+        "min": 7550,
+        "brotli": 3397
       },
       "files": {
         "tags/code-block.marko": 231,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-local-client-fed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8968,
-        "brotli": 3916
+        "min": 8932,
+        "brotli": 3902
       },
       "files": {
         "tags/child.marko": 834,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural-attr/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8024,
-        "brotli": 3638
+        "min": 7991,
+        "brotli": 3607
       },
       "files": {
         "tags/tabs2/index.marko": 318,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-nested-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8002,
-        "brotli": 3624
+        "min": 7969,
+        "brotli": 3598
       },
       "files": {
         "tags/tabs/index.marko": 237,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-server-required/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-server-required/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8708,
-        "brotli": 3865
+        "min": 8673,
+        "brotli": 3843
       },
       "files": {
         "tags/widget/index.marko": 210,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-slot-optional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-slot-optional/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10852,
-      "brotli": 4640
+      "min": 10798,
+      "brotli": 4611
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-spread/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8279,
-        "brotli": 3652
+        "min": 8244,
+        "brotli": 3630
       },
       "files": {
         "tags/card.marko": 263,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-loop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9780,
-        "brotli": 4345
+        "min": 9871,
+        "brotli": 4389
       },
       "files": {
         "tags/list/index.marko": 675,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-spread-feed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-spread-feed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8779,
-        "brotli": 3939
+        "min": 8745,
+        "brotli": 3915
       },
       "files": {
         "tags/tabs/index.marko": 487,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-fill/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-fill/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9028,
-        "brotli": 3971
+        "min": 8993,
+        "brotli": 3951
       },
       "files": {
         "tags/toggle-panel/index.marko": 437,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure-nested/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9788,
-        "brotli": 4274
+        "min": 9752,
+        "brotli": 4288
       },
       "files": {
         "tags/panel/index.marko": 803,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-state-structure/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8346,
-        "brotli": 3729
+        "min": 8311,
+        "brotli": 3714
       },
       "files": {
         "tags/toggle-panel/index.marko": 179,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-structure-through-child/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-structure-through-child/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9243,
-        "brotli": 4080
+        "min": 9208,
+        "brotli": 4043
       },
       "files": {
         "tags/leaf.marko": 464,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-try/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8777,
-        "brotli": 3940
+        "min": 8723,
+        "brotli": 3911
       },
       "files": {
         "tags/widget/index.marko": 291,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-child-unfed-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8979,
-        "brotli": 3978
+        "min": 8944,
+        "brotli": 3961
       },
       "files": {
         "tags/badge/index.marko": 310,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-class-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8653,
-      "brotli": 3810
+      "min": 8618,
+      "brotli": 3791
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-alias-render/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-alias-render/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4410
+      "min": 10262,
+      "brotli": 4390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-elided/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-elided/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10368,
-      "brotli": 4439
+      "min": 10345,
+      "brotli": 4418
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-static-empty/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-static-empty/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10251,
-      "brotli": 4411
+      "min": 10228,
+      "brotli": 4382
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4591
+      "min": 10726,
+      "brotli": 4563
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-attr-tags/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4410
+      "min": 10262,
+      "brotli": 4390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13118,
-      "brotli": 5445
+      "min": 13039,
+      "brotli": 5393
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-body-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-body-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-branch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11276,
-      "brotli": 4780
+      "min": 11197,
+      "brotli": 4740
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11224,
-      "brotli": 4760
+      "min": 11198,
+      "brotli": 4732
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-child-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12357,
-      "brotli": 5306
+      "min": 12349,
+      "brotli": 5311
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12702,
-        "brotli": 5369
+        "min": 12644,
+        "brotli": 5333
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12422,
-        "brotli": 5270
+        "min": 12367,
+        "brotli": 5246
       },
       "files": {
         "tags/card/index.marko": 268,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-closure-mix/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-closure-mix/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11935,
-      "brotli": 5142
+      "min": 11927,
+      "brotli": 5131
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-dynamic-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-fill-state-join-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-fill-state-join-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12834,
-      "brotli": 5513
+      "min": 12793,
+      "brotli": 5516
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-for-intersect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-for-intersect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13672,
-        "brotli": 5870
+        "min": 13618,
+        "brotli": 5835
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-global/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11050,
-        "brotli": 4724
+        "min": 10996,
+        "brotli": 4696
       },
       "files": {
         "tags/widget/index.marko": 123,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-hole/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-hole/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4410
+      "min": 10262,
+      "brotli": 4390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-inner-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-inner-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect-mixed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect-mixed/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12541,
-        "brotli": 5334
+        "min": 12486,
+        "brotli": 5305
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-intersect/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12326,
-        "brotli": 5247
+        "min": 12271,
+        "brotli": 5218
       },
       "files": {
         "tags/box/index.marko": 159,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-join-fills-construct/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 15662,
-        "brotli": 6624
+        "min": 15618,
+        "brotli": 6598
       },
       "files": {
         "tags/box.marko": 231,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11935,
-      "brotli": 5142
+      "min": 11927,
+      "brotli": 5131
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-child-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-child-in-branch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12977,
-        "brotli": 5458
+        "min": 12918,
+        "brotli": 5424
       },
       "files": {
         "tags/box.marko": 231,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-mixed-fill-lazy-page/sizes.json
@@ -5,13 +5,13 @@
       "brotli": 79
     },
     "template.marko.page.mjs": {
-      "min": 1616,
-      "brotli": 824
+      "min": 1606,
+      "brotli": 811
     },
     "page.mjs": {
       "total": {
-        "min": 1020,
-        "brotli": 565
+        "min": 991,
+        "brotli": 552
       },
       "files": {
         "tags/box.marko": 231,
@@ -20,8 +20,8 @@
       }
     },
     "shared": {
-      "min": 12753,
-      "brotli": 5548
+      "min": 12729,
+      "brotli": 5532
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-client-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-client-owned/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12335,
-        "brotli": 5248
+        "min": 12280,
+        "brotli": 5223
       },
       "files": {
         "tags/grand/index.marko": 173,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-renderer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-renderer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-stateful-consumer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-stateful-consumer/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12475,
-        "brotli": 5271
+        "min": 12420,
+        "brotli": 5248
       },
       "files": {
         "tags/grand/index.marko": 169,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11285,
-      "brotli": 4814
+      "min": 11228,
+      "brotli": 4788
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4410
+      "min": 10262,
+      "brotli": 4390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-placeholder-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-placeholder-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10003,
-      "brotli": 4295
+      "min": 9950,
+      "brotli": 4256
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-pair/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-pair/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10818,
-      "brotli": 4630
+      "min": 10764,
+      "brotli": 4603
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-root-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10818,
-      "brotli": 4630
+      "min": 10764,
+      "brotli": 4603
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread-define-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread-define-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12014,
-      "brotli": 5027
+      "min": 11959,
+      "brotli": 4994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12351,
-      "brotli": 5181
+      "min": 12296,
+      "brotli": 5145
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11120,
-      "brotli": 4758
+      "min": 11065,
+      "brotli": 4737
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-static-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-static-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4591
+      "min": 10726,
+      "brotli": 4563
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch-scriptless/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-switch/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12751,
-        "brotli": 5391
+        "min": 12693,
+        "brotli": 5367
       },
       "files": {
         "tags/widget/index.marko": 160,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-try/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-try/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13714,
-      "brotli": 5681
+      "min": 13582,
+      "brotli": 5614
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10752,
-      "brotli": 4592
+      "min": 10726,
+      "brotli": 4568
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-content-two-consumers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4410
+      "min": 10262,
+      "brotli": 4390
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch-default/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8321,
-      "brotli": 3678
+      "min": 8319,
+      "brotli": 3665
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-controllable-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8859,
-      "brotli": 3922
+      "min": 8823,
+      "brotli": 3874
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-define-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-define-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6850,
-      "brotli": 3111
+      "min": 6849,
+      "brotli": 3101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-define-recursive/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-define-recursive/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6850,
-      "brotli": 3111
+      "min": 6849,
+      "brotli": 3101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-body-hole/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-body-hole/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 10872,
-        "brotli": 4649
+        "min": 10818,
+        "brotli": 4624
       },
       "files": {
         "card.marko": 113,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 13263,
-      "brotli": 5646
+      "min": 13220,
+      "brotli": 5645
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-attr-tag-state/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13009,
-        "brotli": 5484
+        "min": 12954,
+        "brotli": 5456
       },
       "files": {
         "card.marko": 556,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10757,
-      "brotli": 4577
+      "min": 10734,
+      "brotli": 4557
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-client-owned-group/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-client-owned-group/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12738,
-        "brotli": 5356
+        "min": 12683,
+        "brotli": 5339
       },
       "files": {
         "tags/picker/card.marko": 534,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-global-server-owned/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-global-server-owned/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4416
+      "min": 10262,
+      "brotli": 4387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-loop-if-in-unpaired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-loop-if-in-unpaired/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 13129,
-        "brotli": 5629
+        "min": 13086,
+        "brotli": 5644
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-native-in-custom/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-native-in-custom/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12485,
-        "brotli": 5289
+        "min": 12430,
+        "brotli": 5264
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-nested-body-in-unpaired/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-nested-body-in-unpaired/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11314,
-        "brotli": 4859
+        "min": 11259,
+        "brotli": 4825
       },
       "files": {
         "card.marko": 129,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-renderer-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-renderer-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10852,
-      "brotli": 4642
+      "min": 10798,
+      "brotli": 4615
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-scriptless-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10285,
-      "brotli": 4416
+      "min": 10262,
+      "brotli": 4387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-server-outer-state-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-server-outer-state-inner/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11590,
-        "brotli": 4959
+        "min": 11535,
+        "brotli": 4922
       },
       "files": {
         "box.marko": 242,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-swap-effects/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-swap-effects/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11385,
-      "brotli": 4830
+      "min": 11331,
+      "brotli": 4791
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-body/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10844,
-      "brotli": 4610
+      "min": 10768,
+      "brotli": 4577
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-native-body-swap/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-native-body-swap/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10757,
-      "brotli": 4577
+      "min": 10734,
+      "brotli": 4557
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-args/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-args/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 11660,
-        "brotli": 4922
+        "min": 11605,
+        "brotli": 4896
       },
       "files": {
         "counter.marko": 374,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-falsy/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var-falsy/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11683,
-      "brotli": 4963
+      "min": 11628,
+      "brotli": 4937
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-dynamic-tag-var/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10950,
-      "brotli": 4645
+      "min": 10896,
+      "brotli": 4620
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-asymmetric-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9041,
-      "brotli": 3979
+      "min": 9006,
+      "brotli": 3970
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12033,
-      "brotli": 5105
+      "min": 11978,
+      "brotli": 5072
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-await/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-await/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 16532,
-      "brotli": 6738
+      "min": 16425,
+      "brotli": 6685
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-in-stateful/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-in-stateful/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12476,
-        "brotli": 5316
+        "min": 12421,
+        "brotli": 5279
       },
       "files": {
         "tags/wrap/index.marko": 150,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-section/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-section/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12116,
-      "brotli": 5129
+      "min": 12061,
+      "brotli": 5099
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-subscribers/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-content-subscribers/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12267,
-      "brotli": 5170
+      "min": 12212,
+      "brotli": 5137
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-depth-3/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10877,
-      "brotli": 4785
+      "min": 10856,
+      "brotli": 4779
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-grow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10224,
-      "brotli": 4544
+      "min": 10314,
+      "brotli": 4551
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-loops-of-loops/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10224,
-      "brotli": 4544
+      "min": 10314,
+      "brotli": 4551
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9075,
-      "brotli": 3987
+      "min": 9040,
+      "brotli": 3981
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-fill-offset-loops/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10259,
-      "brotli": 4533
+      "min": 10349,
+      "brotli": 4569
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-for-in-until/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-for-in-until/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9598,
-      "brotli": 4280
+      "min": 9689,
+      "brotli": 4338
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-for-rest-params/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-for-rest-params/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12222,
-      "brotli": 5270
+      "min": 12214,
+      "brotli": 5254
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6850,
-      "brotli": 3111
+      "min": 6849,
+      "brotli": 3101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-global-derived-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8638,
-      "brotli": 3903
+      "min": 8650,
+      "brotli": 3900
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-required/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-server-required/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 8870,
-        "brotli": 3920
+        "min": 8835,
+        "brotli": 3902
       },
       "files": {
         "tags/outer/tags/inner/index.marko": 219,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-grand-unfed-structural/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 9066,
-        "brotli": 4011
+        "min": 9031,
+        "brotli": 3991
       },
       "files": {
         "tags/badge/index.marko": 314,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-html-script-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6933,
-      "brotli": 3128
+      "min": 6932,
+      "brotli": 3124
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-input-branches/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3862
+      "min": 8512,
+      "brotli": 3850
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-await-frame/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-await-frame/sizes.json
@@ -2,23 +2,23 @@
   "dom": {
     "docs.marko.load.mjs": {
       "min": 97,
-      "brotli": 89
+      "brotli": 88
     },
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "template.marko.page.mjs": {
-      "min": 2348,
-      "brotli": 1109
+      "min": 2359,
+      "brotli": 1118
     },
     "shared": {
-      "min": 15889,
-      "brotli": 7045
+      "min": 15848,
+      "brotli": 6983
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-in-layout-body/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-in-layout-body/sizes.json
@@ -2,23 +2,23 @@
   "dom": {
     "docs.marko.load.mjs": {
       "min": 97,
-      "brotli": 90
+      "brotli": 87
     },
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 88
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 88
     },
     "template.marko.page.mjs": {
-      "min": 2857,
-      "brotli": 1340
+      "min": 2852,
+      "brotli": 1336
     },
     "shared": {
-      "min": 10570,
-      "brotli": 4696
+      "min": 10553,
+      "brotli": 4676
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-nested-entries/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-nested-entries/sizes.json
@@ -6,27 +6,27 @@
     },
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "template.marko.page.mjs": {
       "min": 1419,
-      "brotli": 673
+      "brotli": 676
     },
     "layout.mjs": {
-      "min": 3431,
-      "brotli": 1611
+      "min": 3357,
+      "brotli": 1586
     },
     "page-a.mjs": {
       "min": 235,
-      "brotli": 139
+      "brotli": 136
     },
     "shared": {
-      "min": 14685,
-      "brotli": 6629
+      "min": 14681,
+      "brotli": 6611
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-route-switch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-layout-route-switch/sizes.json
@@ -2,23 +2,23 @@
   "dom": {
     "layout.marko.load.mjs": {
       "min": 99,
-      "brotli": 87
+      "brotli": 81
     },
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 88
+      "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 2869,
-      "brotli": 1330
+      "min": 2852,
+      "brotli": 1335
     },
     "shared": {
-      "min": 15333,
-      "brotli": 6841
+      "min": 15299,
+      "brotli": 6754
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-page-fill-join-records/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-page-fill-join-records/sizes.json
@@ -6,19 +6,19 @@
     },
     "page-a.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "page-b.marko.load.mjs": {
       "min": 99,
-      "brotli": 82
+      "brotli": 81
     },
     "template.marko.page.mjs": {
-      "min": 1456,
-      "brotli": 677
+      "min": 1457,
+      "brotli": 693
     },
     "layout.mjs": {
-      "min": 2633,
-      "brotli": 1303
+      "min": 2567,
+      "brotli": 1238
     },
     "page-a.mjs": {
       "min": 235,
@@ -29,8 +29,8 @@
       "brotli": 185
     },
     "shared": {
-      "min": 15898,
-      "brotli": 7303
+      "min": 15871,
+      "brotli": 7276
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-parent/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-client-parent/sizes.json
@@ -6,8 +6,8 @@
     },
     "template.marko.page.mjs": {
       "total": {
-        "min": 4168,
-        "brotli": 2042
+        "min": 4135,
+        "brotli": 2025
       },
       "files": {
         "components/wrapper.marko": 873,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-conditional/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-conditional/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 87
     },
     "template.marko.page.mjs": {
-      "min": 3740,
-      "brotli": 1818
+      "min": 3702,
+      "brotli": 1797
     },
     "child.mjs": {
       "min": 324,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-effect/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 98,
-      "brotli": 86
+      "brotli": 80
     },
     "template.marko.page.mjs": {
-      "min": 2602,
-      "brotli": 1283
+      "min": 2587,
+      "brotli": 1257
     },
     "child.mjs": {
       "min": 214,
-      "brotli": 158
+      "brotli": 159
     },
     "shared": {
-      "min": 9661,
-      "brotli": 4261
+      "min": 9664,
+      "brotli": 4268
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-inits/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-inits/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 98,
-      "brotli": 87
+      "brotli": 81
     },
     "template.marko.page.mjs": {
-      "min": 1939,
-      "brotli": 976
+      "min": 1932,
+      "brotli": 968
     },
     "child.mjs": {
       "min": 575,
-      "brotli": 362
+      "brotli": 364
     },
     "shared": {
-      "min": 10570,
-      "brotli": 4803
+      "min": 10568,
+      "brotli": 4808
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-load-failed/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 89,
-      "brotli": 79
+      "brotli": 84
     },
     "template.marko.page.mjs": {
-      "min": 2405,
-      "brotli": 1169
+      "min": 2385,
+      "brotli": 1166
     },
     "child.mjs": {
       "min": 205,
-      "brotli": 155
+      "brotli": 156
     },
     "shared": {
-      "min": 7927,
-      "brotli": 3649
+      "min": 7934,
+      "brotli": 3640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-state-input/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct-state-input/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 5027,
-      "brotli": 2412
+      "min": 4994,
+      "brotli": 2399
     },
     "child.mjs": {
       "min": 179,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-construct/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 89,
-      "brotli": 79
+      "brotli": 84
     },
     "template.marko.page.mjs": {
-      "min": 2405,
-      "brotli": 1169
+      "min": 2385,
+      "brotli": 1166
     },
     "child.mjs": {
       "min": 205,
-      "brotli": 155
+      "brotli": 156
     },
     "shared": {
-      "min": 7927,
-      "brotli": 3649
+      "min": 7934,
+      "brotli": 3640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-let-return-visit/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 81
     },
     "template.marko.page.mjs": {
-      "min": 3761,
-      "brotli": 1814
+      "min": 3718,
+      "brotli": 1790
     },
     "child.mjs": {
       "min": 377,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-return-visit/sizes.json
@@ -5,8 +5,8 @@
       "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 4760,
-      "brotli": 2250
+      "min": 4717,
+      "brotli": 2219
     },
     "child.mjs": {
       "min": 216,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-dynamic-scriptless/sizes.json
@@ -5,12 +5,12 @@
       "brotli": 82
     },
     "template.marko.page.mjs": {
-      "min": 3376,
-      "brotli": 1607
+      "min": 3333,
+      "brotli": 1579
     },
     "shared": {
-      "min": 9403,
-      "brotli": 4100
+      "min": 9442,
+      "brotli": 4107
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-lazy-tag-return-visit/sizes.json
@@ -2,19 +2,19 @@
   "dom": {
     "child.marko.load.mjs": {
       "min": 89,
-      "brotli": 79
+      "brotli": 84
     },
     "template.marko.page.mjs": {
-      "min": 2405,
-      "brotli": 1169
+      "min": 2385,
+      "brotli": 1166
     },
     "child.mjs": {
       "min": 205,
-      "brotli": 155
+      "brotli": 156
     },
     "shared": {
-      "min": 7927,
-      "brotli": 3649
+      "min": 7934,
+      "brotli": 3640
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-alias-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-alias-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9553,
-      "brotli": 4264
+      "min": 9643,
+      "brotli": 4297
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-branch-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10986,
-      "brotli": 4828
+      "min": 10965,
+      "brotli": 4836
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-child-tag/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-child-tag/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8810,
-      "brotli": 4008
+      "min": 8902,
+      "brotli": 4049
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-client-inner/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-client-inner/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9177,
-      "brotli": 4167
+      "min": 9142,
+      "brotli": 4131
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-closure/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8905,
-      "brotli": 4017
+      "min": 8996,
+      "brotli": 4060
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-content-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-content-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12400,
-      "brotli": 5324
+      "min": 12389,
+      "brotli": 5335
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-grow-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-grow-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9723,
-      "brotli": 4311
+      "min": 9813,
+      "brotli": 4351
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection-deep/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10863,
-      "brotli": 4799
+      "min": 10842,
+      "brotli": 4764
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-intersection/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9723,
-      "brotli": 4311
+      "min": 9813,
+      "brotli": 4351
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3869
+      "min": 8512,
+      "brotli": 3851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11935,
-      "brotli": 5142
+      "min": 11927,
+      "brotli": 5131
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-root-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-item-root-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8913,
-      "brotli": 3984
+      "min": 8925,
+      "brotli": 3997
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-index/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9196,
-      "brotli": 4126
+      "min": 9287,
+      "brotli": 4143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let-nested/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9791,
-      "brotli": 4380
+      "min": 9771,
+      "brotli": 4341
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-let/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9196,
-      "brotli": 4104
+      "min": 9287,
+      "brotli": 4143
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-nested-grow-outer/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-nested-grow-outer/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10144,
-      "brotli": 4483
+      "min": 10234,
+      "brotli": 4541
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-rest-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-rest-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9576,
-      "brotli": 4287
+      "min": 9666,
+      "brotli": 4306
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-shift/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9309,
-      "brotli": 4195
+      "min": 9290,
+      "brotli": 4188
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-spread/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-spread/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10987,
-      "brotli": 4752
+      "min": 11078,
+      "brotli": 4793
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8931,
-      "brotli": 4032
+      "min": 9022,
+      "brotli": 4073
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7908,
-      "brotli": 3640
+      "min": 8030,
+      "brotli": 3660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-holes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static-holes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8500,
-      "brotli": 3869
+      "min": 8512,
+      "brotli": 3851
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop-static/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7908,
-      "brotli": 3640
+      "min": 8030,
+      "brotli": 3660
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-loop/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8713,
-      "brotli": 3969
+      "min": 8805,
+      "brotli": 3994
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-attr/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-attr/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10368,
-      "brotli": 4443
+      "min": 10345,
+      "brotli": 4413
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-native-content-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11547,
-      "brotli": 4909
+      "min": 11492,
+      "brotli": 4884
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-nested-flow/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9887,
-      "brotli": 4386
+      "min": 9867,
+      "brotli": 4379
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-only-child-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7558,
-      "brotli": 3401
+      "min": 7525,
+      "brotli": 3387
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-option-attrs/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9958,
-      "brotli": 4368
+      "min": 10049,
+      "brotli": 4411
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read-in-content/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read-in-content/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 14696,
-      "brotli": 6074
+      "min": 14588,
+      "brotli": 6020
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-placeholder-server-read/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 11499,
-      "brotli": 4887
+      "min": 11413,
+      "brotli": 4832
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-renderer-prop/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-renderer-prop/sizes.json
@@ -2,8 +2,8 @@
   "dom": {
     "template.marko.page.mjs": {
       "total": {
-        "min": 12702,
-        "brotli": 5367
+        "min": 12644,
+        "brotli": 5333
       },
       "files": {
         "tags/panel/index.marko": 421,

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-server-function-derivation/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-server-function-derivation/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10611,
-      "brotli": 4671
+      "min": 10700,
+      "brotli": 4691
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-holes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6933,
-      "brotli": 3127
+      "min": 6932,
+      "brotli": 3119
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-multiline-text/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-shell-multiline-text/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 6754,
-      "brotli": 3071
+      "min": 6753,
+      "brotli": 3066
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-attributes/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9900,
-      "brotli": 4242
+      "min": 9865,
+      "brotli": 4227
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-handler/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-handler/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9833,
-      "brotli": 4224
+      "min": 9797,
+      "brotli": 4208
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-state/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-spread-state/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10466,
-      "brotli": 4486
+      "min": 10430,
+      "brotli": 4496
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-static-scriptlets/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8656,
-      "brotli": 3826
+      "min": 8622,
+      "brotli": 3808
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-style-in-loop-item/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-style-in-loop-item/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8987,
-      "brotli": 4011
+      "min": 9110,
+      "brotli": 4092
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-abort-disconnect/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-abort-disconnect/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 10507,
-      "brotli": 4524
+      "min": 10399,
+      "brotli": 4471
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-catch-param-in-branch/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-catch-param-in-branch/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 12003,
-      "brotli": 5066
+      "min": 11914,
+      "brotli": 5017
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder-direct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder-direct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-try-nested-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-two-await-placeholder/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-two-await-placeholder/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 9617,
-      "brotli": 4150
+      "min": 9511,
+      "brotli": 4101
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole-in-shell/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-unescaped-hole-in-shell/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 7136,
-      "brotli": 3227
+      "min": 7135,
+      "brotli": 3213
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-unfed-group-construct/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-unfed-group-construct/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8956,
-      "brotli": 3943
+      "min": 8921,
+      "brotli": 3926
     }
   },
   "html": {

--- a/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/sizes.json
+++ b/packages/runtime-tags/src/__tests__/fixtures/persisted-var-server-if/sizes.json
@@ -1,8 +1,8 @@
 {
   "dom": {
     "template.marko.page.mjs": {
-      "min": 8861,
-      "brotli": 3940
+      "min": 8825,
+      "brotli": 3922
     }
   },
   "html": {

--- a/packages/runtime-tags/src/dom/patch-boundary.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-boundary.feat.ts
@@ -14,7 +14,7 @@ import {
   dismissPlaceholder,
   runPendingEffects,
 } from "./control-flow";
-import { getShellContent, shells } from "./patch-shells";
+import { getContent } from "./patch-shells";
 import "./patch-child.feat";
 import {
   caughtError,
@@ -30,13 +30,7 @@ import {
   createBranch,
   type Renderer,
 } from "./renderer";
-import {
-  failPatch,
-  getRegisteredWithScope,
-  patchers,
-  patchScope,
-  withCreating,
-} from "./resume";
+import { failPatch, patchers, patchScope, withCreating } from "./resume";
 import {
   collectScopes,
   findBranchWithKey,
@@ -156,7 +150,7 @@ patchers[PatchKey.Pending] = (scope, key, value) => {
   // A created scope has no live await branch: the entry's id names the body
   // content shell its flush shipped. Mirrors `_await_content`.
   if (typeof value === "string" && !scope[link]) {
-    const renderer = getShellContent(shells[value]);
+    const renderer = getContent(value)!;
     const pendingScopes = collectScopes(
       () =>
         ((
@@ -213,13 +207,10 @@ function attachDetachedAwait(
   return true;
 }
 
-// A boundary slot: `0` stays the elided sentinel; an id resolves through
-// the shipped shell or the dom registration against the try's owner.
+// A boundary slot: `0` stays the elided sentinel; an id resolves its
+// content (shipped shell or dom registration) against the try's owner.
 function resolveBoundaryContent(id: string | 0, owner: Scope) {
-  if (id === 0) return 0;
-  const shell = shells[id];
-  if (shell) return getShellContent(shell, id, owner);
-  return getRegisteredWithScope<(owner: Scope) => unknown>(id)(owner);
+  return id === 0 ? 0 : getContent(id, owner);
 }
 
 const applyChild = patchers[PatchKey.Child];
@@ -242,10 +233,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
     const [partial, contentId, catchId, placeholderId] = value;
     value = partial;
     if (!scope[link]) {
-      const shell = shells[contentId];
-      const renderer =
-        (shell && getShellContent(shell, contentId)) ||
-        getRegisteredWithScope<Renderer>(contentId);
+      const renderer = getContent(contentId)!;
       const marker = scope[accessor as Accessor] as ChildNode;
       const inside = marker.nodeType === 1;
       const parentNode = inside
@@ -272,7 +260,7 @@ patchers[PatchKey.Child] = (scope, key, value) => {
           scope,
         ) as never;
       }
-      if (shell) {
+      if (renderer[RendererProp.Shell]) {
         withCreating(() => patchScope(value as Scope, branch));
       } else {
         patchScope(value as Scope, branch);

--- a/packages/runtime-tags/src/dom/patch-branch.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-branch.feat.ts
@@ -8,7 +8,7 @@ import {
   type Scope,
 } from "../common/types";
 import { insertChildNodes } from "./dom";
-import { getShellContent, type Shell, shells } from "./patch-shells";
+import { getContent } from "./patch-shells";
 import { createAndSetupBranch } from "./renderer";
 import { withCreating, patchers, patchScope } from "./resume";
 import { removeAndDestroyBranch } from "./scope";
@@ -59,7 +59,7 @@ patchers[PatchKey.Branch] = (scope, key, entry) => {
     patchScope(branchPartial, liveBranch as Scope);
   } else {
     // Every branch on the patch path ships a shell (`buildShells`).
-    create(scope, branchKey, branchPartial, shells[shellId!]);
+    create(scope, branchKey, branchPartial, shellId!);
   }
 };
 
@@ -67,7 +67,7 @@ function create(
   scope: Scope,
   branchKey: Accessor,
   branchPartial: Scope,
-  shell: Shell,
+  shellId: string,
 ) {
   const liveBranch = scope[branchKey] as BranchScope | undefined;
   if (liveBranch) {
@@ -84,7 +84,7 @@ function create(
     : (marker.parentNode as Element);
   const branch = createAndSetupBranch(
     scope[AccessorProp.Global],
-    getShellContent(shell),
+    getContent(shellId)!,
     scope,
     parentNode,
   );

--- a/packages/runtime-tags/src/dom/patch-content.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-content.feat.ts
@@ -1,11 +1,10 @@
 import { CONTENT_REGISTER_ID } from "../common/meta";
 import type { Scope } from "../common/types";
-import { getShellContent, registerShell, shells } from "./patch-shells";
+import { getContent, registerShell } from "./patch-shells";
 import { _resume } from "./resume";
 
 // Creates content from an in-band shell, so resume can dereference
 // a static body or boundary content with no template dom module.
-_resume(CONTENT_REGISTER_ID, (shell: string, owner?: Scope) => {
-  const id = registerShell(shell);
-  return getShellContent(shells[id], id, owner);
-});
+_resume(CONTENT_REGISTER_ID, (shell: string, owner?: Scope) =>
+  getContent(registerShell(shell), owner),
+);

--- a/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-dynamic-tag.feat.ts
@@ -10,8 +10,7 @@ import {
 import { _dynamic_tag } from "./control-flow";
 // The tag's branch pairs through a `PatchChild` entry.
 import "./patch-child.feat";
-import { getShellContent, shells } from "./patch-shells";
-import type { Renderer } from "./renderer";
+import { getContent } from "./patch-shells";
 import { createPatchers, getRegisteredWithScope, patchers } from "./resume";
 
 // `[renderer, input, contentId, varId]`, a lone renderer bare; a native tag
@@ -58,7 +57,7 @@ patchers[PatchKey.DynamicTag] = createPatchers[PatchKey.DynamicTag] = (
     _dynamic_tag(
       (MARKO_DEBUG ? accessor : encodeAccessor(accessor)) as EncodedAccessor,
       contentId
-        ? (owner: Scope) => resolveContent(contentId as string, owner)
+        ? (owner: Scope) => resolveContent(contentId as string, owner)!
         : 0,
       varId
         ? () => (owner: Scope, value: unknown) =>
@@ -72,12 +71,8 @@ patchers[PatchKey.DynamicTag] = createPatchers[PatchKey.DynamicTag] = (
   )(scope, renderer || undefined, input ? () => input : undefined);
 };
 
-// A shipped shell builds the content, bound to a forwarded body's owner; a
-// registered one (the page has its renderer) binds to the tag's scope,
-// which owns body content.
+// Shipped content binds to a forwarded body's owner; the tag's own scope
+// owns body content, so that binding is implicit.
 function resolveContent(id: string, owner: Scope, bind?: boolean) {
-  const shell = shells[id];
-  return shell
-    ? getShellContent(shell, id, bind ? owner : undefined)
-    : getRegisteredWithScope<Renderer>(id, owner);
+  return getContent(id, bind ? owner : undefined);
 }

--- a/packages/runtime-tags/src/dom/patch-loop.feat.ts
+++ b/packages/runtime-tags/src/dom/patch-loop.feat.ts
@@ -1,7 +1,7 @@
 import { encodeAccessor } from "../common/helpers";
 import { type Accessor, PatchKey, type Scope } from "../common/types";
 import { _for_of } from "./control-flow";
-import { shells } from "./patch-shells";
+import { getShell } from "./patch-shells";
 import { patchers, patchScope, withCreating } from "./resume";
 
 declare module "./resume" {
@@ -28,7 +28,7 @@ patchers[PatchKey.Loop] = (scope, key, value) => {
   const suffix = key.slice(PatchKey.Loop.length) as Accessor;
   // A loop with a shell creates additions; one whose items pair only
   // (a stateful body) ships none and never adds.
-  const [template, walks, setup] = shells[shellId!] || [];
+  const [template, walks, setup] = getShell(shellId!) || [];
   // The reconciler applies the patch: `params` walks each partial into its
   // paired/created branch, and setup attaches effects to fresh ones.
   const apply = () =>

--- a/packages/runtime-tags/src/dom/patch-shells.ts
+++ b/packages/runtime-tags/src/dom/patch-shells.ts
@@ -9,6 +9,7 @@ import { queueEffect } from "./queue";
 import { _content as content } from "./renderer";
 import {
   _patch_shells,
+  _resume,
   creating,
   createPatchers,
   getRegisteredWithScope,
@@ -59,22 +60,22 @@ export const runSetupIds = ([inits, effects]: SetupIds, scope: Scope) => {
   for (const init of inits) init(scope);
   if (effects) for (const effect of effects) queueEffect(scope, effect);
 };
-export type Shell = [
-  template: string,
-  walks: string,
-  setup?: SetupFn | 0,
-  content?: ReturnType<ReturnType<typeof _content>>,
-];
-export const shells: Record<string, Shell> = {};
+// A shell's parts, kept on the registered factory (and its renderers) for
+// the loop patcher, which reconciles from them rather than a renderer.
+export type Shell = [template: string, walks: string, setup: SetupFn | 0];
+type ShellFactory = ((owner?: Scope) => Renderer) & {
+  [RendererProp.Shell]: Shell;
+};
+type Renderer = ReturnType<ReturnType<typeof _content>> & {
+  [RendererProp.Shell]?: Shell;
+};
 
-export const getShellContent = (shell: Shell, id = "", owner?: Scope) =>
-  owner
-    ? markShell(contentFactory(shell, id)(owner))
-    : (shell[3] ??= markShell(contentFactory(shell, id)()));
-const contentFactory = (shell: Shell, id: string) =>
-  _content(id, shell[0], shell[1], shell[2]);
-const markShell = (renderer: Shell[3]) =>
-  Object.assign(renderer!, { [RendererProp.Shell]: 1 });
+// A shell registers where the dom module would register the same content,
+// so every consumer resolves one id one way; a later flush's shell wins.
+export const getContent = (id: string, owner?: Scope) =>
+  getRegisteredWithScope<ShellFactory | undefined>(id)?.(owner);
+export const getShell = (id: string) =>
+  getRegisteredWithScope<ShellFactory | undefined>(id)?.[RendererProp.Shell];
 
 // `"id inits…!effects…;walks;template"` (`,` for `;walks;` when walk-less):
 // inits render inside the fresh scope's setup, `!` opens the mount effects.
@@ -83,13 +84,23 @@ export const registerShell = (shell: string) => {
   const second = shell[first] === ";" ? shell.indexOf(";", first + 1) : first;
   const idToken = shell.slice(0, first);
   const sep = (idToken + " ").indexOf(" ");
+  const id = idToken.slice(0, sep);
   const setupIds = idToken.slice(sep + 1);
   const resolved = setupIds && resolveSetupIds(setupIds);
-  shells[idToken.slice(0, sep)] = [
+  const parts: Shell = [
     shell.slice(second + 1),
     shell.slice(first + 1, second),
     resolved ? (branch: Scope) => runSetupIds(resolved, branch) : 0,
   ];
-  return idToken.slice(0, sep);
+  const factory = _content(id, parts[0], parts[1], parts[2]);
+  _resume(
+    id,
+    Object.assign(
+      (owner?: Scope) =>
+        Object.assign(factory(owner), { [RendererProp.Shell]: parts }),
+      { [RendererProp.Shell]: parts },
+    ),
+  );
+  return id;
 };
 _patch_shells(registerShell);


### PR DESCRIPTION
A shipped shell now registers a content factory under its id through `_resume`, the same `(owner?) => Renderer` shape the dom module's `_content_resume` registers, so every patcher resolves an id one way through `getContent`. The parallel `shells` table, `getShellContent`, and the shell-over-registration preference in the dynamic tag and boundary patchers are gone. The shell's template, walks and setup ride on the factory (and its renderers) under `RendererProp.Shell`: the loop patcher reconciles from those parts, so `_for_of` is unchanged, and the boundary patcher uses the same mark to apply a shell-created body's partial as creating.

Persisted dom bundles shrink by about 40 B brotli per page; main's sizes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)